### PR TITLE
[NDD-128]:  GET : /video/${videoId} 구현 (2h / 1h)

### DIFF
--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -68,12 +68,6 @@ export class VideoController {
     );
   }
 
-  @Get(':videoId')
-  @UseGuards(AuthGuard('jwt'))
-  async getVideoDetail(@Param('videoId') videoId: number, @Req() req: Request) {
-    return await this.videoService.getVideoDetail(videoId, req.user as Member);
-  }
-
   @Get('/all')
   @UseGuards(AuthGuard('jwt'))
   @ApiCookieAuth()
@@ -85,5 +79,11 @@ export class VideoController {
   )
   async getAllVideo(@Req() req: Request) {
     return await this.videoService.getAllVideosByMemberId(req.user as Member);
+  }
+
+  @Get(':videoId')
+  @UseGuards(AuthGuard('jwt'))
+  async getVideoDetail(@Param('videoId') videoId: number, @Req() req: Request) {
+    return await this.videoService.getVideoDetail(videoId, req.user as Member);
   }
 }

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -23,6 +23,7 @@ import { createApiResponseOption } from 'src/util/swagger.util';
 import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import { CreatePreSignedUrlRequest } from '../dto/createPreSignedUrlRequest';
 import { VideoListResponse } from '../dto/videoListResponse';
+import { VideoDetailResponse } from '../dto/videoDetailResponse';
 
 @Controller('/api/video')
 @ApiTags('video')
@@ -82,6 +83,18 @@ export class VideoController {
   }
 
   @Get(':videoId')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '비디오 상세 정보를 반환',
+  })
+  @ApiResponse(
+    createApiResponseOption(
+      200,
+      '비디오 상세 정보 조회 완료',
+      VideoDetailResponse,
+    ),
+  )
   @UseGuards(AuthGuard('jwt'))
   async getVideoDetail(@Param('videoId') videoId: number, @Req() req: Request) {
     return await this.videoService.getVideoDetail(videoId, req.user as Member);

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { VideoService } from '../service/video.service';
 import { AuthGuard } from '@nestjs/passport';
 import { Request } from 'express';
@@ -58,6 +66,12 @@ export class VideoController {
       req.user as Member,
       createPreSignedUrlRequest,
     );
+  }
+
+  @Get(':videoId')
+  @UseGuards(AuthGuard('jwt'))
+  async getVideoDetail(@Param('videoId') videoId: number, @Req() req: Request) {
+    return await this.videoService.getVideoDetail(videoId, req.user as Member);
   }
 
   @Get('/all')

--- a/BE/src/video/dto/videoDetailResponse.ts
+++ b/BE/src/video/dto/videoDetailResponse.ts
@@ -1,3 +1,5 @@
+import { Video } from '../entity/video';
+
 export class VideoDetailResponse {
   readonly id: number;
   readonly url: string;
@@ -17,5 +19,15 @@ export class VideoDetailResponse {
     this.videoName = videoName;
     this.hash = hash;
     this.createdAt = createdAt;
+  }
+
+  static from(video: Video, hash: string | null) {
+    return new VideoDetailResponse(
+      video.id,
+      video.url,
+      video.name,
+      hash,
+      video.createdAt.getTime(),
+    );
   }
 }

--- a/BE/src/video/dto/videoDetailResponse.ts
+++ b/BE/src/video/dto/videoDetailResponse.ts
@@ -1,0 +1,21 @@
+export class VideoDetailResponse {
+  readonly id: number;
+  readonly url: string;
+  readonly videoName: string;
+  readonly hash: string;
+  readonly createdAt: number;
+
+  constructor(
+    id: number,
+    url: string,
+    videoName: string,
+    hash: string,
+    createdAt: number,
+  ) {
+    this.id = id;
+    this.url = url;
+    this.videoName = videoName;
+    this.hash = hash;
+    this.createdAt = createdAt;
+  }
+}

--- a/BE/src/video/dto/videoDetailResponse.ts
+++ b/BE/src/video/dto/videoDetailResponse.ts
@@ -1,10 +1,34 @@
 import { Video } from '../entity/video';
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from 'src/util/swagger.util';
 
 export class VideoDetailResponse {
+  @ApiProperty(createPropertyOption(1, '비디오의 ID', Number))
   readonly id: number;
+
+  @ApiProperty(
+    createPropertyOption('https://example-video.com', '비디오의 URL', String),
+  )
   readonly url: string;
+
+  @ApiProperty(
+    createPropertyOption('example-video.webm', '비디오 파일의 이름', String),
+  )
   readonly videoName: string;
+
+  @ApiProperty(
+    createPropertyOption(
+      '65f031b26799cc74755bdd3ef4a304eaec197e402582ef4a834edb58e71261a0',
+      '비디오의 URL 해시값',
+      String,
+    ),
+  )
+  @ApiProperty({ nullable: true })
   readonly hash: string;
+
+  @ApiProperty(
+    createPropertyOption(1699858790176, '비디오 생성 일자(ms 단위)', Number),
+  )
   readonly createdAt: number;
 
   constructor(

--- a/BE/src/video/dto/videoListResponse.ts
+++ b/BE/src/video/dto/videoListResponse.ts
@@ -2,33 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Video } from '../entity/video';
 import { SingleVideoResponse } from './singleVideoResponse';
 import { createPropertyOption } from 'src/util/swagger.util';
+import { videoListExample } from '../fixture/video.fixture';
 
-const videoListExample = [
-  {
-    id: 5,
-    thumbnail: 'https://test-thumbnail1.com',
-    videoName: 'test1.webm',
-    videoLength: '02:42',
-    isPublic: false,
-    createdAt: 1699983079205,
-  },
-  {
-    id: 4,
-    thumbnail: 'https://test-thumbnail2.com',
-    videoName: 'test2.webm',
-    videoLength: '03:29',
-    isPublic: false,
-    createdAt: 1699983079201,
-  },
-  {
-    id: 3,
-    thumbnail: 'https://test-thumbnail3.com',
-    videoName: 'test.mp4',
-    videoLength: '05:22',
-    isPublic: false,
-    createdAt: 1699858790176,
-  },
-];
 export class VideoListResponse {
   @ApiProperty(
     createPropertyOption(videoListExample, '질문 dto의 리스트', [

--- a/BE/src/video/exception/video.exception.ts
+++ b/BE/src/video/exception/video.exception.ts
@@ -5,3 +5,9 @@ export class IDriveException extends HttpException {
     super('IDrive 제공 API 처리 도중 에러가 발생하였습니다.', 500);
   }
 }
+
+export class VideoAccessForbiddenException extends HttpException {
+  constructor() {
+    super('해당 비디오에 접근 권한이 없습니다.', 403);
+  }
+}

--- a/BE/src/video/exception/video.exception.ts
+++ b/BE/src/video/exception/video.exception.ts
@@ -11,3 +11,9 @@ export class VideoAccessForbiddenException extends HttpException {
     super('해당 비디오에 접근 권한이 없습니다.', 403);
   }
 }
+
+export class VideoNotFoundException extends HttpException {
+  constructor() {
+    super('존재하지 않는 비디오입니다.', 404);
+  }
+}

--- a/BE/src/video/exception/video.exception.ts
+++ b/BE/src/video/exception/video.exception.ts
@@ -17,3 +17,15 @@ export class VideoNotFoundException extends HttpException {
     super('존재하지 않는 비디오입니다.', 404);
   }
 }
+
+export class EncryptionException extends HttpException {
+  constructor() {
+    super('암호화 중 에러가 발생했습니다.', 500);
+  }
+}
+
+export class DecryptionException extends HttpException {
+  constructor() {
+    super('복호화 중 에러가 발생했습니다.', 500);
+  }
+}

--- a/BE/src/video/fixture/video.fixture.ts
+++ b/BE/src/video/fixture/video.fixture.ts
@@ -1,0 +1,26 @@
+export const videoListExample = [
+  {
+    id: 5,
+    thumbnail: 'https://test-thumbnail1.com',
+    videoName: 'test1.webm',
+    videoLength: '02:42',
+    isPublic: false,
+    createdAt: 1699983079205,
+  },
+  {
+    id: 4,
+    thumbnail: 'https://test-thumbnail2.com',
+    videoName: 'test2.webm',
+    videoLength: '03:29',
+    isPublic: false,
+    createdAt: 1699983079201,
+  },
+  {
+    id: 3,
+    thumbnail: 'https://test-thumbnail3.com',
+    videoName: 'test.mp4',
+    videoLength: '05:22',
+    isPublic: false,
+    createdAt: 1699858790176,
+  },
+];

--- a/BE/src/video/repository/video.repository.ts
+++ b/BE/src/video/repository/video.repository.ts
@@ -21,4 +21,8 @@ export class VideoRepository {
       .orderBy('video.createdAt', 'DESC')
       .getMany();
   }
+
+  async findById(id: number) {
+    return await this.videoRepository.findOneBy({ id: id });
+  }
 }

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -10,10 +10,14 @@ import { CreatePreSignedUrlRequest } from '../dto/createPreSignedUrlRequest';
 import { v4 as uuidv4 } from 'uuid';
 import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import { QuestionRepository } from 'src/question/repository/question.repository';
-import { IDriveException } from '../exception/video.exception';
+import {
+  IDriveException,
+  VideoAccessForbiddenException,
+} from '../exception/video.exception';
 import { VideoListResponse } from '../dto/videoListResponse';
 import { CreateVideoRequest } from '../dto/createVideoRequest';
 import { validateManipulatedToken } from 'src/util/token.util';
+import { notEquals } from 'class-validator';
 
 @Injectable()
 export class VideoService {
@@ -50,7 +54,12 @@ export class VideoService {
   }
 
   async getVideoDetail(videoId: number, member: Member) {
-    throw new Error('Method not implemented.');
+    validateManipulatedToken(member);
+    const memberId = member.id;
+    const video = await this.videoRepository.findById(videoId);
+
+    if (notEquals(memberId, video.memberId))
+      throw new VideoAccessForbiddenException();
   }
 
   async getAllVideosByMemberId(member: Member) {

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -11,6 +11,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import { QuestionRepository } from 'src/question/repository/question.repository';
 import {
+  DecryptionException,
+  EncryptionException,
   IDriveException,
   VideoAccessForbiddenException,
   VideoNotFoundException,
@@ -90,16 +92,24 @@ export class VideoService {
   }
 
   private getEncryptedurl(url: string) {
-    const cipher = crypto.createCipheriv(algorithm, Buffer.from(key), iv);
-    let encrypted = cipher.update(url, 'utf-8', 'hex');
-    encrypted += cipher.final('hex');
-    return encrypted;
+    try {
+      const cipher = crypto.createCipheriv(algorithm, Buffer.from(key), iv);
+      let encrypted = cipher.update(url, 'utf-8', 'hex');
+      encrypted += cipher.final('hex');
+      return encrypted;
+    } catch (error) {
+      throw new EncryptionException();
+    }
   }
 
   private getDecryptedUrl(encryptedUrl: string) {
-    const decipher = crypto.createDecipheriv(algorithm, Buffer.from(key), iv);
-    let decrypted = decipher.update(encryptedUrl, 'hex', 'utf-8');
-    decrypted += decipher.final('utf-8');
-    return decrypted;
+    try {
+      const decipher = crypto.createDecipheriv(algorithm, Buffer.from(key), iv);
+      let decrypted = decipher.update(encryptedUrl, 'hex', 'utf-8');
+      decrypted += decipher.final('utf-8');
+      return decrypted;
+    } catch (error) {
+      throw new DecryptionException();
+    }
   }
 }

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -18,6 +18,7 @@ import { VideoListResponse } from '../dto/videoListResponse';
 import { CreateVideoRequest } from '../dto/createVideoRequest';
 import { validateManipulatedToken } from 'src/util/token.util';
 import { notEquals } from 'class-validator';
+import { VideoDetailResponse } from '../dto/videoDetailResponse';
 
 @Injectable()
 export class VideoService {
@@ -60,6 +61,9 @@ export class VideoService {
 
     if (notEquals(memberId, video.memberId))
       throw new VideoAccessForbiddenException();
+
+    const hash = video.isPublic ? 'URL 해시값' : null;
+    return VideoDetailResponse.from(video, hash);
   }
 
   async getAllVideosByMemberId(member: Member) {

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -13,11 +13,12 @@ import { QuestionRepository } from 'src/question/repository/question.repository'
 import {
   IDriveException,
   VideoAccessForbiddenException,
+  VideoNotFoundException,
 } from '../exception/video.exception';
 import { VideoListResponse } from '../dto/videoListResponse';
 import { CreateVideoRequest } from '../dto/createVideoRequest';
 import { validateManipulatedToken } from 'src/util/token.util';
-import { notEquals } from 'class-validator';
+import { isEmpty, notEquals } from 'class-validator';
 import { VideoDetailResponse } from '../dto/videoDetailResponse';
 import * as crypto from 'crypto';
 import 'dotenv/config';
@@ -65,6 +66,7 @@ export class VideoService {
     const memberId = member.id;
     const video = await this.videoRepository.findById(videoId);
 
+    if (isEmpty(video)) throw new VideoNotFoundException();
     if (notEquals(memberId, video.memberId))
       throw new VideoAccessForbiddenException();
 

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -49,6 +49,10 @@ export class VideoService {
     }
   }
 
+  async getVideoDetail(videoId: number, member: Member) {
+    throw new Error('Method not implemented.');
+  }
+
   async getAllVideosByMemberId(member: Member) {
     validateManipulatedToken(member);
     const videoList = await this.videoRepository.findAllVideosByMemberId(


### PR DESCRIPTION
[![NDD-128](https://badgen.net/badge/JIRA/NDD-128/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-128) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
회원이 자신의 비디오의 상세 정보를 조회하기 위한 로직으로 이번 프로젝트에서 가장 중요한 API 중 하나이다. 이를 구현함으로써 회원이 자신의 비디오의 url을 알 수 있으며, public으로 공유할 비디오의 url hash 값도 확인할 수 있다.  

양방향 암호화 로직에 대한 학습을 간단하게 진행하였고, 이에 대한 구현이 익숙치 않다보니 예상보다 1시간 가량 지체되었다.

### 왜 AES 알고리즘을 사용하였는가?
우리가 흔히 사용하는 SHA-256와 이번에 사용한 AES 알고리즘의 차이를 확인해야한다.
SHA-256, Blowfish 알고리즘은 단방향 암호화 알고리즘으로 한번 암호화가 되면 이를 다시 복호화하여 원문을 알아낼 수가 없다.
그렇기에 비밀번호 암호화 같은 경우에 주로 사용된다.
하지만 프로젝트에서는 해싱된 값을 사용하여 원문 URL을 알아낼 필요가 있다. 양방향 암호화 알고리즘을 사용하면 URL을 암호화하고, 이를 다시 복호화하여 원문을 알아내는 것이 가능하다. 그래서 기능 구현 시에 양방향 암호화 알고리즘의 표준으로 사용되는 AES 알고리즘을 사용하여 암호화를 진행하였다. 

# How
이번 API 구현은 크게 2가지의 큰 로직으로 나눌 수 있을 것 같다.

### 비즈니스 로직
- AuthGuard를 사용해서 쿠키에 담긴 JWT를 토대로 회원 ID를 얻어낸다.
- PathVariable인 videoId를 사용해서 비디오를 조회한다.
- 비디오의 memberId와 요청자의 id를 비교하여 요청한 클라이언트가 현재 조회 요청한 비디오의 주인인지 확인한다.
- 주인이라면 정상적으로 비디오의 정보를 반환한다. + 비디오가 public이라면 url을 암호화한 정보를 넘겨준다.
```javascript
async getVideoDetail(videoId: number, member: Member) {
  validateManipulatedToken(member);
  const memberId = member.id;
  const video = await this.videoRepository.findById(videoId);

  if (isEmpty(video)) throw new VideoNotFoundException();
  if (notEquals(memberId, video.memberId))
    throw new VideoAccessForbiddenException();

  const hash = video.isPublic ? this.getEncryptedurl(video.url) : null;
  return VideoDetailResponse.from(video, hash);
}
```

### url 암호화 로직
- 암호화 알고리즘(aes-256-cbc)과 시크릿키, 초기화 벡터(Initialization Vector)를 사용하여 Cipher 객체를 생성한다.
- url를 암호화한다. (utf-8은 입력 데이터의 인코딩 방식, 'hex'는 출력 데이터의 인코딩 방식)
- cipher.final 메서드를 사용해 마지막 블록을 암호화하고, 패딩을 추가
```javascript
private getEncryptedurl(url: string) {
  const cipher = crypto.createCipheriv(algorithm, Buffer.from(key), iv);
  let encrypted = cipher.update(url, 'utf-8', 'hex');
  encrypted += cipher.final('hex');
  return encrypted;
}
```

# Result
### public인 비디오 조회 시
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/10b7507f-802b-438d-bf87-45b95559928e)
public인 비디오이기에 hash값을 제공하고 이를 사용해서 다른 회원이 비디오를 볼 수 있게 한다.

### private인 비디오 조회 시
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/8cd864e3-22e7-4e1c-9f04-eacffa54d9f4)
private인 비디오이기에 hash값은 null이다.

### 다른 회원의 비디오 조회 시
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/ed6b8126-6bd1-4726-ae4a-954233885b94)
다른 회원의 비디오를 조회할 수 있는 권한이 없으므로, 403(Forbidden) 에러를 반환한다.

### 존재하지 않는 비디오에 대한 조회 시
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/984a6e4b-097a-4918-add0-5e4f0f14aa8b)
존재하지 않는 비디오에 대한 조회 요청 시에는, 404(Not Found) 에러를 반환한다.

# Prize
평소에는 단방향 알고리즘을 자주 사용하였고, 양방향 암호화 알고리즘을 사용할 기회가 없었는데 이번 API 구현을 통해 양방향 암호화 알고리즘도 사용해 볼 수 있었다. 

클라이언트 측면에서도 안정성이 뛰어난 AES 알고리즘을 사용하기에, 자신의 비디오의 URL이 안전하게 해싱되어 public으로 공유되고 있음을 보장받을 수 있다.

# Reference
https://ts2ree.tistory.com/333
https://goatee.tistory.com/8

[NDD-128]: https://milk717.atlassian.net/browse/NDD-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ