### PR TITLE
[NDD-119]: 면접 화면에 나타나는 이름 반환 API 구현 (1h / 1h) 

### DIFF
--- a/BE/src/member/controller/member.controller.ts
+++ b/BE/src/member/controller/member.controller.ts
@@ -15,11 +15,12 @@ import {
   createApiResponseOption,
 } from 'src/util/swagger.util';
 import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
+import { MemberService } from '../service/member.service';
 
 @Controller('/api/member')
 @ApiTags('member')
 export class MemberController {
-  constructor() {}
+  constructor(private memberService: MemberService) {}
 
   @Get()
   @UseGuards(AuthGuard('jwt'))
@@ -40,5 +41,10 @@ export class MemberController {
   getMyInfo(@Req() req: Request) {
     if (!req.user) throw new ManipulatedTokenNotFiltered();
     return MemberResponse.from(req.user as Member);
+  }
+
+  @Get('/name')
+  getNameForInterview() {
+    this.memberService.getNameForInterview();
   }
 }

--- a/BE/src/member/controller/member.controller.ts
+++ b/BE/src/member/controller/member.controller.ts
@@ -44,7 +44,7 @@ export class MemberController {
   }
 
   @Get('/name')
-  getNameForInterview() {
-    this.memberService.getNameForInterview();
+  getNameForInterview(@Req() req: Request) {
+    return this.memberService.getNameForInterview(req);
   }
 }

--- a/BE/src/member/controller/member.controller.ts
+++ b/BE/src/member/controller/member.controller.ts
@@ -5,15 +5,11 @@ import { MemberResponse } from '../dto/memberResponse';
 import {
   ApiTags,
   ApiResponse,
-  ApiBearerAuth,
   ApiOperation,
-  ApiHeader,
+  ApiCookieAuth,
 } from '@nestjs/swagger';
 import { Member } from '../entity/member';
-import {
-  createApiHeaderOption,
-  createApiResponseOption,
-} from 'src/util/swagger.util';
+import { createApiResponseOption } from 'src/util/swagger.util';
 import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
 import { MemberService } from '../service/member.service';
 
@@ -24,13 +20,10 @@ export class MemberController {
 
   @Get()
   @UseGuards(AuthGuard('jwt'))
-  @ApiBearerAuth() // 문서 상에 자물쇠 아이콘을 표시하여 JWT가 필요하다는 것을 나타냄
+  @ApiCookieAuth() // 문서 상에 자물쇠 아이콘을 표시하여 쿠키가 필요하다는 것을 나타냄
   @ApiOperation({
     summary: '회원 정보를 반환하는 메서드',
   })
-  @ApiHeader(
-    createApiHeaderOption('Authorization', 'Access Token (Bearer Token)', true),
-  )
   @ApiResponse(
     createApiResponseOption(
       200,
@@ -44,6 +37,17 @@ export class MemberController {
   }
 
   @Get('/name')
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '면접 화면에 표출할 이름을 반환하는 메서드',
+  })
+  @ApiResponse(
+    createApiResponseOption(
+      200,
+      `면접 화면에 표출할 이름(회원의 경우 저장된 이름을, 비회원의 경우 '면접자')을 반환한다.`,
+      String,
+    ),
+  )
   async getNameForInterview(@Req() req: Request) {
     return await this.memberService.getNameForInterview(req);
   }

--- a/BE/src/member/controller/member.controller.ts
+++ b/BE/src/member/controller/member.controller.ts
@@ -44,7 +44,7 @@ export class MemberController {
   }
 
   @Get('/name')
-  getNameForInterview(@Req() req: Request) {
-    return this.memberService.getNameForInterview(req);
+  async getNameForInterview(@Req() req: Request) {
+    return await this.memberService.getNameForInterview(req);
   }
 }

--- a/BE/src/member/member.module.ts
+++ b/BE/src/member/member.module.ts
@@ -4,10 +4,11 @@ import { Member } from './entity/member';
 import { MemberRepository } from './repository/member.repository';
 import { MemberController } from './controller/member.controller';
 import { TokenModule } from 'src/token/token.module';
+import { MemberService } from './service/member.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Member]), TokenModule],
-  providers: [MemberRepository],
+  providers: [MemberRepository, MemberService],
   exports: [MemberRepository],
   controllers: [MemberController],
 })

--- a/BE/src/member/service/member.service.ts
+++ b/BE/src/member/service/member.service.ts
@@ -1,10 +1,15 @@
 import { Injectable } from '@nestjs/common';
+import { Request } from 'express';
 import { MemberRepository } from '../repository/member.repository';
 
 @Injectable()
 export class MemberService {
   constructor(private memberRepository: MemberRepository) {}
-  getNameForInterview() {
-    throw new Error('Method not implemented.');
+  getNameForInterview(req: Request) {
+    if (!req.cookies['accessToken']) {
+      return '면접자';
+    }
+    // repository 로직 구현
+    return '실제 회원 이름';
   }
 }

--- a/BE/src/member/service/member.service.ts
+++ b/BE/src/member/service/member.service.ts
@@ -1,15 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { Request } from 'express';
+import { TokenService } from 'src/token/service/token.service';
 import { MemberRepository } from '../repository/member.repository';
+import { getTokenValue } from 'src/util/token.util';
 
 @Injectable()
 export class MemberService {
-  constructor(private memberRepository: MemberRepository) {}
-  getNameForInterview(req: Request) {
-    if (!req.cookies['accessToken']) {
-      return '면접자';
-    }
-    // repository 로직 구현
-    return '실제 회원 이름';
+  constructor(
+    private tokenService: TokenService,
+    private memberRepository: MemberRepository,
+  ) {}
+  async getNameForInterview(req: Request) {
+    if (!req.cookies['accessToken']) return '면접자';
+
+    // TODO: 추후에 랜덤 Prefix 생성할 필요가 있음
+    const tokenValue = getTokenValue(req);
+    const memberId = (await this.tokenService.getPayload(tokenValue)).id;
+    return (await this.memberRepository.findById(memberId)).nickname;
   }
 }

--- a/BE/src/member/service/member.service.ts
+++ b/BE/src/member/service/member.service.ts
@@ -14,8 +14,11 @@ export class MemberService {
     if (!req.cookies['accessToken']) return '면접자';
 
     // TODO: 추후에 랜덤 Prefix 생성할 필요가 있음
-    const tokenValue = getTokenValue(req);
+    return (await this.getMemberByToken(getTokenValue(req))).nickname;
+  }
+
+  async getMemberByToken(tokenValue: string) {
     const memberId = (await this.tokenService.getPayload(tokenValue)).id;
-    return (await this.memberRepository.findById(memberId)).nickname;
+    return await this.memberRepository.findById(memberId);
   }
 }

--- a/BE/src/member/service/member.service.ts
+++ b/BE/src/member/service/member.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { MemberRepository } from '../repository/member.repository';
+
+@Injectable()
+export class MemberService {
+  constructor(private memberRepository: MemberRepository) {}
+  getNameForInterview() {
+    throw new Error('Method not implemented.');
+  }
+}


### PR DESCRIPTION
[![NDD-119](https://badgen.net/badge/JIRA/NDD-119/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-119) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
면접 화면 최상단에 현재 사용자의 이름을 띄울 때 사용하기 위한 API를 구현
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/fad6fe1f-d7d3-42b7-9d69-9c64ed65e929)

이번에 개발한 API는 회원/비회원 공용이기에 미리 구현해둔 AuthGuard를 사용할 수 없었고, 그렇기에 새로운 서비스 로직을 만들어야했다.

# How
```javascript
  async getNameForInterview(req: Request) {
    if (!req.cookies['accessToken']) return '면접자';

    // TODO: 추후에 랜덤 Prefix 생성할 필요가 있음
    return (await this.getMemberByToken(getTokenValue(req))).nickname;
  }

  async getMemberByToken(tokenValue: string) {
    const memberId = (await this.tokenService.getPayload(tokenValue)).id;
    return await this.memberRepository.findById(memberId);
  }
```
두 가지 경우에 대한 로직 구현이 필요했다.
1. 비회원 로직
간단한 로직으로 구현할 수 있었다. 우선, Request의 'accessToken' 쿠키가 존재하는지 확인하고 존재하지 않는다면 비회원인 것이므로, '면접자'를 반환하는 방식으로 구현하였다.
 
2. 회원 로직
쿠키가 존재한다면 그 사용자는 회원인 사용자이다. 쿠키에서 JWT를 얻어내고, JWT로 회원 ID를 얻어낸 후 이를 사용해 회원의 이름을 최종적으로 얻어내는 방식으로 구현하였다. 

# Result
### 비회원
의도대로 면접자가 반환됨을 확인할 수 있다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/4738287a-5c8a-4672-85ad-b2e18b2e0173)


### 회원
의도대로 회원 닉네임이 반환됨을 확인할 수 있다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/5ecbb400-bc3e-4e00-a8be-277d30b42ae9)


# Prize
토큰으로 회원 정보를 불러오는 로직을 MemberService에 메서드화하여 코드 재사용성을 높일 수 있었다.

[NDD-119]: https://milk717.atlassian.net/browse/NDD-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ