### PR TITLE
[NDD-167] tabs foundation 컴포넌트 구현 완료 (5h/3h)

### DIFF
--- a/FE/src/components/foundation/SelectionBox/SelectionBox.tsx
+++ b/FE/src/components/foundation/SelectionBox/SelectionBox.tsx
@@ -9,7 +9,7 @@ type SelectionButtonProps = {
   name?: string;
   lineDirection?: 'left' | 'right' | 'top' | 'bottom';
   value?: string;
-  selectedValue?: string;
+  defaultChecked?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 } & HTMLElementTypes<HTMLLabelElement>;
 
@@ -20,7 +20,7 @@ const SelectionBox: React.FC<SelectionButtonProps> = ({
   lineDirection = 'left',
   onChange,
   value,
-  selectedValue,
+  defaultChecked,
   ...args
 }) => {
   return (
@@ -40,7 +40,7 @@ const SelectionBox: React.FC<SelectionButtonProps> = ({
         type={name ? 'radio' : 'checkbox'}
         onChange={onChange}
         value={value}
-        defaultChecked={selectedValue === value}
+        defaultChecked={defaultChecked}
         css={css`
           display: none;
         `}

--- a/FE/src/components/foundation/SelectionBox/SelectionBox.tsx
+++ b/FE/src/components/foundation/SelectionBox/SelectionBox.tsx
@@ -9,7 +9,7 @@ type SelectionButtonProps = {
   lineDirection?: 'left' | 'right' | 'top' | 'bottom';
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-} & HTMLElementTypes<HTMLDivElement>;
+} & HTMLElementTypes<HTMLLabelElement>;
 
 const SelectionBox: React.FC<SelectionButtonProps> = ({
   children,
@@ -21,7 +21,8 @@ const SelectionBox: React.FC<SelectionButtonProps> = ({
   ...args
 }) => {
   return (
-    <div
+    <label
+      htmlFor={id}
       css={css`
         display: inline-block;
         position: relative;
@@ -50,7 +51,7 @@ const SelectionBox: React.FC<SelectionButtonProps> = ({
       >
         {children}
       </label>
-    </div>
+    </label>
   );
 };
 

--- a/FE/src/components/foundation/SelectionBox/SelectionBox.tsx
+++ b/FE/src/components/foundation/SelectionBox/SelectionBox.tsx
@@ -9,6 +9,7 @@ type SelectionButtonProps = {
   name?: string;
   lineDirection?: 'left' | 'right' | 'top' | 'bottom';
   value?: string;
+  selectedValue?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 } & HTMLElementTypes<HTMLLabelElement>;
 
@@ -19,6 +20,7 @@ const SelectionBox: React.FC<SelectionButtonProps> = ({
   lineDirection = 'left',
   onChange,
   value,
+  selectedValue,
   ...args
 }) => {
   return (
@@ -38,6 +40,7 @@ const SelectionBox: React.FC<SelectionButtonProps> = ({
         type={name ? 'radio' : 'checkbox'}
         onChange={onChange}
         value={value}
+        defaultChecked={selectedValue === value}
         css={css`
           display: none;
         `}

--- a/FE/src/components/foundation/SelectionBox/SelectionBox.tsx
+++ b/FE/src/components/foundation/SelectionBox/SelectionBox.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { selectionBox, selectionBoxDirection } from './SelectionBox.styles';
 import { HTMLElementTypes } from '@/types/utils';
+import { theme } from '@styles/theme';
 
 type SelectionButtonProps = {
   children: React.ReactNode;
@@ -27,6 +28,7 @@ const SelectionBox: React.FC<SelectionButtonProps> = ({
         display: inline-block;
         position: relative;
         padding: 0 2rem;
+        color: ${theme.colors.text.subStrong};
       `}
       {...args}
     >
@@ -46,6 +48,7 @@ const SelectionBox: React.FC<SelectionButtonProps> = ({
           ${'#' + id}:checked + & {
             ${selectionBox}
             ${selectionBoxDirection[lineDirection]}
+            color: ${theme.colors.text.default};
           }
         `}
       >

--- a/FE/src/components/foundation/Tabs/Tab.tsx
+++ b/FE/src/components/foundation/Tabs/Tab.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import addChildElementProps from '@/utils/addChildElementProps';
+import { TabContext } from '@foundation/Tabs/index';
 
 type TabProps = {
   children?: React.ReactNode;
@@ -9,11 +10,18 @@ type TabProps = {
 };
 
 const Tab: React.FC<TabProps> = ({ children, name, value, onClick }) => {
+  const { selectedValue } = useContext(TabContext);
+
   return (
     <div onClick={() => onClick && onClick(value)}>
       {addChildElementProps({
         children,
-        newProps: { name, value, onChange: () => onClick && onClick(value) },
+        newProps: {
+          name,
+          value,
+          selectedValue,
+          onChange: () => onClick && onClick(value),
+        },
       })}
     </div>
   );

--- a/FE/src/components/foundation/Tabs/Tab.tsx
+++ b/FE/src/components/foundation/Tabs/Tab.tsx
@@ -1,11 +1,19 @@
+import React from 'react';
+import addChildElementProps from '@/utils/addChildElementProps';
+
 type TabProps = {
-  label?: string;
-  value?: string;
-  onClick?: (value?: string) => void;
+  children?: React.ReactNode;
+  name?: string;
+  value: string;
+  onClick?: (value: string) => void;
 };
 
-const Tab: React.FC<TabProps> = ({ label, value, onClick }) => (
-  <button onClick={() => onClick && onClick(value)}>{label}</button>
-);
+const Tab: React.FC<TabProps> = ({ children, name, value, onClick }) => {
+  return (
+    <div onClick={() => onClick && onClick(value)}>
+      {addChildElementProps({ children, newProps: { name, value } })}
+    </div>
+  );
+};
 
 export default Tab;

--- a/FE/src/components/foundation/Tabs/Tab.tsx
+++ b/FE/src/components/foundation/Tabs/Tab.tsx
@@ -11,7 +11,10 @@ type TabProps = {
 const Tab: React.FC<TabProps> = ({ children, name, value, onClick }) => {
   return (
     <div onClick={() => onClick && onClick(value)}>
-      {addChildElementProps({ children, newProps: { name, value } })}
+      {addChildElementProps({
+        children,
+        newProps: { name, value, onChange: () => onClick && onClick(value) },
+      })}
     </div>
   );
 };

--- a/FE/src/components/foundation/Tabs/Tab.tsx
+++ b/FE/src/components/foundation/Tabs/Tab.tsx
@@ -1,6 +1,4 @@
-import React, { useContext } from 'react';
-import addChildElementProps from '@/utils/addChildElementProps';
-import { TabContext } from '@foundation/Tabs/index';
+import React from 'react';
 
 type TabProps = {
   children?: React.ReactNode;
@@ -9,22 +7,8 @@ type TabProps = {
   onClick?: (value: string) => void;
 };
 
-const Tab: React.FC<TabProps> = ({ children, name, value, onClick }) => {
-  const { selectedValue } = useContext(TabContext);
-
-  return (
-    <div onClick={() => onClick && onClick(value)}>
-      {addChildElementProps({
-        children,
-        newProps: {
-          name,
-          value,
-          selectedValue,
-          onChange: () => onClick && onClick(value),
-        },
-      })}
-    </div>
-  );
+const Tab: React.FC<TabProps> = ({ children, value, onClick }) => {
+  return <div onClick={() => onClick && onClick(value)}>{children}</div>;
 };
 
 export default Tab;

--- a/FE/src/components/foundation/Tabs/Tab.tsx
+++ b/FE/src/components/foundation/Tabs/Tab.tsx
@@ -1,0 +1,11 @@
+type TabProps = {
+  label?: string;
+  value?: string;
+  onClick?: (value?: string) => void;
+};
+
+const Tab: React.FC<TabProps> = ({ label, value, onClick }) => (
+  <button onClick={() => onClick && onClick(value)}>{label}</button>
+);
+
+export default Tab;

--- a/FE/src/components/foundation/Tabs/TabList.tsx
+++ b/FE/src/components/foundation/Tabs/TabList.tsx
@@ -2,21 +2,36 @@ import { SyntheticEvent, useContext } from 'react';
 import { TabContext } from '@foundation/Tabs/index';
 import enhanceChildElement from '@/utils/enhanceChildElement';
 import Tab from '@foundation/Tabs/Tab';
+import { css } from '@emotion/react';
 
 type TabListProps = {
   children: React.ReactNode;
+  name?: string;
+  direction?: 'row' | 'column';
+  gap?: string;
   onChange: (e: SyntheticEvent, value: string) => void;
 };
 
-const TabList: React.FC<TabListProps> = ({ children }) => {
+const TabList: React.FC<TabListProps> = ({
+  children,
+  name,
+  direction = 'row',
+  gap = '0.5rem',
+}) => {
   const { handleTabChange } = useContext(TabContext);
 
   return (
-    <div>
+    <div
+      css={css`
+        display: flex;
+        flex-direction: ${direction};
+        gap: ${gap};
+      `}
+    >
       {enhanceChildElement({
         children,
         component: Tab,
-        newProps: { onClick: handleTabChange },
+        newProps: { onClick: handleTabChange, name },
       })}
     </div>
   );

--- a/FE/src/components/foundation/Tabs/TabList.tsx
+++ b/FE/src/components/foundation/Tabs/TabList.tsx
@@ -1,0 +1,25 @@
+import { SyntheticEvent, useContext } from 'react';
+import { TabContext } from '@foundation/Tabs/index';
+import enhanceChildElement from '@/utils/enhanceChildElement';
+import Tab from '@foundation/Tabs/Tab';
+
+type TabListProps = {
+  children: React.ReactNode;
+  onChange: (e: SyntheticEvent, value: string) => void;
+};
+
+const TabList: React.FC<TabListProps> = ({ children }) => {
+  const { handleTabChange } = useContext(TabContext);
+
+  return (
+    <div>
+      {enhanceChildElement({
+        children,
+        component: Tab,
+        newProps: { onClick: handleTabChange },
+      })}
+    </div>
+  );
+};
+
+export default TabList;

--- a/FE/src/components/foundation/Tabs/TabList.tsx
+++ b/FE/src/components/foundation/Tabs/TabList.tsx
@@ -1,8 +1,8 @@
 import { SyntheticEvent, useContext } from 'react';
 import { TabContext } from '@foundation/Tabs/index';
-import enhanceChildElement from '@/utils/enhanceChildElement';
-import Tab from '@foundation/Tabs/Tab';
 import { css } from '@emotion/react';
+import Tab from '@foundation/Tabs/Tab';
+import enhanceChildElement from '@/utils/enhanceChildElement';
 
 type TabListProps = {
   children: React.ReactNode;
@@ -14,7 +14,6 @@ type TabListProps = {
 
 const TabList: React.FC<TabListProps> = ({
   children,
-  name,
   direction = 'row',
   gap = '0.5rem',
 }) => {
@@ -31,7 +30,7 @@ const TabList: React.FC<TabListProps> = ({
       {enhanceChildElement({
         children,
         component: Tab,
-        newProps: { onClick: handleTabChange, name },
+        newProps: { onClick: handleTabChange },
       })}
     </div>
   );

--- a/FE/src/components/foundation/Tabs/TabPanel.tsx
+++ b/FE/src/components/foundation/Tabs/TabPanel.tsx
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+import { TabContext } from '@foundation/Tabs/index';
+
+type TabPanelProps = {
+  children: React.ReactNode;
+  value: string;
+};
+
+const TabPanel: React.FC<TabPanelProps> = ({ children, value }) => {
+  const { selectedValue } = useContext(TabContext);
+  return selectedValue === value ? <div>{children}</div> : null;
+};
+
+export default TabPanel;

--- a/FE/src/components/foundation/Tabs/TabPanel.tsx
+++ b/FE/src/components/foundation/Tabs/TabPanel.tsx
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
 import { TabContext } from '@foundation/Tabs/index';
+import { css } from '@emotion/react';
 
 type TabPanelProps = {
   children: React.ReactNode;
@@ -8,7 +9,15 @@ type TabPanelProps = {
 
 const TabPanel: React.FC<TabPanelProps> = ({ children, value }) => {
   const { selectedValue } = useContext(TabContext);
-  return selectedValue === value ? <div>{children}</div> : null;
+  return (
+    <div
+      css={css`
+        display: ${selectedValue === value ? 'block' : 'none'};
+      `}
+    >
+      {children}
+    </div>
+  );
 };
 
 export default TabPanel;

--- a/FE/src/components/foundation/Tabs/index.tsx
+++ b/FE/src/components/foundation/Tabs/index.tsx
@@ -2,31 +2,32 @@ import React, { createContext, useState } from 'react';
 import TabList from '@foundation/Tabs/TabList';
 import TabPanel from '@foundation/Tabs/TabPanel';
 import Tab from '@foundation/Tabs/Tab';
+import { HTMLElementTypes } from '@/types/utils';
 
 type TabProviderProps = {
   children: React.ReactNode;
   value: string;
-};
+} & HTMLElementTypes<HTMLDivElement>;
 
 const initialContext = {
   selectedValue: '1',
-  handleTabChange: (value?: string) => {},
+  handleTabChange: (value: string) => {},
 };
 
 export const TabContext = createContext(initialContext);
 
-const Tabs = ({ children, value }: TabProviderProps) => {
+const Tabs = ({ children, value, ...args }: TabProviderProps) => {
   const [selectedValue, setSelectedValue] = useState(
     value || initialContext.selectedValue
   );
 
-  const handleTabChange = (newValue?: string) => {
-    setSelectedValue(newValue || initialContext.selectedValue);
+  const handleTabChange = (newValue: string) => {
+    setSelectedValue(newValue);
   };
 
   return (
     <TabContext.Provider value={{ selectedValue, handleTabChange }}>
-      {children}
+      <div {...args}>{children}</div>
     </TabContext.Provider>
   );
 };

--- a/FE/src/components/foundation/Tabs/index.tsx
+++ b/FE/src/components/foundation/Tabs/index.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useState } from 'react';
+import TabList from '@foundation/Tabs/TabList';
+import TabPanel from '@foundation/Tabs/TabPanel';
+import Tab from '@foundation/Tabs/Tab';
+
+type TabProviderProps = {
+  children: React.ReactNode;
+  value: string;
+};
+
+const initialContext = {
+  selectedValue: '1',
+  handleTabChange: (value?: string) => {},
+};
+
+export const TabContext = createContext(initialContext);
+
+const Tabs = ({ children, value }: TabProviderProps) => {
+  const [selectedValue, setSelectedValue] = useState(
+    value || initialContext.selectedValue
+  );
+
+  const handleTabChange = (newValue?: string) => {
+    setSelectedValue(newValue || initialContext.selectedValue);
+  };
+
+  return (
+    <TabContext.Provider value={{ selectedValue, handleTabChange }}>
+      {children}
+    </TabContext.Provider>
+  );
+};
+
+Tabs.TabList = TabList;
+Tabs.Tab = Tab;
+Tabs.TabPanel = TabPanel;
+
+export default Tabs;

--- a/FE/src/components/foundation/Tabs/index.tsx
+++ b/FE/src/components/foundation/Tabs/index.tsx
@@ -6,7 +6,7 @@ import { HTMLElementTypes } from '@/types/utils';
 
 type TabProviderProps = {
   children: React.ReactNode;
-  value: string;
+  initialValue: string;
 } & HTMLElementTypes<HTMLDivElement>;
 
 const initialContext = {
@@ -16,9 +16,9 @@ const initialContext = {
 
 export const TabContext = createContext(initialContext);
 
-const Tabs = ({ children, value, ...args }: TabProviderProps) => {
+const Tabs = ({ children, initialValue, ...args }: TabProviderProps) => {
   const [selectedValue, setSelectedValue] = useState(
-    value || initialContext.selectedValue
+    initialValue || initialContext.selectedValue
   );
 
   const handleTabChange = (newValue: string) => {

--- a/FE/src/components/foundation/Tabs/index.tsx
+++ b/FE/src/components/foundation/Tabs/index.tsx
@@ -10,16 +10,14 @@ type TabProviderProps = {
 } & HTMLElementTypes<HTMLDivElement>;
 
 const initialContext = {
-  selectedValue: '1',
+  selectedValue: '',
   handleTabChange: (value: string) => {},
 };
 
 export const TabContext = createContext(initialContext);
 
 const Tabs = ({ children, initialValue, ...args }: TabProviderProps) => {
-  const [selectedValue, setSelectedValue] = useState(
-    initialValue || initialContext.selectedValue
-  );
+  const [selectedValue, setSelectedValue] = useState(initialValue);
 
   const handleTabChange = (newValue: string) => {
     setSelectedValue(newValue);

--- a/FE/src/components/myPage/MyPagesTabs.tsx
+++ b/FE/src/components/myPage/MyPagesTabs.tsx
@@ -9,7 +9,7 @@ const MyPagesTabs: React.FC = () => {
   const [value, setValue] = useState('1');
   return (
     <Tabs
-      value={value}
+      initialValue={value}
       css={css`
         display: flex;
         flex-direction: column;

--- a/FE/src/components/myPage/MyPagesTabs.tsx
+++ b/FE/src/components/myPage/MyPagesTabs.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import Tabs from '@foundation/Tabs';
+
+const MyPagesTabs: React.FC = () => {
+  const [value, setValue] = useState('1');
+  return (
+    <Tabs value={value}>
+      <Tabs.TabList onChange={(_, v) => setValue(v)}>
+        <Tabs.Tab label="질문 추가하기" value="1" />
+        <Tabs.Tab label="영상 다시보기" value="2" />
+      </Tabs.TabList>
+      <Tabs.TabPanel value="1">질문 추가 모달</Tabs.TabPanel>
+      <Tabs.TabPanel value="2">영상 리스트</Tabs.TabPanel>
+    </Tabs>
+  );
+};
+
+export default MyPagesTabs;

--- a/FE/src/components/myPage/MyPagesTabs.tsx
+++ b/FE/src/components/myPage/MyPagesTabs.tsx
@@ -31,7 +31,9 @@ const MyPagesTabs: React.FC = () => {
           <Tabs.Tab value="1">
             <SelectionBox
               id="add-question"
+              name="my-page"
               lineDirection="bottom"
+              defaultChecked
               css={css`
                 padding: 1rem 0;
               `}
@@ -42,6 +44,7 @@ const MyPagesTabs: React.FC = () => {
           <Tabs.Tab value="2">
             <SelectionBox
               id="replay"
+              name="my-page"
               lineDirection="bottom"
               css={css`
                 padding: 1rem 0;

--- a/FE/src/components/myPage/MyPagesTabs.tsx
+++ b/FE/src/components/myPage/MyPagesTabs.tsx
@@ -1,16 +1,65 @@
 import { useState } from 'react';
 import Tabs from '@foundation/Tabs';
+import SelectionBox from '@foundation/SelectionBox/SelectionBox';
+import { css } from '@emotion/react';
+import Box from '@foundation/Box/Box';
+import Typography from '@foundation/Typography/Typography';
 
 const MyPagesTabs: React.FC = () => {
   const [value, setValue] = useState('1');
   return (
-    <Tabs value={value}>
-      <Tabs.TabList onChange={(_, v) => setValue(v)}>
-        <Tabs.Tab label="질문 추가하기" value="1" />
-        <Tabs.Tab label="영상 다시보기" value="2" />
-      </Tabs.TabList>
-      <Tabs.TabPanel value="1">질문 추가 모달</Tabs.TabPanel>
-      <Tabs.TabPanel value="2">영상 리스트</Tabs.TabPanel>
+    <Tabs
+      value={value}
+      css={css`
+        display: flex;
+        flex-direction: column;
+        row-gap: 1.5rem;
+      `}
+    >
+      <Box
+        css={css`
+          display: flex;
+          align-items: center;
+          padding: 0.5rem 1.5rem;
+        `}
+      >
+        <Tabs.TabList
+          name="my-page"
+          gap="1rem"
+          onChange={(_, v) => setValue(v)}
+        >
+          <Tabs.Tab value="1">
+            <SelectionBox
+              id="add-question"
+              lineDirection="bottom"
+              css={css`
+                padding: 1rem 0;
+              `}
+            >
+              <Typography variant="title4">질문 추가</Typography>
+            </SelectionBox>
+          </Tabs.Tab>
+          <Tabs.Tab value="2">
+            <SelectionBox
+              id="replay"
+              lineDirection="bottom"
+              css={css`
+                padding: 1rem 0;
+              `}
+            >
+              <Typography variant="title4">영상 다시보기</Typography>
+            </SelectionBox>
+          </Tabs.Tab>
+        </Tabs.TabList>
+      </Box>
+      <Box
+        css={css`
+          padding: 3rem;
+        `}
+      >
+        <Tabs.TabPanel value="1">질문 추가 모달</Tabs.TabPanel>
+        <Tabs.TabPanel value="2">영상 리스트</Tabs.TabPanel>
+      </Box>
     </Tabs>
   );
 };

--- a/FE/src/page/myPage/index.tsx
+++ b/FE/src/page/myPage/index.tsx
@@ -1,12 +1,14 @@
 import MyPageLayout from '@/components/myPage/MyPageLayout';
 import MyPageHeader from '@/components/myPage/MyPageHeader';
 import Profile from '@/components/myPage/Profile';
+import MyPagesTabs from '@components/myPage/MyPagesTabs';
 
 const MyPage: React.FC = () => {
   return (
     <MyPageLayout>
       <MyPageHeader />
       <Profile />
+      <MyPagesTabs />
     </MyPageLayout>
   );
 };

--- a/FE/src/page/myPage/index.tsx
+++ b/FE/src/page/myPage/index.tsx
@@ -1,13 +1,12 @@
 import MyPageLayout from '@/components/myPage/MyPageLayout';
-import MyPageHeader from '@/components/myPage/MyPageHeader';
-import Profile from '@/components/myPage/Profile';
 import MyPagesTabs from '@components/myPage/MyPagesTabs';
+import MyPageHeader from '@components/myPage/MyPageHeader';
 
 const MyPage: React.FC = () => {
   return (
     <MyPageLayout>
       <MyPageHeader />
-      <Profile />
+      {/*<Profile />*/}
       <MyPagesTabs />
     </MyPageLayout>
   );

--- a/FE/src/utils/addChildElementProps.ts
+++ b/FE/src/utils/addChildElementProps.ts
@@ -1,0 +1,20 @@
+import React, { Children, cloneElement, isValidElement } from 'react';
+
+type AddChildElementProps<T> = {
+  children: React.ReactNode;
+  newProps: Partial<T>;
+};
+
+const addChildElementProps = <T>({
+  children,
+  newProps,
+}: AddChildElementProps<T>) => {
+  return Children.map(
+    children,
+    (child: React.ReactNode) =>
+      isValidElement(child) &&
+      cloneElement(child, { ...child.props, ...newProps } as Partial<T>)
+  );
+};
+
+export default addChildElementProps;

--- a/FE/src/utils/enhanceChildElement.ts
+++ b/FE/src/utils/enhanceChildElement.ts
@@ -3,7 +3,7 @@ import React, { Children, cloneElement, isValidElement } from 'react';
 type enhanceChildElementProps<T> = {
   children: React.ReactNode;
   component: React.ComponentType<T>;
-  newProps: T;
+  newProps: Partial<T>;
 };
 
 const enhanceChildElement = <T>({


### PR DESCRIPTION
[![NDD-167](https://badgen.net/badge/JIRA/NDD-167/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-167) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

문제 선택 다이얼로그에서도 탭이 사용되고, 마이페이지에서도 탭이 사용되기 때문에 tabs에 대한 foundation 컴포넌트가 필요하다고 생각해서 만들게 되었습니다.

# How
## compound component 패턴을 적용
compound component 패턴을 적용해서 묶음으로 사용되는 컴포넌트간의 공유되는 상태를 contextApi를 사용해서 관리했습니다.

## enhanceChildElementProps 타입 변경
```ts
type enhanceChildElementProps<T> = {
  children: React.ReactNode;
  component: React.ComponentType<T>;
  newProps: Partial<T>;    //T->Parial<T>로 타입을 변경했습니다.
};
```
타입을 변경한 이유는 아래와 같습니다.
### TabList
```tsx
const TabList: React.FC<TabListProps> = ({
  children,
  name,
  direction = 'row',
  gap = '0.5rem',
}) => {
  const { handleTabChange } = useContext(TabContext);

  return (
    <div
      css={css`
        display: flex;
        flex-direction: ${direction};
        gap: ${gap};
      `}
    >
      {enhanceChildElement({
        children,
        component: Tab,
        newProps: { onClick: handleTabChange, name },
      })}
    </div>
  );
};
```
### Tab
```tsx
const Tab: React.FC<TabProps> = ({ children, name, value, onClick }) => {
  return (
    <div onClick={() => onClick && onClick(value)}>
      {addChildElementProps({
        children,
        newProps: { name, value, onChange: onClick && onClick(value) },
      })}
    </div>
  );
};
```
TabList와 Tab이 위와 같은 props를 갖고 있을 때 TabList에서 Tab으로 전달해줘야 하는 속성은 onClick과 name입니다.
Tab에서 value값은 아래 보시는 것 처럼 컴포넌트 선언시에 넘겨줬던 값을 사용해야합니다.
```tsx
<Tabs.TabList
  name="my-page"
  gap="1rem"
  onChange={(_, v) => setValue(v)}
>
  <Tabs.Tab value="1">
    탭1 
  </Tabs.Tab>
  <Tabs.Tab value="2">
    탭2
  </Tabs.Tab>
</Tabs.TabList>
```
그런데 newProps의 타입이 `T`로 지정되어 있는 경우 전체 props에 해당하는 타입이 newProps에 할당되기 때문에
props의 일부분만 넘겨주면 타입 에러가 발생하게 됩니다.
<img width="1047" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/28d7ad8d-98b3-4171-ba86-4b68876be412">
따라서 이 문제를 해결하고자 `Parial<T>`로 타입을 변경해주어 props의 부분집합만 넘겨줘도 에러가 발생하지 않도록 수정했습니다.

## addChildElementProps 유틸 추가
```tsx
<Tabs.Tab value="1">
  <SelectionBox
    id="add-question"
    lineDirection="bottom"
    css={css`
      padding: 1rem 0;
    `}
  >
    <Typography variant="title4">질문 추가</Typography>
  </SelectionBox>
</Tabs.Tab>
```
Tabs.Tab안에서 해민님이 만들어주신 SelectionBox를 children으로 넘겨서 사용할 수 있도록 구현하던 도중 문제가 생겼습니다.
SelectionBox컴포넌트는 props로 emotion의 style을 받을 수 있는데 이로 인해 고차 컴포넌트로 한겹 감싸지게 되고, Tab 컴포넌트에서 enhanceChildElement를 사용해 props를 넘겨줄 수 없는 이슈가 발생했습니다.
따라서 컴포넌트의 타입과 관계 없이 props를 전달해줄 수 있는 `addChildElementProps` 유틸함수를 따로 생성하게 되었습니다.

### 의논해야 할 것
- `addChildElementProps`와 `enhanceChildElement`는 비슷한 동작을 수행하는 함수이므로 한 파일의 유틸 함수로 관리하는건 어떨까요?
- 둘의 네이밍 갭차이가 좀 큰데 좀 더 좋은 네이밍이 없을까요?

# Result


https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/66946bb3-036e-418c-98a0-e02a1a9bd5b1




# Reference

https://www.patterns.dev/react/compound-pattern

[NDD-167]: https://milk717.atlassian.net/browse/NDD-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ