### PR TITLE
[NDD-160]: 카테고리 추가 기능 구현 (2h / 1h)

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module';
 import { TokenModule } from './token/token.module';
 import { QuestionModule } from './question/question.module';
 import { VideoModule } from './video/video.module';
+import { CategoryModule } from './category/category.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { VideoModule } from './video/video.module';
     TokenModule,
     QuestionModule,
     VideoModule,
+    CategoryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BE/src/category/category.module.ts
+++ b/BE/src/category/category.module.ts
@@ -2,8 +2,12 @@ import { Module } from '@nestjs/common';
 import { CategoryRepository } from './repository/category.repository';
 import { CategoryService } from './service/category.service';
 import { CategoryController } from './controller/category.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Category } from './entity/category';
+import { Question } from '../question/entity/question';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Category, Question])],
   providers: [CategoryRepository, CategoryService],
   controllers: [CategoryController],
 })

--- a/BE/src/category/category.module.ts
+++ b/BE/src/category/category.module.ts
@@ -1,7 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CategoryRepository } from './repository/category.repository';
+import { CategoryService } from './service/category.service';
+import { CategoryController } from './controller/category.controller';
 
 @Module({
-  providers: [CategoryRepository],
+  providers: [CategoryRepository, CategoryService],
+  controllers: [CategoryController],
 })
 export class CategoryModule {}

--- a/BE/src/category/controller/category.controller.spec.ts
+++ b/BE/src/category/controller/category.controller.spec.ts
@@ -49,6 +49,9 @@ describe('CategoryController', () => {
     //given
 
     //when
+    mockCategoryService.createCategory.mockRejectedValue(
+      new CategoryNameEmptyException(),
+    );
 
     //then
     await expect(
@@ -63,6 +66,9 @@ describe('CategoryController', () => {
     //given
 
     //when
+    mockCategoryService.createCategory.mockRejectedValue(
+      new ManipulatedTokenNotFiltered(),
+    );
 
     //then
     await expect(

--- a/BE/src/category/controller/category.controller.spec.ts
+++ b/BE/src/category/controller/category.controller.spec.ts
@@ -1,11 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CategoryController } from './category.controller';
 import { CategoryService } from '../service/category.service';
+import { mockReqWithMemberFixture } from '../../member/fixture/member.fixture';
+import { CreateCategoryRequest } from '../dto/createCategoryRequest';
+import { CategoryNameEmptyException } from '../exception/category.exception';
+import { ManipulatedTokenNotFiltered } from '../../token/exception/token.exception';
+import { Request } from 'express';
 
 describe('CategoryController', () => {
   let controller: CategoryController;
 
-  const mockCategoryService = {};
+  const mockCategoryService = {
+    createCategory: jest.fn(),
+  };
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -23,6 +30,51 @@ describe('CategoryController', () => {
     expect(controller).toBeDefined();
   });
 
+  it('카테고리 저장을 성공시 undefined를 반환한다.', async () => {
+    //given
+
+    //when
+    mockCategoryService.createCategory.mockResolvedValue(undefined);
+
+    //then
+    await expect(
+      controller.createCategory(
+        mockReqWithMemberFixture,
+        new CreateCategoryRequest('tester'),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('카테고리 저장시, body가 isEmpty라면 CategoryNameEmptyException을 반환한다.', async () => {
+    //given
+
+    //when
+
+    //then
+    await expect(
+      controller.createCategory(
+        mockReqWithMemberFixture,
+        new CreateCategoryRequest(undefined),
+      ),
+    ).rejects.toThrow(new CategoryNameEmptyException());
+  });
+
+  it('카테고리 저장시 회원 객체가 없으면 ManipulatedTokenException을 반환한다.', async () => {
+    //given
+
+    //when
+
+    //then
+    await expect(
+      controller.createCategory(
+        { user: null } as unknown as Request,
+        new CreateCategoryRequest('tester'),
+      ),
+    ).rejects.toThrow(new ManipulatedTokenNotFiltered());
+  });
+});
+
+describe('CategoryController 통합테스트', () => {
   it('카테고리 저장을 성공시 200상태코드가 반환된다.', () => {});
 
   it('카테고리 저장시, name이 없으면 CategoryNameEmptyException을 반환한다.', () => {});

--- a/BE/src/category/controller/category.controller.spec.ts
+++ b/BE/src/category/controller/category.controller.spec.ts
@@ -7,7 +7,7 @@ describe('CategoryController', () => {
 
   const mockCategoryService = {};
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CategoryController],
       providers: [CategoryService],
@@ -22,4 +22,10 @@ describe('CategoryController', () => {
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
+
+  it('카테고리 저장을 성공시 200상태코드가 반환된다.', () => {});
+
+  it('카테고리 저장시, name이 없으면 CategoryNameEmptyException을 반환한다.', () => {});
+
+  it('카테고리 저장시 회원 객체가 없으면 UnauthorizedException을 반환한다.', () => {});
 });

--- a/BE/src/category/controller/category.controller.spec.ts
+++ b/BE/src/category/controller/category.controller.spec.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoryController } from './category.controller';
+import { CategoryService } from '../service/category.service';
+
+describe('CategoryController', () => {
+  let controller: CategoryController;
+
+  const mockCategoryService = {};
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoryController],
+      providers: [CategoryService],
+    })
+      .overrideProvider(CategoryService)
+      .useValue(mockCategoryService)
+      .compile();
+
+    controller = module.get<CategoryController>(CategoryController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('category')
+export class CategoryController {}

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -1,15 +1,31 @@
-import { Body, Controller, Req } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  ApiBody,
+  ApiCookieAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { CategoryService } from '../service/category.service';
 import { Request } from 'express';
 import { CreateCategoryRequest } from '../dto/createCategoryRequest';
 import { Member } from '../../member/entity/member';
+import { AuthGuard } from '@nestjs/passport';
+import { createApiResponseOption } from '../../util/swagger.util';
 
 @Controller('/api/category')
 @ApiTags('category')
 export class CategoryController {
   constructor(private categoryService: CategoryService) {}
 
+  @Post()
+  @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth() // 문서 상에 자물쇠 아이콘을 표시하여 쿠키가 필요하다는 것을 나타냄
+  @ApiOperation({
+    summary: '카테고리를 추가한다.',
+  })
+  @ApiBody({ type: CreateCategoryRequest })
+  @ApiResponse(createApiResponseOption(201, '카테고리 추가', null))
   async createCategory(
     @Req() req: Request,
     @Body() createCategoryRequest: CreateCategoryRequest,

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -1,4 +1,23 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Req } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { CategoryService } from '../service/category.service';
 
-@Controller('category')
-export class CategoryController {}
+import { Request } from 'express';
+import { CreateCategoryRequest } from '../dto/createCategoryRequest';
+import { Member } from '../../member/entity/member';
+
+@Controller('/api/category')
+@ApiTags('category')
+export class CategoryController {
+  constructor(private categoryService: CategoryService) {}
+
+  async createCategory(
+    @Req() req: Request,
+    @Body() createCategoryRequest: CreateCategoryRequest,
+  ) {
+    return await this.categoryService.createCategory(
+      createCategoryRequest,
+      req.user as Member,
+    );
+  }
+}

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -1,7 +1,6 @@
 import { Body, Controller, Req } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { CategoryService } from '../service/category.service';
-
 import { Request } from 'express';
 import { CreateCategoryRequest } from '../dto/createCategoryRequest';
 import { Member } from '../../member/entity/member';

--- a/BE/src/category/dto/categoryResponse.ts
+++ b/BE/src/category/dto/categoryResponse.ts
@@ -1,7 +1,12 @@
 import { Category } from '../entity/category';
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from '../../util/swagger.util';
 
 export class CategoryResponse {
+  @ApiProperty(createPropertyOption(1, '카테고리 ID', Number))
   id: number;
+
+  @ApiProperty(createPropertyOption('BE', '카테고리 이름', String))
   name: string;
 
   constructor(id: number, name: string) {

--- a/BE/src/category/dto/categoryResponse.ts
+++ b/BE/src/category/dto/categoryResponse.ts
@@ -1,0 +1,15 @@
+import { Category } from '../entity/category';
+
+export class CategoryResponse {
+  id: number;
+  name: string;
+
+  constructor(id: number, name: string) {
+    this.id = id;
+    this.name = name;
+  }
+
+  static from(category: Category) {
+    return new CategoryResponse(category.id, category.name);
+  }
+}

--- a/BE/src/category/dto/createCategoryRequest.ts
+++ b/BE/src/category/dto/createCategoryRequest.ts
@@ -1,4 +1,11 @@
+import { IsNotEmpty, IsString } from '@nestjs/class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from '../../util/swagger.util';
+
 export class CreateCategoryRequest {
+  @ApiProperty(createPropertyOption('BE', '카테고리명', String))
+  @IsString()
+  @IsNotEmpty()
   name: string;
 
   constructor(name: string) {

--- a/BE/src/category/dto/createCategoryRequest.ts
+++ b/BE/src/category/dto/createCategoryRequest.ts
@@ -1,0 +1,7 @@
+export class CreateCategoryRequest {
+  name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}

--- a/BE/src/category/entity/category.ts
+++ b/BE/src/category/entity/category.ts
@@ -24,14 +24,14 @@ export class Category extends DefaultEntity {
   @JoinTable({ name: 'CategoryQuestion' })
   questions: Question[];
 
-  constructor(name: string, member: Member) {
-    super(undefined, new Date());
+  constructor(id: number, name: string, member: Member, createdAt: Date) {
+    super(id, createdAt);
     this.member = member;
     this.name = name;
   }
 
   static from(inputObj: CreateCategoryRequest | Category, member: Member) {
-    return new Category(inputObj.name, member);
+    return new Category(undefined, inputObj.name, member, new Date());
   }
 
   getName() {

--- a/BE/src/category/entity/category.ts
+++ b/BE/src/category/entity/category.ts
@@ -1,7 +1,13 @@
-import { Column, Entity, JoinTable, ManyToMany, ManyToOne } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  JoinTable,
+  ManyToMany,
+  ManyToOne,
+} from 'typeorm';
 import { DefaultEntity } from '../../app.entity';
 import { Member } from '../../member/entity/member';
-import { JoinColumn } from 'typeorm/browser';
 import { Question } from '../../question/entity/question';
 
 @Entity({ name: 'Category' })

--- a/BE/src/category/entity/category.ts
+++ b/BE/src/category/entity/category.ts
@@ -9,6 +9,7 @@ import {
 import { DefaultEntity } from '../../app.entity';
 import { Member } from '../../member/entity/member';
 import { Question } from '../../question/entity/question';
+import { CreateCategoryRequest } from '../dto/createCategoryRequest';
 
 @Entity({ name: 'Category' })
 export class Category extends DefaultEntity {
@@ -23,13 +24,14 @@ export class Category extends DefaultEntity {
   @JoinTable({ name: 'CategoryQuestion' })
   questions: Question[];
 
-  constructor(name: string) {
+  constructor(name: string, member: Member) {
     super(undefined, new Date());
+    this.member = member;
     this.name = name;
   }
 
-  static copyCategory(category: Category) {
-    return new Category(category.name);
+  static from(inputObj: CreateCategoryRequest | Category, member: Member) {
+    return new Category(inputObj.name, member);
   }
 
   getName() {

--- a/BE/src/category/exception/category.exception.ts
+++ b/BE/src/category/exception/category.exception.ts
@@ -1,0 +1,9 @@
+import { HttpException } from '@nestjs/common';
+
+class CategoryNameEmptyException extends HttpException {
+  constructor() {
+    super('카테고리명을 입력해주세요.', 400);
+  }
+}
+
+export { CategoryNameEmptyException };

--- a/BE/src/category/fixture/category.fixture.ts
+++ b/BE/src/category/fixture/category.fixture.ts
@@ -1,7 +1,27 @@
 import { Category } from '../entity/category';
 import { memberFixture } from '../../member/fixture/member.fixture';
 
-export const beCategoryFixture = new Category('BE', memberFixture);
-export const feCategoryFixture = new Category('FE', memberFixture);
-export const csCategoryFixture = new Category('CS', memberFixture);
-export const customCategoryFixture = new Category('나만의 질문', memberFixture);
+export const beCategoryFixture = new Category(
+  undefined,
+  'BE',
+  memberFixture,
+  new Date(),
+);
+export const feCategoryFixture = new Category(
+  undefined,
+  'FE',
+  memberFixture,
+  new Date(),
+);
+export const csCategoryFixture = new Category(
+  undefined,
+  'CS',
+  memberFixture,
+  new Date(),
+);
+export const customCategoryFixture = new Category(
+  undefined,
+  '나만의 질문',
+  memberFixture,
+  new Date(),
+);

--- a/BE/src/category/fixture/category.fixture.ts
+++ b/BE/src/category/fixture/category.fixture.ts
@@ -1,0 +1,7 @@
+import { Category } from '../entity/category';
+import { memberFixture } from '../../member/fixture/member.fixture';
+
+export const beCategoryFixture = new Category('BE', memberFixture);
+export const feCategoryFixture = new Category('FE', memberFixture);
+export const csCategoryFixture = new Category('CS', memberFixture);
+export const customCategoryFixture = new Category('나만의 질문', memberFixture);

--- a/BE/src/category/repository/category.repository.ts
+++ b/BE/src/category/repository/category.repository.ts
@@ -21,4 +21,8 @@ export class CategoryRepository {
   async remove(category: Category) {
     await this.repository.remove(category);
   }
+
+  async query(query: string) {
+    return await this.repository.query(query);
+  }
 }

--- a/BE/src/category/service/category.service.spec.ts
+++ b/BE/src/category/service/category.service.spec.ts
@@ -9,13 +9,12 @@ describe('CategoryService', () => {
   const mockCategoryRepository = {
     save: jest.fn(),
     findCategories: jest.fn(),
-    findQuestionByIdAndMember_Id: jest.fn(),
     remove: jest.fn(),
   };
 
   const mockMemberRepository = {};
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [CategoryService, MemberRepository, CategoryRepository],
     })
@@ -31,4 +30,10 @@ describe('CategoryService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+
+  it('카테고리 저장을 성공시 undefined로 반환된다.', () => {});
+
+  it('카테고리 저장시, name이 없으면 CategoryNameEmptyException을 반환한다.', () => {});
+
+  it('카테고리 저장시 회원 객체가 없으면 UnauthorizedException을 반환한다.', () => {});
 });

--- a/BE/src/category/service/category.service.spec.ts
+++ b/BE/src/category/service/category.service.spec.ts
@@ -12,7 +12,7 @@ describe('CategoryService', () => {
 
   const mockCategoryRepository = {
     save: jest.fn(),
-    findCategories: jest.fn(),
+    findAllByMemberId: jest.fn(),
     remove: jest.fn(),
   };
 
@@ -56,7 +56,7 @@ describe('CategoryService', () => {
     //when
 
     //then
-    expect(service.createCategory(request, member)).rejects.toThrow(
+    await expect(service.createCategory(request, member)).rejects.toThrow(
       new CategoryNameEmptyException(),
     );
   });

--- a/BE/src/category/service/category.service.spec.ts
+++ b/BE/src/category/service/category.service.spec.ts
@@ -1,0 +1,34 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoryService } from './category.service';
+import { MemberRepository } from '../../member/repository/member.repository';
+import { CategoryRepository } from '../repository/category.repository';
+
+describe('CategoryService', () => {
+  let service: CategoryService;
+
+  const mockCategoryRepository = {
+    save: jest.fn(),
+    findCategories: jest.fn(),
+    findQuestionByIdAndMember_Id: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  const mockMemberRepository = {};
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CategoryService, MemberRepository, CategoryRepository],
+    })
+      .overrideProvider(CategoryRepository)
+      .useValue(mockCategoryRepository)
+      .overrideProvider(MemberRepository)
+      .useValue(mockMemberRepository)
+      .compile();
+
+    service = module.get<CategoryService>(CategoryService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/BE/src/category/service/category.service.spec.ts
+++ b/BE/src/category/service/category.service.spec.ts
@@ -4,7 +4,8 @@ import { MemberRepository } from '../../member/repository/member.repository';
 import { CategoryRepository } from '../repository/category.repository';
 import { memberFixture } from '../../member/fixture/member.fixture';
 import { CreateCategoryRequest } from '../dto/createCategoryRequest';
-import { UnauthorizedException } from '@nestjs/common';
+import { CategoryNameEmptyException } from '../exception/category.exception';
+import { ManipulatedTokenNotFiltered } from '../../token/exception/token.exception';
 
 describe('CategoryService', () => {
   let service: CategoryService;
@@ -61,13 +62,13 @@ describe('CategoryService', () => {
   });
 
   it('카테고리 저장시 회원 객체가 없으면 UnauthorizedException을 반환한다.', () => {
-    const request = new CreateCategoryRequest(undefined);
+    const request = new CreateCategoryRequest('test name');
 
     //when
 
     //then
     expect(service.createCategory(request, undefined)).rejects.toThrow(
-      new UnauthorizedException(),
+      new ManipulatedTokenNotFiltered(),
     );
   });
 });

--- a/BE/src/category/service/category.service.spec.ts
+++ b/BE/src/category/service/category.service.spec.ts
@@ -2,6 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { CategoryService } from './category.service';
 import { MemberRepository } from '../../member/repository/member.repository';
 import { CategoryRepository } from '../repository/category.repository';
+import { memberFixture } from '../../member/fixture/member.fixture';
+import { CreateCategoryRequest } from '../dto/createCategoryRequest';
+import { UnauthorizedException } from '@nestjs/common';
 
 describe('CategoryService', () => {
   let service: CategoryService;
@@ -31,9 +34,40 @@ describe('CategoryService', () => {
     expect(service).toBeDefined();
   });
 
-  it('카테고리 저장을 성공시 undefined로 반환된다.', () => {});
+  it('카테고리 저장을 성공시 undefined로 반환된다.', async () => {
+    //given
+    const member = memberFixture;
+    const request = new CreateCategoryRequest('testCategory');
 
-  it('카테고리 저장시, name이 없으면 CategoryNameEmptyException을 반환한다.', () => {});
+    //when
+    mockCategoryRepository.save.mockResolvedValue(undefined);
 
-  it('카테고리 저장시 회원 객체가 없으면 UnauthorizedException을 반환한다.', () => {});
+    //then
+    await expect(
+      service.createCategory(request, member),
+    ).resolves.toBeUndefined();
+  });
+
+  it('카테고리 저장시, name이 없으면 CategoryNameEmptyException을 반환한다.', async () => {
+    const member = memberFixture;
+    const request = new CreateCategoryRequest(undefined);
+
+    //when
+
+    //then
+    expect(service.createCategory(request, member)).rejects.toThrow(
+      new CategoryNameEmptyException(),
+    );
+  });
+
+  it('카테고리 저장시 회원 객체가 없으면 UnauthorizedException을 반환한다.', () => {
+    const request = new CreateCategoryRequest(undefined);
+
+    //when
+
+    //then
+    expect(service.createCategory(request, undefined)).rejects.toThrow(
+      new UnauthorizedException(),
+    );
+  });
 });

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CategoryService {}

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -15,6 +15,7 @@ export class CategoryService {
     createCategoryRequest: CreateCategoryRequest,
     member: Member,
   ) {
+    console.log(createCategoryRequest);
     if (isEmpty(createCategoryRequest.name)) {
       throw new CategoryNameEmptyException();
     }
@@ -23,7 +24,7 @@ export class CategoryService {
       throw new ManipulatedTokenNotFiltered();
     }
 
-    await this.categoryRepository.save(
+    return await this.categoryRepository.save(
       Category.from(createCategoryRequest, member),
     );
   }

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -15,7 +15,6 @@ export class CategoryService {
     createCategoryRequest: CreateCategoryRequest,
     member: Member,
   ) {
-    console.log(createCategoryRequest);
     if (isEmpty(createCategoryRequest.name)) {
       throw new CategoryNameEmptyException();
     }

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -2,6 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { CategoryRepository } from '../repository/category.repository';
 import { CreateCategoryRequest } from '../dto/createCategoryRequest';
 import { Member } from '../../member/entity/member';
+import { isEmpty } from 'class-validator';
+import { CategoryNameEmptyException } from '../exception/category.exception';
+import { ManipulatedTokenNotFiltered } from '../../token/exception/token.exception';
+import { Category } from '../entity/category';
 
 @Injectable()
 export class CategoryService {
@@ -10,5 +14,17 @@ export class CategoryService {
   async createCategory(
     createCategoryRequest: CreateCategoryRequest,
     member: Member,
-  ) {}
+  ) {
+    if (isEmpty(createCategoryRequest.name)) {
+      throw new CategoryNameEmptyException();
+    }
+
+    if (isEmpty(member)) {
+      throw new ManipulatedTokenNotFiltered();
+    }
+
+    await this.categoryRepository.save(
+      Category.from(createCategoryRequest, member),
+    );
+  }
 }

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -4,8 +4,8 @@ import { CreateCategoryRequest } from '../dto/createCategoryRequest';
 import { Member } from '../../member/entity/member';
 import { isEmpty } from 'class-validator';
 import { CategoryNameEmptyException } from '../exception/category.exception';
-import { ManipulatedTokenNotFiltered } from '../../token/exception/token.exception';
 import { Category } from '../entity/category';
+import { validateManipulatedToken } from 'src/util/token.util';
 
 @Injectable()
 export class CategoryService {
@@ -15,12 +15,10 @@ export class CategoryService {
     createCategoryRequest: CreateCategoryRequest,
     member: Member,
   ) {
+    validateManipulatedToken(member);
+
     if (isEmpty(createCategoryRequest.name)) {
       throw new CategoryNameEmptyException();
-    }
-
-    if (isEmpty(member)) {
-      throw new ManipulatedTokenNotFiltered();
     }
 
     return await this.categoryRepository.save(

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { CategoryRepository } from '../repository/category.repository';
 import { CreateCategoryRequest } from '../dto/createCategoryRequest';
+import { Member } from '../../member/entity/member';
 
 @Injectable()
 export class CategoryService {
   constructor(private categoryRepository: CategoryRepository) {}
 
-  async createCategory(createCategoryRequest: CreateCategoryRequest) {}
+  async createCategory(
+    createCategoryRequest: CreateCategoryRequest,
+    member: Member,
+  ) {}
 }

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -1,4 +1,10 @@
 import { Injectable } from '@nestjs/common';
+import { CategoryRepository } from '../repository/category.repository';
+import { CreateCategoryRequest } from '../dto/createCategoryRequest';
 
 @Injectable()
-export class CategoryService {}
+export class CategoryService {
+  constructor(private categoryRepository: CategoryRepository) {}
+
+  async createCategory(createCategoryRequest: CreateCategoryRequest) {}
+}


### PR DESCRIPTION
[![NDD-160](https://badgen.net/badge/JIRA/NDD-160/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-160) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

기존의 ERD에서 카테고리를 컬럼에서 테이블로 분리하고, 이에 대한 확장성을 고려해 Category만의 API가 필요하다고 생각했다. 
이를 위해서, 기본적인 Category 추가 기능을 구현하려고 했다. 

## Reason of 2h/1h
해당 API부터 TDD를 개인적으로 적용해보았다. API 자체에 대해서 첫 테스트를 만들기 위해서, 테스트를 위한 TestModule을 셋팅해야 했다. 
이로 인한 딜레이가 발생했다.

# How

구현의 순서는 아래와 같아. 
```
1. 단위 테스트를 추가한다(이 때, 에러가 아닌 테스트 실패를 위해, Exception과 내부적인 로직은 빈 객체/함수로 만들어둔다.)
2. 테스트를 성공시키기 위한 함수를 만든다. 
3. 서비스/컨트롤러마다 1, 2를 반복한다. 
4. 서비스 통합테스트를 한다(단위테스트에서는 repository를 mocking했다면, 이번엔 실제로 이를 동작시켜본다)
5. 컨트롤러 통합테스트를 한다(이 때는 함수단위가 아닌, Request => Response를 검증하기 위해 토큰부터 모든 것을 실제 요청처럼 검증한다)
6. 통합테스트를 통한 정리된 과정을 swagger에 적용될 수 있도록 문서화 코드를 추가한다.
```

# Result
![스크린샷 2023-11-15 15 22 38](https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/478dbe65-31cc-494b-960a-c15f519d5e7b)
단위/통합 테스트가 성공적으로 동작되었으며, 
<img width="370" alt="스크린샷 2023-11-15 15 23 00" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/9ec4fff9-7b6e-41f6-a23e-d8f5dccbbbc1">
swagger에도 이에 대한 문서가 등록되었다. 


[NDD-160]: https://milk717.atlassian.net/browse/NDD-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ