### PR TITLE
[NDD-99] 테스트를 위한 Jest 설정 변경 (1h / 1h)

### DIFF
--- a/BE/package.json
+++ b/BE/package.json
@@ -86,6 +86,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "src/(.*)": "<rootDir>/$1"
+    }
   }
 }

--- a/BE/src/config/typeorm.config.ts
+++ b/BE/src/config/typeorm.config.ts
@@ -1,6 +1,4 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
-
-import { Member } from 'src/member/entity/member';
 import 'dotenv/config';
 
 export const MYSQL_OPTION: TypeOrmModuleOptions = {


### PR DESCRIPTION
[![NDD-99](https://badgen.net/badge/JIRA/NDD-99/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-99) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
코드 작성을 하다보면 다른 파일에 존재하는 모듈(클래스, 메서드 등)을 import 할 때 상대 경로 또는 절대 경로를 사용하여 자동적으로 import가 진행된다.
하지만 현재 Jest 설정으로는 절대 경로에 대한 import는 실제 모듈을 불러올 수가 없다. 이를 해결하기 위해 Jest 설정을 변경하여야 했다.

또한 TypeORM에 추가적으로 사용하지 않는 import가 있어 이를 삭제할 필요성이 있었다.

# How
해당 문제를 구글링해보니, tsconfig 또는 jest 관련 config의 문제라는 것을 확인할 수 있었다.
Compile 시에는 정상적으로 작동하나, Test 실행 시에만 이런 문제가 발생하므로 tsconfig의 문제라기 보다는 jest 관련 config의 문제라는 판단으로 Jest 관련 설정을 수정해보았다.
상대 경로는 되고, 절대 경로는 문제가 발생했기에 프로젝트 루트에 대한 인식의 문제이거나 src 관련 문제라고 판단하여 이에 대한 레퍼런스를 뒤져보았고, 이를 통해 해결할 수 있었다.

# Result
pacakge.json의 jest 설정에 아래와 같은 추가적인 설정을 달아줌으로써 해결되었다.
```
"moduleNameMapper": {
      "src/(.*)": "<rootDir>/$1"
    }
```

# Prize
Jest 설정에 대한 학습을 진행할 수 있었다.
모듈들에 대한 import 시에 절대 경로 사용이 가능해졌다.

# Reference
https://velog.io/@shelly/Typescript-Jest-%EC%A0%88%EB%8C%80%EA%B2%BD%EB%A1%9C-%EC%84%A4%EC%A0%95

[NDD-99]: https://milk717.atlassian.net/browse/NDD-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ