### PR TITLE
[NDD-56]: release drafter 설정 추가 (1h/1h)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,17 @@
+name-template: "v$RESOLVED_VERSION 🌈"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "Bug Fixes"
+    label: "bug"
+  - title: "New Features"
+    label: "feature"
+  - title: "Documentation"
+    label: "documentation"
+  - title: "Chore"
+    label: "chore"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,40 @@
+name: Release Drafter
+
+on:
+  pull_request:
+    branches:
+      - dev
+    # Only following types are handled by the action, but one can default to all as well
+    types: [closed]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        with:
+          config-file-path: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Why
조금 더 편리하게 버전 변경사항을 정하기 위해서 자동화 bot을 추가 하고자 합니다.

# How

기존의 프로젝트에 있었던걸 토대로 저희 프로젝트에 맞춰서 변경하였습니다. PR의 Label을 기준으로 PR제목을 배포 초안에 작성해 줍니다. 
dev로 merge가 되어야 실행이 됩니다.

# Result

### 해결하고 싶었던 방안
FE와 BE가 한 레포지토리에 있기 때문에 어쩔수 없어 FE, BE 라벨로 구분을 하는데 release drafter에는 해당 라벨을 토대로 노트의 초안을 중첩적을 하는 방법은 없었습니다. ex) FE의 feature BE의 feature 이런식으로요
그래서 조금 찾아봤는데 [이슈](https://github.com/release-drafter/release-drafter/issues/499) 이런 방법이 있더라고요 workflow에서 분기점으로 label을 가져와서 그것에 맞게 config-file-path을 가져오는 파일을 변경하는 식으로 하고 이슈에 있는 include-labels을 통하여 그것에 맞게끔 분기처리를 하면 될것 같은데 에러 테스트나 직접 하는데 시간이 오래 걸리것 같아서 일단은 작성했습니다.
지금 상황에서는 초안으로만 작성할 의도로 사용되었기 때문에 FE, BE둘다 카테고리로 분류하고 수동으로 저희가 분류해 주면 될 것 같습니다.

# Reference

https://github.com/cancook/momokji-frontend/blob/development/.github/release-drafter.yml
https://github.com/release-drafter/release-drafter#include-pull-requests


# Link

[지라 링크](https://milk717.atlassian.net/browse/NDD-56?atlOrigin=eyJpIjoiZDJjZjk1ZWE4NmExNDQzYmIzZTc4Nzg4ODMwYWJkYjYiLCJwIjoiaiJ9)