### PR TITLE
[NDD-76] 테마 시스템에 그림자 추가 (0.3 / 1h)

### DIFF
--- a/FE/src/styles/_shadow.ts
+++ b/FE/src/styles/_shadow.ts
@@ -1,0 +1,13 @@
+export const shadow = {
+  /**
+   * 큰 박스에 사용되는 그림자 입니다.
+   * ex) 마이페이지 프로필, 마이페이지 탭, 문제 선택기 박스
+   */
+  boxShadow: `8px 8px 25px 0px rgba(0, 0, 0, 0.10)`,
+
+  /**
+   * 작은 박스에 사용되는 그림자입니다.
+   * ex) 문제 선택기 박스 안에 있는 아이템
+   */
+  boxSmallShadow: `0px 4px 10px 0px rgba(0, 0, 0, 0.10)`,
+};

--- a/FE/src/styles/theme.ts
+++ b/FE/src/styles/theme.ts
@@ -1,7 +1,8 @@
 import { colors } from './_colors';
 import { typography } from './_typography';
+import { shadow } from '@styles/_shadow';
 
-export const theme = { colors, typography };
+export const theme = { colors, typography, shadow };
 export type ThemeType = typeof theme;
 
 /*


### PR DESCRIPTION
# Why

테마 시스템에 그림자 정보가 누락되어 추가했습니다.

# Result
아래 두 가지 종류의 그림자를 추가했습니다.

```
export const shadow = {
  /**
   * 큰 박스에 사용되는 그림자 입니다.
   * ex) 마이페이지 프로필, 마이페이지 탭, 문제 선택기 박스
   */
  boxShadow: `8px 8px 25px 0px rgba(0, 0, 0, 0.10)`,

  /**
   * 작은 박스에 사용되는 그림자입니다.
   * ex) 문제 선택기 박스 안에 있는 아이템
   */
  boxSmallShadow: `0px 4px 10px 0px rgba(0, 0, 0, 0.10)`,
};
```
