### PR TITLE
[NDD-150] 구글 애널리틱스 설정 완료 (0.5h/1h)

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -18,6 +18,7 @@
         "axios": "^1.6.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-ga4": "^2.1.0",
         "react-router-dom": "^6.18.0",
         "recoil": "^0.7.7"
       },
@@ -9256,6 +9257,11 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
+    },
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -35,6 +35,7 @@
         "@typescript-eslint/parser": "^6.9.1",
         "babel-loader": "^9.1.3",
         "copy-webpack-plugin": "^11.0.0",
+        "dotenv-webpack": "^8.0.1",
         "eslint": "^8.53.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.1",
@@ -5621,6 +5622,39 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv-defaults": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+      "dev": true,
+      "dependencies": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "node_modules/dotenv-webpack": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz",
+      "integrity": "sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==",
+      "dev": true,
+      "dependencies": {
+        "dotenv-defaults": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "webpack": "^4 || ^5"
       }
     },
     "node_modules/ee-first": {

--- a/FE/package.json
+++ b/FE/package.json
@@ -20,6 +20,7 @@
     "axios": "^1.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-ga4": "^2.1.0",
     "react-router-dom": "^6.18.0",
     "recoil": "^0.7.7"
   },

--- a/FE/package.json
+++ b/FE/package.json
@@ -37,6 +37,7 @@
     "@typescript-eslint/parser": "^6.9.1",
     "babel-loader": "^9.1.3",
     "copy-webpack-plugin": "^11.0.0",
+    "dotenv-webpack": "^8.0.1",
     "eslint": "^8.53.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.1",

--- a/FE/src/index.tsx
+++ b/FE/src/index.tsx
@@ -1,4 +1,5 @@
 import ReactDOM from 'react-dom/client';
+import ReactGA from 'react-ga4';
 import { worker } from '@/mocks/browser';
 import App from '@/App';
 
@@ -7,6 +8,11 @@ async function deferRender() {
     return;
   }
   return worker.start();
+}
+
+//GA 추적 태그 설정
+if (process.env.REACT_APP_GTAG_ID) {
+  ReactGA.initialize(process.env.REACT_APP_GTAG_ID);
 }
 
 deferRender()

--- a/FE/webpack.config.js
+++ b/FE/webpack.config.js
@@ -2,6 +2,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const webpack = require('webpack');
 const CopyPlugin = require('copy-webpack-plugin');
+const Dotenv = require('dotenv-webpack');
 
 module.exports = {
   mode: process.env.production === 'true' ? 'production' : 'development',
@@ -44,6 +45,7 @@ module.exports = {
     new CopyPlugin({
       patterns: [{ from: 'public/mockServiceWorker.js', to: '' }],
     }),
+    new Dotenv(),
   ],
   module: {
     rules: [


### PR DESCRIPTION
[![NDD-150](https://badgen.net/badge/JIRA/NDD-150/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-150) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

우선 구글 애널리틱스 태그 연결만 진행했습니다.
각 페이지별 추적이나 행동 추적 이벤트는 좀 더 개발이 진행된 후에 다는 것이 좋다고 판단했습니다.

# How

- GTAG는 웹사이트에서 개발자모드를 켜서 확인할 수 있는 코드라서 env에 숨기지 않아도 되지만... 뭔가가 뭔가라는 팀원들의 의견을 반영해서 env파일에 넣었습니다.
- env 파일을 설정하기 위해 webpack에 dotenv 플러그인을 추가했습니다.
- GA 추적 태그를 설정하는 코드는 일단 index.ts에 넣어놨는데 다른곳에 넣는 것이 좋다는 의견이 있으면 이동하도록 하겠습니다~

# Result
<img width="1082" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/70c5d32e-07e9-4dea-83b1-d5a4b14a6caf">

[NDD-150]: https://milk717.atlassian.net/browse/NDD-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ