### PR TITLE
[NDD-168] Selection Box 컴포넌트 생성 (2h/2h)

### DIFF
--- a/FE/src/components/foundation/SelectionBox/SelectionBox.styles.tsx
+++ b/FE/src/components/foundation/SelectionBox/SelectionBox.styles.tsx
@@ -1,0 +1,49 @@
+import { theme } from '@/styles/theme';
+import { css } from '@emotion/react';
+
+export const selectionBox = css`
+  ::before {
+    content: '';
+    position: absolute;
+    background-color: ${theme.colors.point.primary.default};
+  }
+`;
+
+export const selectionBoxDirection = {
+  top: css`
+    ::before {
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 0.4rem;
+      border-radius: 0 0 0.2rem 0.2rem;
+    }
+  `,
+  left: css`
+    ::before {
+      top: 0;
+      left: 0;
+      width: 0.4rem;
+      height: 100%;
+      border-radius: 0 0.2rem 0.2rem 0;
+    }
+  `,
+  right: css`
+    ::before {
+      top: 0;
+      right: 0;
+      width: 0.4rem;
+      height: 100%;
+      border-radius: 0.2rem 0 0 0.2rem;
+    }
+  `,
+  bottom: css`
+    ::before {
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 0.4rem;
+      border-radius: 0.2rem 0.2rem 0 0;
+    }
+  `,
+} as const;

--- a/FE/src/components/foundation/SelectionBox/SelectionBox.tsx
+++ b/FE/src/components/foundation/SelectionBox/SelectionBox.tsx
@@ -1,0 +1,57 @@
+import { css } from '@emotion/react';
+import { selectionBox, selectionBoxDirection } from './SelectionBox.styles';
+import { HTMLElementTypes } from '@/types/utils';
+
+type SelectionButtonProps = {
+  children: React.ReactNode;
+  id: string;
+  name?: string;
+  lineDirection?: 'left' | 'right' | 'top' | 'bottom';
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+} & HTMLElementTypes<HTMLDivElement>;
+
+const SelectionBox: React.FC<SelectionButtonProps> = ({
+  children,
+  id,
+  name,
+  lineDirection = 'left',
+  onChange,
+  value,
+  ...args
+}) => {
+  return (
+    <div
+      css={css`
+        display: inline-block;
+        position: relative;
+        padding: 0 2rem;
+      `}
+      {...args}
+    >
+      <input
+        id={id}
+        name={name}
+        type={name ? 'radio' : 'checkbox'}
+        onChange={onChange}
+        value={value}
+        css={css`
+          display: none;
+        `}
+      />
+      <label
+        htmlFor={id}
+        css={css`
+          ${'#' + id}:checked + & {
+            ${selectionBox}
+            ${selectionBoxDirection[lineDirection]}
+          }
+        `}
+      >
+        {children}
+      </label>
+    </div>
+  );
+};
+
+export default SelectionBox;

--- a/FE/src/styles/_typography.ts
+++ b/FE/src/styles/_typography.ts
@@ -31,6 +31,16 @@ export const typography = {
   },
 
   /**
+   * 문제선택 tab, 마이페이지의 tab 컴포넌트에 사용됩니다.
+   */
+  title4: {
+    fontFamily: 'Pretendard',
+    fontStyle: 'normal',
+    fontWeight: 600,
+    fontSize: '1.125rem',
+  },
+
+  /**
    * 기본 글자에는 모두 이 스타일이 사용됩니다.
    */
   body1: {


### PR DESCRIPTION
[![NDD-168](https://badgen.net/badge/JIRA/NDD-168/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-168) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

lineDirection이 top 하고 bottom일때 디자인 이슈가 있어서 수정하느라 조금 늦었습니다.

# How


수민님은 인터페이스에 맞춰서 다음과 같이 사용하는게 일반적일 것입니다.
```typescript
          <SelectionBox
            id="test-id"
            lineDirection="bottom"
            css={css`
              padding: 1rem 0rem;
            `}
          >
            <Typography variant="title3">아래 방향</Typography>
          </SelectionBox>
```

컴포넌트의 원리는 border와 똑같다고 생각하시면 됩니다. 다만 저희 borderRadius가 border와는 역방향 이기 때문에 가상 선택자로 임의로 선을 집어 넣었습니다.
따라서 선택시의 선의 위치 조절은 padding으로 이루어져야 합니다.

## 포인트 1
input 태그와 label을 넣어서 선택시에 디자인을 변경하도록 하였습니다. input내부의 onChange이벤트 핸들러와 value를 통해서 선택되었는지 안되었는지 확인할 수 있습니다.

## 포인트 2
tab을 사용할 시에는 하나 클릭시 나머지는 선택이 되면 안되므로 radio를 사용해서 name으로 그룹을 묶어주어 하나 선택시에 나머지 SlectionBox는 취소가 되게 합니다

```typescript
        <SelectionBox id="FE" name="group">
          FE
        </SelectionBox>
        <SelectionBox id="BE" name="group">
          BE
        </SelectionBox>
```
만약 name이 없을시에는 checkbox로 동작하게 됩니다



# Result

<img width="777" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/49224104/8661b459-09b6-40c4-99a2-84c6476fbec1">

[NDD-168]: https://milk717.atlassian.net/browse/NDD-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ