### PR TITLE
 [NDD-159]: Category 객체, 리포지토리 구현 (1h / 1h)

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -7,6 +7,7 @@ import { MemberModule } from './member/member.module';
 import { AuthModule } from './auth/auth.module';
 import { TokenModule } from './token/token.module';
 import { QuestionModule } from './question/question.module';
+import { CategoryModule } from './category/category.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { QuestionModule } from './question/question.module';
     AuthModule,
     TokenModule,
     QuestionModule,
+    CategoryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -7,7 +7,6 @@ import { MemberModule } from './member/member.module';
 import { AuthModule } from './auth/auth.module';
 import { TokenModule } from './token/token.module';
 import { QuestionModule } from './question/question.module';
-import { CategoryModule } from './category/category.module';
 
 @Module({
   imports: [
@@ -16,7 +15,6 @@ import { CategoryModule } from './category/category.module';
     AuthModule,
     TokenModule,
     QuestionModule,
-    CategoryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BE/src/category/category.module.ts
+++ b/BE/src/category/category.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class CategoryModule {}

--- a/BE/src/category/category.module.ts
+++ b/BE/src/category/category.module.ts
@@ -1,4 +1,7 @@
 import { Module } from '@nestjs/common';
+import { CategoryRepository } from './repository/category.repository';
 
-@Module({})
+@Module({
+  providers: [CategoryRepository],
+})
 export class CategoryModule {}

--- a/BE/src/category/entity/category.ts
+++ b/BE/src/category/entity/category.ts
@@ -9,8 +9,8 @@ export class Category extends DefaultEntity {
   @Column()
   name: string;
 
-  @ManyToOne(() => Member, { nullable: true })
-  @JoinColumn({ name: 'memberId' })
+  @ManyToOne(() => Member, { nullable: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'member' })
   member: Member;
 
   @ManyToMany(() => Question)

--- a/BE/src/category/entity/category.ts
+++ b/BE/src/category/entity/category.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, JoinTable, ManyToMany, ManyToOne } from 'typeorm';
+import { DefaultEntity } from '../../app.entity';
+import { Member } from '../../member/entity/member';
+import { JoinColumn } from 'typeorm/browser';
+import { Question } from '../../question/entity/question';
+
+@Entity({ name: 'Category' })
+export class Category extends DefaultEntity {
+  @Column()
+  name: string;
+
+  @ManyToOne(() => Member, { nullable: true })
+  @JoinColumn({ name: 'memberId' })
+  member: Member;
+
+  @ManyToMany(() => Question)
+  @JoinTable({ name: 'CategoryQuestion' })
+  questions: Question[];
+
+  constructor(name: string) {
+    super(undefined, new Date());
+    this.name = name;
+  }
+
+  static copyCategory(category: Category) {
+    return new Category(category.name);
+  }
+
+  getName() {
+    return this.name;
+  }
+}

--- a/BE/src/category/repository/category.repository.ts
+++ b/BE/src/category/repository/category.repository.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Category } from '../entity/category';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class CategoryRepository {
+  constructor(
+    @InjectRepository(Category) private repository: Repository<Category>,
+  ) {}
+
+  async save(category: Category) {
+    await this.repository.save(category);
+  }
+
+  async findAllByMemberId(memberId: number) {
+    const option = memberId === null ? null : { id: memberId };
+    return await this.repository.findBy({ member: option });
+  }
+
+  async remove(category: Category) {
+    await this.repository.remove(category);
+  }
+}


### PR DESCRIPTION
[![NDD-159](https://badgen.net/badge/JIRA/NDD-159/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-159) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

일단 이전의 ERD를 봐야 한다. 
![erd](https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/d4b0b984-d3ab-465f-bd05-cc9b3b05d41b)

해당 ERD를 가지고 구현을 하는 중, 기획에서 추가된 사항이 존재했다. 
- 회원은 볼 수 있는 카테고리만을 골라서 볼 수 있다(카테고리의 삭제를 할 수 있다)
- 카테고리는 여러 질문을 가질 수 있다. 
- 다른 사람이 추가한 질문들을, 나의 카테고리에서 조회할 수 있어야 한다. 

이를 위한 구조로, Member(1) - Category(n), Category(m) - Question(n)의 구조를 생각했다. 
```
Member는 여러 카테고리를 가진다. 회원을 새롭게 만들 때 마다 CS, BE, FE, '나만의 질문' 카테고리를 만들어준다. 
또한, 해당 카테고리를 삭제하거나, 새롭게 자신만의 카테고리를 만들 수 있다. 
후에는 각 분야별 질문들을 추가할 수 있다. 
또한, 다른 회원이 만든 질문을 가져와 볼 수 있다. (질문을 추가한 사람이 해당 질문을 삭제하면 null처리할 것이다)
```
위의 요구사항을 만족시키도록 구조를 수정했다. 

또한, 후에 Question 객체를 수정할 계획이다. category의 type을 string이 아닌, Category로 만들어야 한다. 
Question.writer로 Member를 다대일로 추가해야 한다. 이를 통해, Question의 삭제 권한을 검증할 수 있어야 한다.

# How

<img width="764" alt="스크린샷 2023-11-14 16 33 25" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/25c32003-62a9-45c0-bc1f-1bb981301ab3">
<img width="694" alt="스크린샷 2023-11-14 16 33 40" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/41eca985-8772-453e-9a20-ea8dcc26615c">
리포지토리에서 회원 가입을 할 때, memberId가 null인 Category와 그 속의 질문들을 가져올 것이다. 이를 복사해 회원의 Category, Question으로 넣어주기 위해 이러한 로직을 짰다.

<!-- jira 혹은 figma 링크를 작성합니다. (Jira ISSUE 번호) -->

[NDD-159]: https://milk717.atlassian.net/browse/NDD-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ