### PR TITLE
[NDD-29]: QuestionItem 컴포넌트 구현, 이에 필요한 foundation 컴포넌트 구현 (6h / 5h)

### DIFF
--- a/FE/src/components/common/QuestionItem/QuestionItem.styles.ts
+++ b/FE/src/components/common/QuestionItem/QuestionItem.styles.ts
@@ -1,0 +1,13 @@
+import { css } from '@emotion/react';
+import { theme } from '@styles/theme';
+
+export const QuestionItemStyles = {
+  default: css`
+    background-color: ${theme.colors.surface.default};
+    color: ${theme.colors.text.default};
+  `,
+  expanded: css`
+    background-color: ${theme.colors.point.secondary.default};
+    color: ${theme.colors.text.white};
+  `,
+};

--- a/FE/src/components/common/QuestionItem/QuestionItem.tsx
+++ b/FE/src/components/common/QuestionItem/QuestionItem.tsx
@@ -1,0 +1,76 @@
+import { FC, MouseEventHandler, SyntheticEvent } from 'react';
+import { css } from '@emotion/react';
+import { QuestionItemStyles } from '@common/QuestionItem/QuestionItem.styles';
+import { Typography } from '@foundation/Typography/Typography';
+import { LeadingDot } from '@foundation/LeadingDot/LeadingDot';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+} from '@foundation/Accordion';
+import { theme } from '@styles/theme';
+
+type Props = {
+  isSelected: boolean;
+  isLogin: boolean;
+  id: string;
+  question: string;
+  answer?: string;
+  onChange: (event: SyntheticEvent, id: string) => void;
+  onEditButtonClick: MouseEventHandler;
+};
+export const QuestionItem: FC<Props> = ({
+  isSelected,
+  isLogin,
+  id,
+  question,
+  answer,
+  onChange,
+  onEditButtonClick,
+}) => {
+  const handleEditButtonClick: MouseEventHandler = (e) => {
+    e.stopPropagation();
+    onEditButtonClick(e);
+  };
+
+  return (
+    <>
+      <Accordion expanded={isSelected} onChange={(e) => onChange(e, id)}>
+        <AccordionSummary
+          defaultStyle={QuestionItemStyles.default}
+          expandedStyle={QuestionItemStyles.expanded}
+        >
+          <Typography paragraph variant={'body1'}>
+            {question}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails onClick={(e) => handleEditButtonClick(e)}>
+          <LeadingDot>
+            <Typography noWrap paragraph variant={'body1'}>
+              {answer}
+            </Typography>
+          </LeadingDot>
+          {isLogin && (
+            <div
+              css={css`
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                padding: 0.5rem;
+                border-radius: 3.125rem;
+                background-color: ${theme.colors.surface.inner};
+                cursor: pointer;
+
+                &:hover {
+                  background-color: #e5e5e5;
+                }
+              `}
+            >
+              <p>아</p>
+            </div>
+          )}
+        </AccordionDetails>
+      </Accordion>
+    </>
+  );
+};

--- a/FE/src/components/foundation/Accordion/Accordion.tsx
+++ b/FE/src/components/foundation/Accordion/Accordion.tsx
@@ -1,0 +1,51 @@
+import React, {
+  Children,
+  cloneElement,
+  isValidElement,
+  ReactNode,
+  SyntheticEvent,
+} from 'react';
+import { css } from '@emotion/react';
+import { theme } from '@styles/theme';
+import { HTMLElementTypes } from '@/types/utils';
+
+type AccordionProps = {
+  children: ReactNode[];
+  expanded?: boolean;
+  onChange: (event: SyntheticEvent, expanded: boolean) => void;
+} & HTMLElementTypes<HTMLDivElement>;
+
+export const Accordion: React.FC<AccordionProps> = ({
+  children,
+  expanded,
+  onChange,
+  ...args
+}) => {
+  const childrenArray = Children.toArray(children).map(
+    (child) =>
+      isValidElement(child) && cloneElement(child, { ...child.props, expanded })
+  );
+
+  return (
+    <div
+      onClick={(e) => onChange(e, !!expanded)}
+      css={css`
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-self: stretch;
+        border-radius: 0.625rem;
+        box-shadow: ${expanded && theme.shadow.boxShadow};
+        cursor: pointer;
+        user-select: none;
+
+        &:hover {
+          box-shadow: ${theme.shadow.boxShadow};
+        }
+      `}
+      {...args}
+    >
+      {childrenArray}
+    </div>
+  );
+};

--- a/FE/src/components/foundation/Accordion/AccordionDetails.tsx
+++ b/FE/src/components/foundation/Accordion/AccordionDetails.tsx
@@ -1,0 +1,34 @@
+import { FC, ReactNode } from 'react';
+import { css } from '@emotion/react';
+import { HTMLElementTypes } from '@/types/utils';
+import { theme } from '@styles/theme';
+
+type AccordionDetailsProps = {
+  children: ReactNode;
+  expanded?: boolean;
+} & HTMLElementTypes<HTMLDivElement>;
+
+export const AccordionDetails: FC<AccordionDetailsProps> = ({
+  children,
+  expanded,
+  ...args
+}) => {
+  return (
+    expanded && (
+      <div
+        css={css`
+          display: flex;
+          align-items: center;
+          column-gap: 1rem;
+          padding: 0.5rem;
+          border-radius: 0 0 0.625rem 0.625rem;
+          color: ${theme.colors.text.default};
+          background-color: ${theme.colors.surface.default};
+        `}
+        {...args}
+      >
+        {children}
+      </div>
+    )
+  );
+};

--- a/FE/src/components/foundation/Accordion/AccordionSummary.tsx
+++ b/FE/src/components/foundation/Accordion/AccordionSummary.tsx
@@ -1,0 +1,36 @@
+import React, { FC, ReactNode } from 'react';
+import { css, Interpolation, Theme } from '@emotion/react';
+import { HTMLElementTypes } from '@/types/utils';
+
+type AccordionSummaryProps = {
+  children: ReactNode;
+  expanded?: boolean;
+  defaultStyle?: Interpolation<Theme>;
+  expandedStyle?: Interpolation<Theme>;
+} & HTMLElementTypes<HTMLDivElement>;
+export const AccordionSummary: FC<AccordionSummaryProps> = ({
+  children,
+  expanded,
+  defaultStyle,
+  expandedStyle,
+  ...args
+}) => {
+  const optionalStyle =
+    expanded && expandedStyle ? expandedStyle : defaultStyle;
+
+  return (
+    <div
+      css={[
+        css`
+          display: flex;
+          padding: 1rem;
+          border-radius: ${expanded ? '0.625rem 0.625rem 0 0' : '0.625rem'};
+        `,
+        optionalStyle,
+      ]}
+      {...args}
+    >
+      {children}
+    </div>
+  );
+};

--- a/FE/src/components/foundation/Accordion/index.ts
+++ b/FE/src/components/foundation/Accordion/index.ts
@@ -1,0 +1,3 @@
+export { Accordion } from './Accordion';
+export { AccordionDetails } from './AccordionDetails';
+export { AccordionSummary } from './AccordionSummary';

--- a/FE/src/components/foundation/Avatar/Avatar.tsx
+++ b/FE/src/components/foundation/Avatar/Avatar.tsx
@@ -1,4 +1,4 @@
-import { theme } from '@/styles/theme';
+import { theme } from '@styles/theme';
 import { HTMLElementTypes } from '@/types/utils';
 import { css } from '@emotion/react';
 import React from 'react';

--- a/FE/src/components/foundation/Box/Box.tsx
+++ b/FE/src/components/foundation/Box/Box.tsx
@@ -1,4 +1,4 @@
-import { theme } from '@/styles/theme';
+import { theme } from '@styles/theme';
 import { HTMLElementTypes } from '@/types/utils';
 import { css } from '@emotion/react';
 import React from 'react';

--- a/FE/src/components/foundation/Button/Button.styles.ts
+++ b/FE/src/components/foundation/Button/Button.styles.ts
@@ -1,4 +1,4 @@
-import { theme } from '@/styles/theme';
+import { theme } from '@styles/theme';
 import { css } from '@emotion/react';
 
 export const buttonSize = {

--- a/FE/src/components/foundation/Button/Button.tsx
+++ b/FE/src/components/foundation/Button/Button.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { theme } from '@/styles/theme';
+import { theme } from '@styles/theme';
 import { HTMLElementTypes } from '@/types/utils';
-import { buttonSize } from '@components/Button/Button.styles';
+import { buttonSize } from '@foundation/Button/Button.styles';
 
 type ButtonProps = {
   size?: 'sm' | 'md' | 'lg';

--- a/FE/src/components/foundation/InputArea/InputArea.tsx
+++ b/FE/src/components/foundation/InputArea/InputArea.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
-import { HTMLElementTypes } from '../../types/utils';
-import { theme } from '@/styles/theme';
+import { HTMLElementTypes } from '../../../types/utils';
+import { theme } from '@styles/theme';
 
 type InputAreaProps = HTMLElementTypes<HTMLTextAreaElement>;
 

--- a/FE/src/components/foundation/LeadingDot/LeadingDot.tsx
+++ b/FE/src/components/foundation/LeadingDot/LeadingDot.tsx
@@ -1,0 +1,41 @@
+import { FC, ReactNode } from 'react';
+import { css } from '@emotion/react';
+
+type LeadingDotProps = {
+  children: ReactNode;
+  color?: string;
+  gap?: string;
+  size?: string;
+};
+
+export const LeadingDot: FC<LeadingDotProps> = ({
+  children,
+  color = '#76d773',
+  gap = '0.5rem',
+  size = '0.5rem',
+}) => {
+  return (
+    <div
+      css={css`
+        display: flex;
+        position: relative;
+        padding-left: calc(${size} + ${gap});
+        overflow: hidden;
+
+        &:before {
+          content: '';
+          position: absolute;
+          left: 0;
+          top: 50%;
+          transform: translateY(-50%);
+          width: ${size};
+          height: ${size};
+          background-color: ${color};
+          border-radius: 50%;
+        }
+      `}
+    >
+      {children}
+    </div>
+  );
+};

--- a/FE/src/components/foundation/Typography/Typography.tsx
+++ b/FE/src/components/foundation/Typography/Typography.tsx
@@ -1,0 +1,44 @@
+import React, { ElementType, ReactNode } from 'react';
+import { css, Theme } from '@emotion/react';
+import { theme } from '@styles/theme';
+
+type Props = {
+  component?: ElementType;
+  variant?: keyof Theme['typography'];
+  noWrap?: boolean;
+  paragraph?: boolean;
+  color?: string;
+  children: ReactNode;
+};
+
+export const Typography: React.FC<Props> = ({
+  component,
+  variant = 'body1',
+  noWrap,
+  paragraph,
+  color,
+  children,
+}) => {
+  const Component = component || (paragraph ? 'p' : 'span');
+
+  return (
+    <Component
+      css={[
+        css`
+          position: relative;
+          text-align: left;
+          color: ${color};
+          ${noWrap &&
+          `
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          `}
+        `,
+        theme.typography[variant],
+      ]}
+    >
+      {children}
+    </Component>
+  );
+};


### PR DESCRIPTION
# Why
## QuestionItem을 common으로 분류한 이유
- 기존에는 QuestionItem을 foundation으로 분리했었음.
- 우리 프로젝트에서는 foundation을 ui 라이브러리같은 느낌으로 분류하기로 했음.
- 그런데 QuestionItem라는 이름부터 너무 비즈니스에 종속적임
- foundation에 들어가는 컴포넌트들은 이 프로젝트가 아니라 다른 프로젝트에서도 사용할 수 있어야 한다고 생각함 (Button이나 Input Area 등등)
- 만약 foundation에 넣으려면 [React Accordion component - Material UI](https://mui.com/material-ui/react-accordion/)처럼 한단계 더 추상화한 컴포넌트를 만들고, 이를 사용하는 common/QuestionItem을 만들어야 한다고 생각함
- 현재 MVP 단계에서는 개발 속도를 위해 일단 common만드로 생성하기로 이야기가 됨 (@2023.11.2 인터미션 스프린트 기간에 만나서 구두로 이야기함)

# How
QuestionItem 컴포넌트를 하나의 common 컴포넌트로 만들려고 했으나 코드의 가독성이 좋지 않았음.
<details>
<summary>하나의 common 컴포넌트로 만든 컴포넌트 코드</summary>
<div markdown="1">

```tsx
import React, { ReactNode } from 'react';
import { css } from '@emotion/react';

type Props = {
    isSelected: boolean;
    id: string;
    question: string;
    answer?: string;
    icon?: ReactNode;
    onClick: (event: React.MouseEvent<HTMLDivElement>, id: string) => void;
};
export const QuestionItem: React.FC<Props> = ({
    isSelected,
    id,
    question,
    answer,
    icon,
    onClick,
}) => {
    return (
        <>
            <div
                onClick={(e) => onClick(e, id)}
                css={css`
                    display: flex;
                    flex-direction: column;
                    justify-content: center;
                    align-self: stretch;
                    background-color: ${isSelected ? '#475595' : '#fff'};
                    border-radius: 10px;
                    box-shadow: ${isSelected &&
                    '0 4px 8px 0 rgba(0, 0, 0, 0.25)'};
                    cursor: pointer;

                    &:hover {
                        box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.25);
                    }
                `}
            >
                <div
                    css={css`
                        display: flex;
                        padding: 1rem;
                    `}
                >
                    <p
                        css={css`
                            text-align: left;
                            color: ${isSelected ? '#fff' : '#000'};
                        `}
                    >
                        {question}
                    </p>
                </div>
                {isSelected && (
                    <div
                        css={css`
                            display: flex;
                            align-items: center;
                            column-gap: 1rem;
                            padding: 0.5rem;
                            border-radius: 0 0 10px 10px;
                            background-color: #fff;
                        `}
                    >
                        <p
                            css={css`
                                position: relative;
                                padding-left: 1.5rem;
                                overflow: hidden;
                                text-overflow: ellipsis;
                                white-space: nowrap;

                                &:before {
                                    content: '';
                                    position: absolute;
                                    left: 0;
                                    top: 50%;
                                    transform: translateY(-50%);
                                    width: 8px;
                                    height: 8px;
                                    background-color: #76d773;
                                    border-radius: 99px;
                                }
                            `}
                        >
                            {answer}
                        </p>
                        {icon && (
                            <div
                                css={css`
                                    display: flex;
                                    justify-content: center;
                                    align-items: center;
                                    padding: 8px;
                                    border-radius: 50px;
                                    background-color: #f5f5f5;
                                    cursor: pointer;

                                    &:hover {
                                        background-color: #e5e5e5;
                                    }
                                `}
                            >
                                {icon}
                            </div>
                        )}
                    </div>
                )}
            </div>
        </>
    );
};
```
</div>
</details>

그래서 만들다보니 Typography, LeadingDot, Accordion 컴포넌트의 필요성을 느껴서 이를 foundation 컴포넌트로 개발함

## foundation 컴포넌트 목록
### Typography
디자인 시스템의 타이포그래피 시스템에서 variant 이름을 통해 원하는 글자를 가져오는 방식으로 구현했습니다.
paragraph 옵션은 컴포넌트를 단락으로 랜더링할지 여부를 결정하는 props입니다.
이 옵션 활성화시 엔터를 인식하도록 추후 업데이트할 예정입니다.
### LeadingDot
children의 왼쪽에 가상요소로 점을 추가해주는 컴포넌트입니다.
녹화중, 연결상태, 문제 선택기 등에서 왼쪽에 점이 추가될 일이 많기 때문에 따로 분류했습니다.
### Accordion
[MUI의 Accordion 컴포넌트](https://mui.com/material-ui/react-accordion/)에서 아이디어를 얻어서 개발했습니다.
Accordion에서 cloneElement를 통해 하위 요소에 props를 전달한 이유는 이 컴포넌트를 아래 컴포넌트에서도 사용하기 위함입니다.
<img width="384" alt="image" src="https://github.com/boostcampwm2023/Web14-EchoView/assets/57657868/fbc07071-2353-4982-b1e3-313093502c5e">
Accordion을 하나의 컴포넌트로 묶는다면 추후에 하위 디자인을 변경하기 위해 props를 따로 전달하거나 스타일을 덮어씌워야 하는데 이 방식으로 개발하면 AccordionDetails, AccordionSummary 내부의 children 요소만 변경하면 여러 곳에서 재사용 할 수 있습니다.

## Accordion 컴포넌트 구현중 생긴 이슈
### css props를 넘기면 element의 타입이 달라지는 이슈 발생
#### 발생한 문제
커스텀 컴포넌트에 스타일을 덮어씌울 때 css props를 사용하기 위해 아래 타입을 활용했습니다.
```ts
import { Interpolation, Theme } from '@emotion/react';

export type HTMLElementTypes<T> = React.ClassAttributes<T> &
  React.HTMLAttributes<T> & {
    css?: Interpolation<Theme>;
  };

```

그래서 아래와 같은 형식으로 커스텀 컴포넌트의 스타일을 덮어씌울 수 있었습니다.
```tsx
<AccordionSummary
    css={css`  
        background-color: #fff;    `}  
    expandedStyle={css`  
        background-color: #475595;    `}  
>  
    <Typography paragraph>{question}</Typography>  
</AccordionSummary>
```
하지만 여기서 문제가 발생했습니다. 
emotion에서는 css props가 컴포넌트에 적용될 때 고차 컴포넌트로 감싸서 새로운 컴포넌트를 반환합니다.
이 과정에서 원본 컴포넌트의 타입이 Emotion이 생성한 타입으로 변경됩니다.

<img width="593" alt="Pasted image 20231107092015" src="https://github.com/boostcampwm2023/Web14-EchoView/assets/57657868/cc72b19f-30e6-458c-a062-9ffd0305aefc">

이런 문제로 인해 Accordion에서 컴포넌트를 구분할 수 없게 되었습니다.
#### 해결 방법
<img width="727" alt="image" src="https://github.com/boostcampwm2023/Web14-EchoView/assets/57657868/a2c9333c-f2e8-474b-9778-9a793bd1cc3f">

cloneElement를 사용해서 children으로 props를 전달할 때 AccordionDetails, AccordionSummary를 구분하지 않고 동일한 props를 넘겨주도록 변경했습니다. expanded에 따른 AccordionDetails 표시 여부도 AccordionDetails 컴포넌트 내부에서 처리하도록 했습니다.

### style 우선순위 문제

#### 발생한 문제
AccordionSummary의 스타일을 지정할 때 css props로 넘긴 스타일을 default style로 설정하고, expandedStyles props를 통해 새로운 스타일을 넘기면 Accordion이 펼쳐졌을 때 expandedStyles이 기존 스타일을 덮어씌우도록 구현하고 싶었습니다.
하지만, css props를 통해 넘긴 스타일은 하위 컴포넌트로 넘어갈 때 css 그 자체로 넘어가는 것이 아니라 emotion에서 클래스로 변환해서 className으로 전달됩니다.
<img width="453" alt="image" src="https://github.com/boostcampwm2023/Web14-EchoView/assets/57657868/94d45029-c031-44f0-b27e-f52cd4e666c0">
css props와 className은 위와 같은 우선순위를 갖게 되고, 결국 상위 컴포넌트에서 css props로 넘긴 스타일이 다른 스타일을 덮어쓰게 됩니다. 

#### 해결 방법
AccordionSummary 컴포넌트에서 defaultStyle, expandedStyle을 따로 받아서 expanded 상태에 따른 스타일을 다르게 적용해줬습니다. 그리고 AccordionSummary 컴포넌트를 사용하는 QuestionItem 컴포넌트에서 상태 변화에 따른 스타일을 관리하기 위해QuestionItemStyles를 따로 분리해서 관리했습니다.


# Result

<img width="719" alt="image" src="https://github.com/boostcampwm2023/Web14-EchoView/assets/57657868/de70a628-eed1-486e-b367-7c111c97ea58">

아이콘은 웹팩 설정 이슈로 일단 텍스트로 렌더링했습니다.
추후 다른 task로 분리해서 처리할 예정입니다.

# Reference
https://mui.com/material-ui/react-accordion/
# Link
[NDD-29](https://milk717.atlassian.net/browse/NDD-29)
