### PR TITLE
[NDD-127] GET : /video/all API 구현 (1h / 1h)

### DIFF
--- a/BE/src/member/controller/member.controller.ts
+++ b/BE/src/member/controller/member.controller.ts
@@ -10,8 +10,8 @@ import {
 } from '@nestjs/swagger';
 import { Member } from '../entity/member';
 import { createApiResponseOption } from 'src/util/swagger.util';
-import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
 import { MemberService } from '../service/member.service';
+import { validateManipulatedToken } from 'src/util/token.util';
 
 @Controller('/api/member')
 @ApiTags('member')
@@ -32,7 +32,7 @@ export class MemberController {
     ),
   )
   getMyInfo(@Req() req: Request) {
-    if (!req.user) throw new ManipulatedTokenNotFiltered();
+    validateManipulatedToken(req.user as Member);
     return MemberResponse.from(req.user as Member);
   }
 

--- a/BE/src/util/token.util.ts
+++ b/BE/src/util/token.util.ts
@@ -1,4 +1,11 @@
+import { isEmpty } from 'class-validator';
 import { Request } from 'express';
+import { Member } from 'src/member/entity/member';
+import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
 
 export const getTokenValue = (request: Request) =>
   request.cookies['accessToken'].split(' ').pop();
+
+export const validateManipulatedToken = (member: Member | undefined) => {
+  if (isEmpty(member)) throw new ManipulatedTokenNotFiltered();
+};

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -14,6 +14,7 @@ import {
 import { createApiResponseOption } from 'src/util/swagger.util';
 import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import { CreatePreSignedUrlRequest } from '../dto/createPreSignedUrlRequest';
+import { VideoListResponse } from '../dto/videoListResponse';
 
 @Controller('/api/video')
 @ApiTags('video')
@@ -61,6 +62,13 @@ export class VideoController {
 
   @Get('/all')
   @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '자신의 모든 비디오 정보를 반환',
+  })
+  @ApiResponse(
+    createApiResponseOption(200, '모든 비디오 조회 완료', VideoListResponse),
+  )
   async getAllVideo(@Req() req: Request) {
     return await this.videoService.getAllVideosByMemberId(req.user as Member);
   }

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
 import { VideoService } from '../service/video.service';
 import { AuthGuard } from '@nestjs/passport';
 import { Request } from 'express';
@@ -51,11 +51,17 @@ export class VideoController {
   )
   async getPreSignedUrl(
     @Req() req: Request,
-    @Body() createPreSignedUrlRequest,
+    @Body() createPreSignedUrlRequest: CreatePreSignedUrlRequest,
   ) {
     return await this.videoService.getPreSignedUrl(
       req.user as Member,
       createPreSignedUrlRequest,
     );
+  }
+
+  @Get('/all')
+  @UseGuards(AuthGuard('jwt'))
+  async getAllVideo(@Req() req: Request) {
+    return await this.videoService.getAllVideo(req.user as Member);
   }
 }

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -62,6 +62,6 @@ export class VideoController {
   @Get('/all')
   @UseGuards(AuthGuard('jwt'))
   async getAllVideo(@Req() req: Request) {
-    return await this.videoService.getAllVideo(req.user as Member);
+    return await this.videoService.getAllVideosByMemberId(req.user as Member);
   }
 }

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -3,7 +3,7 @@ import { VideoService } from '../service/video.service';
 import { AuthGuard } from '@nestjs/passport';
 import { Request } from 'express';
 import { Member } from 'src/member/entity/member';
-import { CreateVideoRequest } from '../dto/CreateVideoRequest';
+import { CreateVideoRequest } from '../dto/createVideoRequest';
 import {
   ApiBody,
   ApiCookieAuth,

--- a/BE/src/video/dto/singleVideoResponse.ts
+++ b/BE/src/video/dto/singleVideoResponse.ts
@@ -1,0 +1,26 @@
+export class SingleVideoResponse {
+  readonly id: number;
+
+  readonly thumbnail: string;
+
+  readonly videoName: string;
+  readonly videoLength: string;
+  readonly isPublic: boolean;
+  readonly createdAt: number;
+
+  constructor(
+    id: number,
+    thumbnail: string,
+    videoName: string,
+    videoLength: string,
+    isPublic: boolean,
+    createdAt: number,
+  ) {
+    this.id = id;
+    this.thumbnail = thumbnail;
+    this.videoName = videoName;
+    this.videoLength = videoLength;
+    this.isPublic = isPublic;
+    this.createdAt = createdAt;
+  }
+}

--- a/BE/src/video/dto/singleVideoResponse.ts
+++ b/BE/src/video/dto/singleVideoResponse.ts
@@ -1,11 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from 'src/util/swagger.util';
 import { Video } from '../entity/video';
 
 export class SingleVideoResponse {
+  @ApiProperty(createPropertyOption(1, '비디오 ID', Number))
   readonly id: number;
+
+  @ApiProperty(
+    createPropertyOption(
+      'https://thumbnail.com',
+      '비디오 썸네일 이미지',
+      String,
+    ),
+  )
   readonly thumbnail: string;
+
+  @ApiProperty(createPropertyOption('test.webm', '비디오 이름', String))
   readonly videoName: string;
+
+  @ApiProperty(createPropertyOption('03:29', '비디오 길이', String))
   readonly videoLength: string;
+
+  @ApiProperty(createPropertyOption('false', '비디오 공개 여부', Boolean))
   readonly isPublic: boolean;
+
+  @ApiProperty(
+    createPropertyOption(1699858790176, '비디오 생성 일자(ms 단위)', Number),
+  )
   readonly createdAt: number;
 
   constructor(

--- a/BE/src/video/dto/singleVideoResponse.ts
+++ b/BE/src/video/dto/singleVideoResponse.ts
@@ -1,8 +1,8 @@
+import { Video } from '../entity/video';
+
 export class SingleVideoResponse {
   readonly id: number;
-
   readonly thumbnail: string;
-
   readonly videoName: string;
   readonly videoLength: string;
   readonly isPublic: boolean;
@@ -22,5 +22,16 @@ export class SingleVideoResponse {
     this.videoLength = videoLength;
     this.isPublic = isPublic;
     this.createdAt = createdAt;
+  }
+
+  static from(video: Video) {
+    return new SingleVideoResponse(
+      video.id,
+      'https://test-thumbnail.com',
+      video.name,
+      '02:42',
+      video.isPublic,
+      video.createdAt.getTime(),
+    );
   }
 }

--- a/BE/src/video/dto/videoListResponse.ts
+++ b/BE/src/video/dto/videoListResponse.ts
@@ -1,7 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Video } from '../entity/video';
 import { SingleVideoResponse } from './singleVideoResponse';
+import { createPropertyOption } from 'src/util/swagger.util';
 
+const videoListExample = [
+  {
+    id: 5,
+    thumbnail: 'https://test-thumbnail1.com',
+    videoName: 'test1.webm',
+    videoLength: '02:42',
+    isPublic: false,
+    createdAt: 1699983079205,
+  },
+  {
+    id: 4,
+    thumbnail: 'https://test-thumbnail2.com',
+    videoName: 'test2.webm',
+    videoLength: '03:29',
+    isPublic: false,
+    createdAt: 1699983079201,
+  },
+  {
+    id: 3,
+    thumbnail: 'https://test-thumbnail3.com',
+    videoName: 'test.mp4',
+    videoLength: '05:22',
+    isPublic: false,
+    createdAt: 1699858790176,
+  },
+];
 export class VideoListResponse {
+  @ApiProperty(
+    createPropertyOption(videoListExample, '질문 dto의 리스트', [
+      SingleVideoResponse,
+    ]),
+  )
   readonly videoList: SingleVideoResponse[];
   constructor(videos: SingleVideoResponse[]) {
     this.videoList = videos;

--- a/BE/src/video/dto/videoListResponse.ts
+++ b/BE/src/video/dto/videoListResponse.ts
@@ -1,0 +1,8 @@
+import { SingleVideoResponse } from './singleVideoResponse';
+
+export class VideoListResponse {
+  readonly videoList: SingleVideoResponse[];
+  constructor(videos: SingleVideoResponse[]) {
+    this.videoList = videos;
+  }
+}

--- a/BE/src/video/dto/videoListResponse.ts
+++ b/BE/src/video/dto/videoListResponse.ts
@@ -1,8 +1,13 @@
+import { Video } from '../entity/video';
 import { SingleVideoResponse } from './singleVideoResponse';
 
 export class VideoListResponse {
   readonly videoList: SingleVideoResponse[];
   constructor(videos: SingleVideoResponse[]) {
     this.videoList = videos;
+  }
+
+  static from(videoList: Video[]) {
+    return new VideoListResponse(videoList.map(SingleVideoResponse.from));
   }
 }

--- a/BE/src/video/entity/video.ts
+++ b/BE/src/video/entity/video.ts
@@ -3,7 +3,7 @@ import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { DefaultEntity } from 'src/app.entity';
 import { Member } from 'src/member/entity/member';
 import { Question } from 'src/question/entity/question';
-import { CreateVideoRequest } from '../dto/CreateVideoRequest';
+import { CreateVideoRequest } from '../dto/createVideoRequest';
 
 @Entity({ name: 'Video' })
 export class Video extends DefaultEntity {

--- a/BE/src/video/repository/video.repository.ts
+++ b/BE/src/video/repository/video.repository.ts
@@ -13,4 +13,12 @@ export class VideoRepository {
   async save(video: Video) {
     await this.videoRepository.save(video);
   }
+
+  async findAllVideosByMemberId(memberId: number) {
+    return this.videoRepository
+      .createQueryBuilder('video')
+      .where('video.memberId = :memberId', { memberId })
+      .orderBy('video.createdAt', 'DESC')
+      .getMany();
+  }
 }

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import { QuestionRepository } from 'src/question/repository/question.repository';
 import { IDriveException } from '../exception/video.exception';
+import { VideoListResponse } from '../dto/videoListResponse';
 
 @Injectable()
 export class VideoService {
@@ -45,8 +46,11 @@ export class VideoService {
     }
   }
 
-  async getAllVideo(member: Member) {
-    throw new Error('Method not implemented.');
+  async getAllVideosByMemberId(member: Member) {
+    const videoList = await this.videoRepository.findAllVideosByMemberId(
+      member.id,
+    );
+    return VideoListResponse.from(videoList);
   }
 
   private async getQuestionContent(questionId: number) {

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { Member } from 'src/member/entity/member';
-import { CreateVideoRequest } from '../dto/CreateVideoRequest';
 import { Video } from '../entity/video';
 import { VideoRepository } from '../repository/video.repository';
 import {
@@ -14,6 +13,7 @@ import { QuestionRepository } from 'src/question/repository/question.repository'
 import { IDriveException } from '../exception/video.exception';
 import { VideoListResponse } from '../dto/videoListResponse';
 import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
+import { CreateVideoRequest } from '../dto/createVideoRequest';
 
 @Injectable()
 export class VideoService {

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -14,6 +14,7 @@ import { IDriveException } from '../exception/video.exception';
 import { VideoListResponse } from '../dto/videoListResponse';
 import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
 import { CreateVideoRequest } from '../dto/createVideoRequest';
+import { isEmpty } from 'class-validator';
 
 @Injectable()
 export class VideoService {
@@ -22,7 +23,7 @@ export class VideoService {
     private questionRepository: QuestionRepository,
   ) {}
   async createVideo(member: Member, createVidoeRequest: CreateVideoRequest) {
-    if (!member) throw new ManipulatedTokenNotFiltered();
+    if (isEmpty(member)) throw new ManipulatedTokenNotFiltered();
 
     const newVideo = Video.from(member, createVidoeRequest);
     await this.videoRepository.save(newVideo);
@@ -50,7 +51,7 @@ export class VideoService {
   }
 
   async getAllVideosByMemberId(member: Member) {
-    if (!member) throw new ManipulatedTokenNotFiltered();
+    if (isEmpty(member)) throw new ManipulatedTokenNotFiltered();
 
     const videoList = await this.videoRepository.findAllVideosByMemberId(
       member.id,

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -12,9 +12,8 @@ import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import { QuestionRepository } from 'src/question/repository/question.repository';
 import { IDriveException } from '../exception/video.exception';
 import { VideoListResponse } from '../dto/videoListResponse';
-import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
 import { CreateVideoRequest } from '../dto/createVideoRequest';
-import { isEmpty } from 'class-validator';
+import { validateManipulatedToken } from 'src/util/token.util';
 
 @Injectable()
 export class VideoService {
@@ -23,7 +22,7 @@ export class VideoService {
     private questionRepository: QuestionRepository,
   ) {}
   async createVideo(member: Member, createVidoeRequest: CreateVideoRequest) {
-    if (isEmpty(member)) throw new ManipulatedTokenNotFiltered();
+    validateManipulatedToken(member);
 
     const newVideo = Video.from(member, createVidoeRequest);
     await this.videoRepository.save(newVideo);
@@ -51,8 +50,7 @@ export class VideoService {
   }
 
   async getAllVideosByMemberId(member: Member) {
-    if (isEmpty(member)) throw new ManipulatedTokenNotFiltered();
-
+    validateManipulatedToken(member);
     const videoList = await this.videoRepository.findAllVideosByMemberId(
       member.id,
     );

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -45,6 +45,10 @@ export class VideoService {
     }
   }
 
+  async getAllVideo(member: Member) {
+    throw new Error('Method not implemented.');
+  }
+
   private async getQuestionContent(questionId: number) {
     const question = await this.questionRepository.findById(questionId);
     return question ? question.content : '삭제된 질문';

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -13,6 +13,7 @@ import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import { QuestionRepository } from 'src/question/repository/question.repository';
 import { IDriveException } from '../exception/video.exception';
 import { VideoListResponse } from '../dto/videoListResponse';
+import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
 
 @Injectable()
 export class VideoService {
@@ -21,6 +22,8 @@ export class VideoService {
     private questionRepository: QuestionRepository,
   ) {}
   async createVideo(member: Member, createVidoeRequest: CreateVideoRequest) {
+    if (!member) throw new ManipulatedTokenNotFiltered();
+
     const newVideo = Video.from(member, createVidoeRequest);
     await this.videoRepository.save(newVideo);
   }
@@ -47,9 +50,13 @@ export class VideoService {
   }
 
   async getAllVideosByMemberId(member: Member) {
+    if (!member) throw new ManipulatedTokenNotFiltered();
+
     const videoList = await this.videoRepository.findAllVideosByMemberId(
       member.id,
     );
+
+    // TODO: 비디오의 썸네일과 길이에 대한 처리도 필요
     return VideoListResponse.from(videoList);
   }
 


### PR DESCRIPTION
[![NDD-127](https://badgen.net/badge/JIRA/NDD-127/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-127) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
현재 클라이언트가 등록한 비디오 전체를 조회하는 API를 구현하여, 마이페이지 상의 비디오 조회 페이지에서 해당 API를 사용할 수 있도록 하기 위함

# How
1. AuthGuard를 사용하여 JWT 토큰을 가지고 회원 정보를 가져옴 => 회원 정보가 없다면, AuthGuard가 뚫린 것이므로 에러 throw
2. AuthGuard에서 받아온 회원 정보 중 ID를 가지고, 전체 비디오 정보를 조회
3. 조회한 Video의 배열을 토대로, VideoListResponse 객체를 생성하여 이를 클라이언트로 반환
※ 아직 썸네일과 영상 시간을 처리할 로직이 확정되지 않아 임시값으로 반환되도록 구현된 상태

```javascript
async getAllVideosByMemberId(member: Member) {
    if (!member) throw new ManipulatedTokenNotFiltered();

    const videoList = await this.videoRepository.findAllVideosByMemberId(
      member.id,
    );

    // TODO: 비디오의 썸네일과 길이에 대한 처리도 필요
    return VideoListResponse.from(videoList);
  }
```

# Result
### 비디오를 등록한 회원의 경우 응답
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/f72320ee-d79f-49dd-b1b3-45aee0a6916c)

### 비디오가 등록되지 않은 회원의 경우 응답
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/dff17aa1-0bfd-4f50-871a-32eb8812ba2f)

# Prize
아래와 같은 복잡한 조회 쿼리를 Nest.js에서 이번에 처음 진행해보았다. 앞으로 이것보다 더 복잡한 쿼리를 작성해야 할 일이 많을텐데, 이를 위한 기초를 다질 수 있는 이번 API 구현이었다고 생각한다.
```javascript
  async findAllVideosByMemberId(memberId: number) {
    return this.videoRepository
      .createQueryBuilder('video')
      .where('video.memberId = :memberId', { memberId })
      .orderBy('video.createdAt', 'DESC')
      .getMany();
  }
```

[NDD-127]: https://milk717.atlassian.net/browse/NDD-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ