### PR TITLE
[NDD-103] Member API E2E 테스트 (1h / 1h)

### DIFF
--- a/BE/.eslintrc.js
+++ b/BE/.eslintrc.js
@@ -15,11 +15,12 @@ module.exports = {
     node: true,
     jest: true,
   },
-  ignorePatterns: ['/eslintrc.js'],
+  ignorePatterns: ['.eslintrc.js'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
   },
 };

--- a/BE/src/config/cors.config.ts
+++ b/BE/src/config/cors.config.ts
@@ -1,8 +1,8 @@
-import {CorsOptions} from "@nestjs/common/interfaces/external/cors-options.interface";
-import {CORS_HEADERS, CORS_ORIGIN} from "./cors.secure";
+import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
+import { CORS_HEADERS, CORS_ORIGIN } from './cors.secure';
 
 export const CORS_CONFIG: CorsOptions = {
-    origin: CORS_ORIGIN,
-    credentials: true,
-    exposedHeaders: CORS_HEADERS,
-}
+  origin: CORS_ORIGIN,
+  credentials: true,
+  exposedHeaders: CORS_HEADERS,
+};

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -2,7 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { setupSwagger } from './config/swagger.config';
-import {CORS_CONFIG} from "./config/cors.config";
+import { CORS_CONFIG } from './config/cors.config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/BE/src/member/controller/member.controller.spec.ts
+++ b/BE/src/member/controller/member.controller.spec.ts
@@ -1,9 +1,14 @@
-import { Test } from '@nestjs/testing';
+import { Test, TestingModule } from '@nestjs/testing';
 import { MemberController } from './member.controller';
 import { MemberResponse } from '../dto/memberResponse';
 import { Request } from 'express';
 import { Member } from '../entity/member';
 import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
+import { INestApplication } from '@nestjs/common';
+import { AppModule } from 'src/app.module';
+import * as request from 'supertest';
+import { TokenModule } from 'src/token/token.module';
+import { TokenService } from 'src/token/service/token.service';
 
 describe('MemberController', () => {
   let memberController: MemberController;
@@ -45,5 +50,46 @@ describe('MemberController', () => {
     expect(() =>
       memberController.getMyInfo(mockReq as unknown as Request),
     ).toThrow(ManipulatedTokenNotFiltered);
+  });
+});
+
+describe('MemberController (E2E Test)', () => {
+  let app: INestApplication;
+  let tokenService: TokenService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule, TokenModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    tokenService = moduleFixture.get<TokenService>(TokenService);
+  });
+
+  it('GET /api/member (회원 정보 반환 성공)', async () => {
+    const memberId = 1; // 항상 DB에 들어있는 회원의 ID로의 설정이 필요해보입니다.
+    const validToken = await tokenService.assignToken(memberId);
+
+    const response = await request(app.getHttpServer())
+      .get('/api/member')
+      .set('Authorization', `Bearer ${validToken}`)
+      .expect(200);
+
+    expect(response.body.id).toBe(memberId);
+  });
+
+  it('GET /api/member (유효하지 않은 토큰 사용으로 인한 회원 정보 반환 실패)', async () => {
+    const invalidToken = 'INVALID_TOKEN';
+
+    await request(app.getHttpServer())
+      .get('/api/member')
+      .set('Authorization', `Bearer ${invalidToken}`)
+      .expect(401);
+  });
+
+  afterAll(async () => {
+    await app.close();
   });
 });

--- a/BE/test/test.util.ts
+++ b/BE/test/test.util.ts
@@ -1,0 +1,16 @@
+import { ModuleMetadata } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+export const createTestModuleFixture = async (
+  imports: unknown,
+  controllers: unknown,
+  providers: unknown,
+) => {
+  const moduleFixture: TestingModule = await Test.createTestingModule({
+    imports: imports,
+    controllers: controllers,
+    providers: providers,
+  } as ModuleMetadata).compile();
+
+  return moduleFixture;
+};


### PR DESCRIPTION
[![NDD-103](https://badgen.net/badge/JIRA/NDD-103/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-103) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
회원 정보를 가져오는 Member API에 대한 E2E 테스트를 수행하기 위함

# How
Reference와 ChatGPT를 참고하여, Jest를 사용한 E2E 테스트 코드를 작성

1. Member API에 대한 성공 테스트 코드를 작성
```javascript
const oauthRequestFixture = {
  email: 'fixture@example.com',
  name: 'fixture',
  img: 'https://test.com',
} as OAuthRequest;

const validToken = (await authService.login(oauthRequestFixture)).replace(
  'Bearer ',
  '',
);
const response = await request(app.getHttpServer())
  .get('/api/member')
  .set('Authorization', `Bearer ${validToken}`)
  .expect(200);

expect(response.body.email).toBe(oauthRequestFixture.email);
expect(response.body.nickname).toBe(oauthRequestFixture.name);
expect(response.body.profileImg).toBe(oauthRequestFixture.img);
```
유효한 Access Token을 소셜 로그인을 사용하여서 직접 발급 받고 싶었으나, 테스트 코드로 OAuth 로그인을 시도하는 것은 불가능하여 어쩔 수 없이 임의의 MeberID를 사용하여 토큰을 발급받고, 이를 사용하여 200 응답을 받을 수 있도록 테스트 코드 작성

2. Member API에 대한 실패 테스트 코드를 작성
```javascript
const invalidToken = 'INVALID_TOKEN';

await request(app.getHttpServer())
.get('/api/member')
.set('Authorization', `Bearer ${invalidToken}`)
.expect(401);
```
위 코드와 같이 유효하지 않은 Access Token을 가지고 요청을 보냄으로써 401 응답 받도록 테스트 코드 작성

# Result
### 테스트
아래 2가지 경우에 대한 테스트를 진행
1. 회원 정보를 가져오는 API가 요청에 성공적으로 응답하는 경우
2. 회원 정보를 가져오는 API가 유효하지 않은 요청의 Access Token으로 인해 401(UnAuthorized) 응답하는 경우
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/f69d4c27-2024-4b14-a205-a1938c119c7e)

### 테스팅 모듈을 생성하는 Util 메서드 
```javascript
export const createTestModuleFixture = async (
  imports: unknown,
  controllers: unknown,
  providers: unknown,
) => {
  const moduleFixture: TestingModule = await Test.createTestingModule({
    imports: imports,
    controllers: controllers,
    providers: providers,
  } as ModuleMetadata).compile();

  return moduleFixture;
};
```
NestApp 생성 시에 사용하는 TestingModuleFixture를 생성하는 Util 메서드를 구현하였습니다. 
하지만 이를 적용하면, import에 문제가 발생하여서 테스트 코드에 대한 너무 많은 시간이 소비되기에 추후 적용하기로 결정하였습니다.


# Prize
저번 단위 테스트 코드 작성에 이어 이번에는 인수 테스트를 위한 코드를 직접 작성하면서 점점 테스트 코드 작성에 대해 친숙해지고 있다.
Member API가 실제 사용자의 요청 시에 상황에 맞게 의도대로 동작한다는 기술적 확신을 얻을 수 있었다.

# Reference
[E2E API 테스트를 위한 Ref](https://velog.io/@kon6443/Node-JS-Jest-supertest-%EA%B0%9C%EB%85%90-%EB%B0%8F-CRUD-API-testing-%EA%B0%84%EB%8B%A8-%EC%98%88%EC%A0%9C)

[NDD-103]: https://milk717.atlassian.net/browse/NDD-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ