### PR TITLE
[NDD-132] video api mocking 추가 (2h / 2h)

### DIFF
--- a/FE/src/constants/api.ts
+++ b/FE/src/constants/api.ts
@@ -1,12 +1,15 @@
 export const BASE_URL = '';
 
 type Id = number;
+type Hash = string;
 
 export const API = {
   MEMBER: '/member',
   VIDEO: '/video',
+  VIDEO_PRE_SIGNED: '/video/pre-signed',
   VIDEO_ALL: '/video/all',
   VIDEO_ID: (id?: Id) => `/video/${id ?? ':id'}`,
+  VIDEO_HASH: (hash?: Hash) => `/video/${hash ?? ':hash'}`,
   QUESTION: '/question',
   QUESTION_ID: (id?: Id) => `/question/${id ?? ':id'}`,
   ANSWER: '/answer',

--- a/FE/src/constants/api.ts
+++ b/FE/src/constants/api.ts
@@ -9,7 +9,7 @@ export const API = {
   VIDEO_PRE_SIGNED: '/video/pre-signed',
   VIDEO_ALL: '/video/all',
   VIDEO_ID: (id?: Id) => `/video/${id ?? ':id'}`,
-  VIDEO_HASH: (hash?: Hash) => `/video/${hash ?? ':hash'}`,
+  VIDEO_HASH: (hash?: Hash) => `/video/hash/${hash ?? ':hash'}`,
   QUESTION: '/question',
   QUESTION_ID: (id?: Id) => `/question/${id ?? ':id'}`,
   ANSWER: '/answer',

--- a/FE/src/mocks/handlers.ts
+++ b/FE/src/mocks/handlers.ts
@@ -1,10 +1,11 @@
-import { http, HttpResponse } from 'msw';
 import memberHandlers from './handlers/member';
 import questionHandlers from './handlers/question';
 import answerHandlers from './handlers/answer';
+import videoHandlers from '@/mocks/handlers/video';
 
 export const handlers = [
   ...memberHandlers,
   ...questionHandlers,
   ...answerHandlers,
+  ...videoHandlers,
 ];

--- a/FE/src/mocks/handlers/video.ts
+++ b/FE/src/mocks/handlers/video.ts
@@ -56,7 +56,7 @@ const videoHandlers = [
           id: 1,
           url: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
           hash: 'asdfasdfasdfsfasdfasf',
-          name: 'CSS 선택자의 종류에 대해 설명해주세요.',
+          videoName: 'CSS 선택자의 종류에 대해 설명해주세요.',
           createdAt: '1699941626145',
         },
       ],

--- a/FE/src/mocks/handlers/video.ts
+++ b/FE/src/mocks/handlers/video.ts
@@ -1,0 +1,79 @@
+import { API } from '@/constants/api';
+import { http, HttpResponse } from 'msw';
+
+const videoHandlers = [
+  http.post(API.VIDEO, ({ request }) => {
+    return HttpResponse.json({}, { status: 201 });
+  }),
+  http.post(API.VIDEO_PRE_SIGNED, ({ request }) => {
+    return HttpResponse.json({}, { status: 201 });
+  }),
+  http.get(API.VIDEO_ALL, () => {
+    return HttpResponse.json(
+      [
+        {
+          id: 1,
+          questionId: 1,
+          name: 'CSS 선택자의 종류에 대해 설명해주세요.',
+          url: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
+          thumbnail:
+            'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/ElephantsDream.jpg',
+          videoLength: '00:10:53',
+          isPublic: false,
+          createdAt: '2023-11-12 08:22:12',
+        },
+        {
+          id: 2,
+          questionId: 1,
+          name: 'Big Buck Bunny',
+          url: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+          thumbnail:
+            'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg',
+          videoLength: '',
+          isPublic: true,
+          createdAt: '2001-07-17 08:22:12',
+        },
+        {
+          id: 3,
+          questionId: 1,
+          name: 'Elephant Dream',
+          url: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4',
+          thumbnail:
+            'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/ForBiggerBlazes.jpg',
+          videoLength: '',
+          isPublic: false,
+          createdAt: '2023-11-11 08:22:12',
+        },
+      ],
+      { status: 200 }
+    );
+  }),
+  http.get(API.VIDEO_ID(), () => {
+    return HttpResponse.json(
+      [
+        {
+          id: 1,
+          questionId: 1,
+          name: 'CSS 선택자의 종류에 대해 설명해주세요.',
+          url: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
+          createdAt: '2023-11-12 08:22:12',
+        },
+      ],
+      { status: 200 }
+    );
+  }),
+  http.get(API.VIDEO_HASH(), () => {
+    return HttpResponse.json(
+      { hash: 'hashstringstringsrting' },
+      { status: 200 }
+    );
+  }),
+  http.patch(API.VIDEO_ID(), () => {
+    return HttpResponse.json(null, { status: 204 });
+  }),
+  http.delete(API.VIDEO_ID(), ({ request }) => {
+    return HttpResponse.json(null, { status: 204 });
+  }),
+];
+
+export default videoHandlers;

--- a/FE/src/mocks/handlers/video.ts
+++ b/FE/src/mocks/handlers/video.ts
@@ -6,43 +6,44 @@ const videoHandlers = [
     return HttpResponse.json({}, { status: 201 });
   }),
   http.post(API.VIDEO_PRE_SIGNED, ({ request }) => {
-    return HttpResponse.json({}, { status: 201 });
+    return HttpResponse.json(
+      {
+        preSignedUrl:
+          'https://videos.k4i7.la.idrivee2-20.com/%EB%A3%A8%EC%9D%B4%EB%B7%94%ED%86%B5%ED%86%B5%ED%8A%80%EA%B8%B0%EB%84%A4_%EC%82%AD%EC%A0%9C%EB%90%9C%20%EC%A7%88%EB%AC%B8_754ad469-a5e7-48a2-b6bd-61430219c831.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=9li5IlcqRaLakjxoO16x%2F20231114%2Fe2%2Fs3%2Faws4_request&X-Amz-Date=20231114T060953Z&X-Amz-Expires=100&X-Amz-Signature=48691d27634299f2ad74ae7812b49e2bd88a0f8ab677b6b19ba0fc3921b08d24&X-Amz-SignedHeaders=host',
+        key: 'Idrive에 등록될 파일 이름입니다.',
+      },
+      { status: 201 }
+    );
   }),
   http.get(API.VIDEO_ALL, () => {
     return HttpResponse.json(
       [
         {
           id: 1,
-          questionId: 1,
-          name: 'CSS 선택자의 종류에 대해 설명해주세요.',
-          url: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
+          videoName: 'CSS 선택자의 종류에 대해 설명해주세요.',
           thumbnail:
             'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/ElephantsDream.jpg',
-          videoLength: '00:10:53',
+          videoLength: '10:53',
           isPublic: false,
-          createdAt: '2023-11-12 08:22:12',
+          createdAt: '1699941626145',
         },
         {
           id: 2,
-          questionId: 1,
-          name: 'Big Buck Bunny',
-          url: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+          videoName: 'Big Buck Bunny',
           thumbnail:
             'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg',
-          videoLength: '',
+          videoLength: '07:17',
           isPublic: true,
-          createdAt: '2001-07-17 08:22:12',
+          createdAt: '1699941626145',
         },
         {
           id: 3,
-          questionId: 1,
-          name: 'Elephant Dream',
-          url: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4',
+          videoName: 'Elephant Dream',
           thumbnail:
             'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/ForBiggerBlazes.jpg',
-          videoLength: '',
+          videoLength: '03:00',
           isPublic: false,
-          createdAt: '2023-11-11 08:22:12',
+          createdAt: '1699941626145',
         },
       ],
       { status: 200 }
@@ -53,10 +54,10 @@ const videoHandlers = [
       [
         {
           id: 1,
-          questionId: 1,
-          name: 'CSS 선택자의 종류에 대해 설명해주세요.',
           url: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
-          createdAt: '2023-11-12 08:22:12',
+          hash: 'asdfasdfasdfsfasdfasf',
+          name: 'CSS 선택자의 종류에 대해 설명해주세요.',
+          createdAt: '1699941626145',
         },
       ],
       { status: 200 }


### PR DESCRIPTION
[![NDD-132](https://badgen.net/badge/JIRA/NDD-132/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-132) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- 일단 명세대로 만들었으나 의문이 드는 부분과 변경 요청을 드리고 싶은 부분이 있어서 2023.11.14일에 대면으로 만나서 의논할 예정

# Why

- 명세대로 mocking만 진행한다면 1시간도 안걸릴 일이었겠지만, 변경 사항이 생길 것 같아서 넉넉하게 스토리포인트를 2로 산정했습니다.

# How
## api 명세에서 궁금한 것과 수정 요청할 것
api 명세서에 나와있는대로 mocking 작업을 진행하던 중 아래와 같은 의문점이 생겼습니다.

### /api/video/all => 마이페이지에서 전체 동영상 리스트를 불러오는 api
#### 현재 응답 형식
```
[
  {
    id: 비디오 ID,
    questionId: 질문 ID,
    thumbnail: 썸네일 이미지,
    videoName: 비디오의 이름,
    videoLength: 비디오의 길이,
    isPublic: 비디오 공개 여부
    createdAt: 비디오 촬영 날짜,
  },
  ...
]
```
#### 궁금한 것과 요청사항
- videoLength 형식은 어떤지? hh:mm:ss 예상하고있습니다.
- createdAt 날짜 형식은 어떻게 되나요? ISO 8601 예상하고있습니다.
- questionId는 왜 응답에 포함하신건지 궁금합니다.

### /api/video/${videoId}
#### 현재 응답 형식
```
{
  id: 비디오의 ID,
  url: 비디오의 URL,
  hash: 해싱된 비디오의 URL / 비디오가 private면 null
}
```
#### 궁금한 것과 요청사항
- 요기도 이름과 날짜를 내려주세요
  - 리스트 보기에서 받아왔던 정보를 넘겨도 되긴 하는데 이렇게 되면 영상 공개 url을 통해서 접근했을 때는 이름과 날짜를 알 수 없습니다.

# Result

## api 의논 결과
### /api/video/all
- id: number
- videoName: string
- thumbnail: 썸네일 url
- videoLength: mm:ss 형식의 문자열
- isPublic: boolean
- createdAt: UNIX time

questionId를 포함했던 이유는 나중에 동영상과 관련된 질문 등을 표시하기 위해서 넣었던건데 
아직 기획에 없는 부분이므로 현재 단계에서는 응답에서 제외하기로 결정했습니다.

### /api/video/${videoId}
- id: number
- url: 비디오 링크
- hash: 해시 스트링
- videoName: string
- createdAt: UNIX time

비디오 상세보기 페이지에서 영상을 전체 링크 공유로 설정했을 경우를 대비해서 videoName과 createdAt 필드가 추가되었습니다. 

[NDD-132]: https://milk717.atlassian.net/browse/NDD-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ