### PR TITLE
[NDD-58] 테마 시스템 정의 (3h/3h)

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { css, Global, ThemeProvider } from '@emotion/react';
-import { theme } from './styles/theme';
+import { theme } from '@styles/theme';
 import _global from '@styles/_global';
 
 const EmotionStyledDiv = styled.div`

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
+import { css, ThemeProvider } from '@emotion/react';
+import { theme } from './styles/theme';
 
 const EmotionStyledDiv = styled.div`
   color: red;
@@ -7,18 +8,20 @@ const EmotionStyledDiv = styled.div`
 
 function App() {
   return (
-    <div>
-      asdfasdfasdfasdfasdfasdfasdf
-      <EmotionStyledDiv>hihi</EmotionStyledDiv>Hello
-      Worasdfasasdfasdfdflasdfasdfasdfasdasdfasdfasdfasdfasdfasdf
-      <div
-        css={css`
-          color: blue;
-        `}
-      >
-        Styled with Emotion!
+    <ThemeProvider theme={theme}>
+      <div>
+        asdfasdfasdfasdfasdfasdfasdf
+        <EmotionStyledDiv>hihi</EmotionStyledDiv>Hello
+        Worasdfasasdfasdfdflasdfasdfasdfasdasdfasdfasdfasdfasdfasdf
+        <div
+          css={css`
+            color: ${theme.colors.point.primary};
+          `}
+        >
+          Styled with Emotion!
+        </div>
       </div>
-    </div>
+    </ThemeProvider>
   );
 }
 export default App;

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -18,6 +18,8 @@ function App() {
         <div
           css={css`
             color: ${theme.colors.point.primary};
+            font-family: 'Pretendard', serif;
+            font-weight: 600;
           `}
         >
           Styled with Emotion!

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
-import { css, ThemeProvider } from '@emotion/react';
+import { css, Global, ThemeProvider } from '@emotion/react';
 import { theme } from './styles/theme';
+import resetCss from './styles/resetCss';
 
 const EmotionStyledDiv = styled.div`
   color: red;
@@ -9,6 +10,7 @@ const EmotionStyledDiv = styled.div`
 function App() {
   return (
     <ThemeProvider theme={theme}>
+      <Global styles={resetCss} />
       <div>
         asdfasdfasdfasdfasdfasdfasdf
         <EmotionStyledDiv>hihi</EmotionStyledDiv>Hello

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { css, Global, ThemeProvider } from '@emotion/react';
 import { theme } from './styles/theme';
-import resetCss from './styles/resetCss';
+import _global from '@styles/_global';
 
 const EmotionStyledDiv = styled.div`
   color: red;
@@ -10,7 +10,7 @@ const EmotionStyledDiv = styled.div`
 function App() {
   return (
     <ThemeProvider theme={theme}>
-      <Global styles={resetCss} />
+      <Global styles={_global} />
       <div>
         asdfasdfasdfasdfasdfasdfasdf
         <EmotionStyledDiv>hihi</EmotionStyledDiv>Hello

--- a/FE/src/styles/_colors.ts
+++ b/FE/src/styles/_colors.ts
@@ -1,0 +1,83 @@
+const colorChips = {
+    grayscaleWhite: '#FFFFFF',
+    grayscale100: '#F5F5F5',
+    grayscale300: '#EDEDED',
+    grayscale500: '#B0B8C1',
+    grayscale700: '#9299A1',
+    grayscale900: '#505967',
+    grayscaleBlack: '#000000',
+
+    blue50: '#CBDBFA',
+    blue100: '#BDD1F9',
+    blue200: '#9FBCF6',
+    blue300: '#82A8F3',
+    blue400: '#6493F1',
+    blue500: '#477FEE',
+    blue600: '#3C6BC8',
+    blue700: '#3056A2',
+    blue800: '#25427C',
+    blue900: '#1A2E56',
+
+    navy50: '#CBCFE1',
+    navy100: '#BDC2D9',
+    navy200: '#9FA7C8',
+    navy300: '#828BB7',
+    navy400: '#6470A6',
+    navy500: '#475595',
+    navy600: '#3C477D',
+    navy700: '#303A65',
+    navy800: '#252C4D',
+    navy900: '#1A1F36',
+
+    green50: '#D9F4D8',
+    green100: '#CEF1CD',
+    green200: '#B8EAB6',
+    green300: '#A2E4A0',
+    green400: '#8CDD89',
+    green500: '#76D773',
+    green600: '#63B561',
+    green700: '#50924E',
+    green800: '#3D703C',
+    green900: '#2A4D29',
+
+    red50: '#F6CFCA',
+    red100: '#F4C1BB',
+    red200: '#EFA59C',
+    red300: '#EA897E',
+    red400: '#E56E5F',
+    red500: '#E05241',
+    red600: '#BC4537',
+    red700: '#98382C',
+    red800: '#742B22',
+    red900: '#511E17'
+};
+
+export const colors = {
+    text: {
+        default: colorChips.grayscaleBlack, // #000000
+        bold: colorChips.grayscaleBlack,    // #000000
+        weak: colorChips.grayscale900,      // #505967
+        sub: colorChips.grayscale500,       // #B0B8C1
+        subStrong: colorChips.grayscale700, // #9299A1
+        white: colorChips.grayscaleWhite,   // #FFFFFF
+    },
+    border: {
+        default: colorChips.grayscale500,   // #B0B8C1
+        weak: colorChips.grayscale300,      // #EDEDED
+    },
+    surface: {
+        default: colorChips.grayscaleWhite, // #FFFFFF
+        inner: colorChips.grayscale100,     // #F5F5F5
+        weak: colorChips.grayscale300,      // #EDEDED
+        black50: colorChips.grayscaleBlack, // #000000
+        black100: colorChips.grayscaleBlack,// #000000
+    },
+    point: {
+        primary: colorChips.blue500,        // #477FEE
+        secondary: colorChips.navy500,      // #475595
+    },
+    status: {
+        active: colorChips.green500,        // #76D773
+        record: colorChips.red500,          // #E05241
+    },
+};

--- a/FE/src/styles/_global.ts
+++ b/FE/src/styles/_global.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-const resetCss = css`
+const _global = css`
   html,
   body,
   div,
@@ -159,4 +159,4 @@ const resetCss = css`
     font-style: normal;
   }
 `;
-export default resetCss;
+export default _global;

--- a/FE/src/styles/_typography.ts
+++ b/FE/src/styles/_typography.ts
@@ -1,0 +1,64 @@
+export const typography = {
+  /**
+   * 페이지의 제목에 사용됩니다.
+   */
+  title1: {
+    fontFamily: 'Pretendard',
+    fontStyle: 'normal',
+    fontWeight: 700,
+    fontSize: '2rem',
+  },
+
+  /**
+   * 탭이나 모달의 제목에 사용됩니다.
+   * 마이페이지의 사용자 닉네임에도 사용됩니다
+   * 큰 버튼의 텍스트로도 사용됩니다.
+   */
+  title2: {
+    fontFamily: 'Pretendard',
+    fontStyle: 'normal',
+    fontWeight: 700,
+    fontSize: '1.5rem',
+  },
+
+  /**
+   * 기본 글자에는 모두 이 스타일이 사용됩니다.
+   */
+  body1: {
+    fontFamily: 'Pretendard',
+    fontStyle: 'normal',
+    fontWeight: 400,
+    fontSize: '1rem',
+  },
+
+  /**
+   * 동영상 페이지의 대본 글자, 모달의 body 등에 사용되는 스타일입니다.
+   */
+  body2: {
+    fontFamily: 'Pretendard',
+    fontStyle: 'normal',
+    fontWeight: 400,
+    fontSize: '1.125rem',
+  },
+
+  /**
+   * 마이페이지의 이메일, 마이페이지의 동영상 타이틀에 사용됩니다.
+   */
+  body3: {
+    fontFamily: 'Pretendard',
+    fontStyle: 'normal',
+    fontWeight: 400,
+    fontSize: '0.875rem',
+  },
+
+  /**
+   * Progress Step Bar, 녹화중 표시 등
+   * 사이즈 12px에는 모두 이 스타일이 사용됩니다.
+   */
+  captionBold: {
+    fontFamily: 'Pretendard',
+    fontStyle: 'normal',
+    fontWeight: 600,
+    fontSize: '0.75rem',
+  },
+};

--- a/FE/src/styles/resetCss.ts
+++ b/FE/src/styles/resetCss.ts
@@ -1,0 +1,138 @@
+import { css } from '@emotion/react';
+
+const resetCss = css`
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  section {
+    display: block;
+  }
+
+  body {
+    line-height: 1;
+  }
+
+  ol,
+  ul {
+    list-style: none;
+  }
+
+  blockquote,
+  q {
+    quotes: none;
+  }
+
+  blockquote:before,
+  blockquote:after,
+  q:before,
+  q:after {
+    content: '';
+    content: none;
+  }
+
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+`;
+export default resetCss;

--- a/FE/src/styles/resetCss.ts
+++ b/FE/src/styles/resetCss.ts
@@ -134,5 +134,29 @@ const resetCss = css`
   * {
     box-sizing: border-box;
   }
+
+  @font-face {
+    font-family: 'Pretendard';
+    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff')
+      format('woff');
+    font-weight: 400;
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: 'Pretendard';
+    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff')
+      format('woff');
+    font-weight: 600;
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: 'Pretendard';
+    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff')
+      format('woff');
+    font-weight: 700;
+    font-style: normal;
+  }
 `;
 export default resetCss;

--- a/FE/src/styles/theme.ts
+++ b/FE/src/styles/theme.ts
@@ -1,0 +1,12 @@
+import { colors } from './_colors';
+import { typography } from './_typography';
+
+export const theme = { colors, typography };
+export type ThemeType = typeof theme;
+
+/*
+    useTheme를 통해 테마를 불러올 때 타입 자동완성을 위한 코드입니다.
+ */
+declare module '@emotion/react' {
+  export interface Theme extends ThemeType {}
+}

--- a/FE/tsconfig.json
+++ b/FE/tsconfig.json
@@ -15,7 +15,8 @@
       "@common/*": ["./src/components/common/*"],
       "@foundation/*": ["./src/components/foundation/*"],
       "@page/*": ["./src/page/*"],
-      "@constants/*": ["./src/constants/*"]
+      "@constants/*": ["./src/constants/*"],
+      "@styles/*": ["./src/styles/*"]
     }
   },
   "include": ["src"]

--- a/FE/webpack.config.js
+++ b/FE/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
       '@foundation': path.resolve(__dirname, 'src/components/foundation/'),
       '@page': path.resolve(__dirname, 'src/page/'),
       '@constants': path.resolve(__dirname, 'src/constants/'),
+      '@styles': path.resolve(__dirname, 'src/styles/'),
     },
   },
 


### PR DESCRIPTION
# Why
피그마의 디자인을 효율적으로 옮기기 위해 디자인 시스템을 정의했습니다.

# How

- 피그마에서 사용된 컬러 색상을 모두 뽑은 후 Color Levels Generator를 사용해서 컬러칩을 정의했습니다.
- 컬러칩을 기반으로 컬러 시스템을 만들었습니다.
- 폰트 시스템은 코드로 먼저 정의하고 피그마를 수정했습니다.
- reset css는 global로 적용했습니다.

# Result
ThemeProvider, global css를 적용했습니다.

### color 시스템 관련 안내사항
`styles/_colors.ts` 안에 정의되어있는 colorChips는 프로젝트에서 직접적으로 사용되지 않습니다.
colorChips에 정의된 팔레트를 사용해서 colors 객체를 정의했습니다.

### 폰트 시스템 관련 안내사항
테마에 정의해둔 폰트 시스템은 Typography 컴포넌트에서 폰트 이름을 기반으로 사용할 수 있도록 구성할 예정입니다.

# Reference

- https://emotion.sh/docs/theming
- https://bootcamp.uxdesign.cc/how-to-create-a-nice-color-palette-in-figma-b61e1996a398

# Link
[[NDD-58] design-system 설정하기 - Jira](https://milk717.atlassian.net/browse/NDD-58)