### PR TITLE
[NDD-136] setting 전역 hook 작성 (1h/2h)

### DIFF
--- a/FE/src/atoms/interviewSetting.ts
+++ b/FE/src/atoms/interviewSetting.ts
@@ -1,0 +1,43 @@
+import { atom } from 'recoil';
+
+type PageStatus = 'pending' | 'success' | 'error';
+type RecordMethod = 'local' | 'idrive' | 'none' | undefined;
+
+type SelectedData = {
+  [key: string]: {
+    id: number;
+    content: string;
+    answer: string;
+  };
+};
+
+export const questionSetting = atom<{
+  status: PageStatus;
+  selectedData: SelectedData;
+}>({
+  key: 'questionSetting',
+  default: {
+    status: 'pending',
+    selectedData: {},
+  },
+});
+
+export const videoSetting = atom<{
+  status: PageStatus;
+}>({
+  key: 'videoSetting',
+  default: {
+    status: 'pending',
+  },
+});
+
+export const recordSetting = atom<{
+  status: PageStatus;
+  method: RecordMethod;
+}>({
+  key: 'recordSetting',
+  default: {
+    status: 'pending',
+    method: undefined,
+  },
+});

--- a/FE/src/atoms/interviewSetting.ts
+++ b/FE/src/atoms/interviewSetting.ts
@@ -4,21 +4,19 @@ type PageStatus = 'pending' | 'success' | 'error';
 type RecordMethod = 'local' | 'idrive' | 'none' | undefined;
 
 type SelectedData = {
-  [key: string]: {
-    id: number;
-    content: string;
-    answer: string;
-  };
+  id: number;
+  content: string;
+  answer: string;
 };
 
 export const questionSetting = atom<{
   status: PageStatus;
-  selectedData: SelectedData;
+  selectedData: SelectedData[];
 }>({
   key: 'questionSetting',
   default: {
     status: 'pending',
-    selectedData: {},
+    selectedData: [],
   },
 });
 

--- a/FE/tsconfig.json
+++ b/FE/tsconfig.json
@@ -17,7 +17,8 @@
       "@page/*": ["./src/page/*"],
       "@constants/*": ["./src/constants/*"],
       "@styles/*": ["./src/styles/*"],
-      "@assets/*": ["./src/assets/*"]
+      "@assets/*": ["./src/assets/*"],
+      "@atoms/*": ["./src/atoms/*"]
     }
   },
   "include": ["src"]

--- a/FE/webpack.config.js
+++ b/FE/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
       '@constants': path.resolve(__dirname, 'src/constants/'),
       '@styles': path.resolve(__dirname, 'src/styles/'),
       '@assets': path.resolve(__dirname, 'src/assets/'),
+      '@atoms': path.resolve(__dirname, 'src/atoms/'),
     },
   },
 


### PR DESCRIPTION
[![NDD-136](https://badgen.net/badge/JIRA/NDD-136/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-136) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

다른건 건드릴수가 없어서 어쩌다보니 atom 생성만 하였습니다. 그래서 한시간 정도 감소했네요.
빠르게 머지하고 성인님이 해당 코드 사용하시죠!!

# How

페이지 마다 얻은 상태를 전역으로 관리합니다. atom의 특징을 조금 찾아보니까 하나의 큰 스토어 안에 state가 여러개 있는게 아니라 모듈로 나눌 수 있다는 장점이 크더라고요. useState를 분리하는 기준과 똑같이 나누어 보았습니다. 

성인님이 페이지별로 세팅 값을 토대로 간단하게 더미데이터를 만들고 작업을 진행하시면 될것 같습니다. 

## 포인트1
타입은 아직 폴더 구조나 어디에 추가로 의존하고 있을지 몰라서 같은 파일에 놔두었는데 아마 SlectedData의 타입은 문제 데이터를 받아오는 api fetch 결과값과 똑같을것이라고 예상되어서 해당 부분 작업할때 합치는 쪽으로 가는게 좋을것 같습니다.

## 포인트2

제가 이해한 내용을 공유드리면 recoil은 3가지 방법으로 상태를 받아올 수 있었는데요.
1. useRecoilState(// 생성한 atom의 결과값) 우리가 아는 useState와 똑같은 꼴
2. useRecoilValue(// 생성한 atom의 결과값) getter만 반환
3. useSetRecoilState(// 생성한 atom의 결과값) setter만 반환

굉장히 별거 없더라고요. 지금까지의 느낌은 그냥 전역 useState그 자체인것 같습니다

[NDD-136]: https://milk717.atlassian.net/browse/NDD-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ