### PR TITLE
[NDD-172]: 카테고리 삭제 기능 구현 (2h / 1h) 

### DIFF
--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Post,
   Query,
@@ -70,8 +71,18 @@ export class CategoryController {
     return CategoryListResponse.of(categories);
   }
 
-  deleteCategoryById(
+  @Delete()
+  @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '카테고리를 삭제한다.',
+  })
+  @ApiResponse(createApiResponseOption(204, '카테고리 삭제', null))
+  async deleteCategoryById(
     @Req() req: Request,
     @Query('categoryId') categoryId: number,
-  ) {}
+  ) {
+    const member = req.user as Member;
+    await this.categoryService.deleteCategoryById(member, categoryId);
+  }
 }

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBody,
   ApiCookieAuth,
@@ -61,4 +69,9 @@ export class CategoryController {
 
     return CategoryListResponse.of(categories);
   }
+
+  deleteCategoryById(
+    @Req() req: Request,
+    @Query('categoryId') categoryId: number,
+  ) {}
 }

--- a/BE/src/category/entity/category.ts
+++ b/BE/src/category/entity/category.ts
@@ -16,7 +16,7 @@ export class Category extends DefaultEntity {
   @Column()
   name: string;
 
-  @ManyToOne(() => Member, { nullable: true, onDelete: 'CASCADE' })
+  @ManyToOne(() => Member, { nullable: true, onDelete: 'CASCADE', eager: true })
   @JoinColumn({ name: 'memberId' })
   member: Member;
 

--- a/BE/src/category/entity/category.ts
+++ b/BE/src/category/entity/category.ts
@@ -34,6 +34,10 @@ export class Category extends DefaultEntity {
     return new Category(null, inputObj.name, member, new Date());
   }
 
+  isOwnedBy(member: Member) {
+    return this.member.equals(member);
+  }
+
   getName() {
     return this.name;
   }

--- a/BE/src/category/entity/category.ts
+++ b/BE/src/category/entity/category.ts
@@ -1,14 +1,6 @@
-import {
-  Column,
-  Entity,
-  JoinColumn,
-  JoinTable,
-  ManyToMany,
-  ManyToOne,
-} from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { DefaultEntity } from '../../app.entity';
 import { Member } from '../../member/entity/member';
-import { Question } from '../../question/entity/question';
 import { CreateCategoryRequest } from '../dto/createCategoryRequest';
 
 @Entity({ name: 'Category' })
@@ -19,10 +11,6 @@ export class Category extends DefaultEntity {
   @ManyToOne(() => Member, { nullable: true, onDelete: 'CASCADE', eager: true })
   @JoinColumn({ name: 'memberId' })
   member: Member;
-
-  @ManyToMany(() => Question)
-  @JoinTable({ name: 'CategoryQuestion' })
-  questions: Question[];
 
   constructor(id: number, name: string, member: Member, createdAt: Date) {
     super(id, createdAt);

--- a/BE/src/category/exception/category.exception.ts
+++ b/BE/src/category/exception/category.exception.ts
@@ -6,4 +6,10 @@ class CategoryNameEmptyException extends HttpException {
   }
 }
 
-export { CategoryNameEmptyException };
+class CategoryNotFoundException extends HttpException {
+  constructor() {
+    super('카테고리자 존재하지 않습니다.', 404);
+  }
+}
+
+export { CategoryNameEmptyException, CategoryNotFoundException };

--- a/BE/src/category/repository/category.repository.ts
+++ b/BE/src/category/repository/category.repository.ts
@@ -34,6 +34,10 @@ export class CategoryRepository {
     await this.repository.remove(category);
   }
 
+  async findByCategoryId(categoryId) {
+    return await this.repository.findOneBy({ id: categoryId });
+  }
+
   async query(query: string) {
     return await this.repository.query(query);
   }

--- a/BE/src/category/service/category.service.spec.ts
+++ b/BE/src/category/service/category.service.spec.ts
@@ -149,10 +149,13 @@ describe('CategoryService', () => {
     //given
 
     //when
+    mockCategoryRepository.findByCategoryId.mockResolvedValue(
+      Category.from(beCategoryFixture, memberFixture),
+    );
 
     //then
     await expect(
-      service.deleteCategoryById(memberFixture, beCategoryFixture.id),
+      service.deleteCategoryById(undefined, beCategoryFixture.id),
     ).rejects.toThrow(new ManipulatedTokenNotFiltered());
   });
 
@@ -173,7 +176,10 @@ describe('CategoryService', () => {
 
     //when
     mockCategoryRepository.findByCategoryId.mockResolvedValue(
-      beCategoryFixture,
+      Category.from(
+        beCategoryFixture,
+        new Member(20, 'ja@ja.com', 'ja', 'https://www.google.com', new Date()),
+      ),
     );
 
     //then

--- a/BE/src/category/service/category.service.spec.ts
+++ b/BE/src/category/service/category.service.spec.ts
@@ -277,6 +277,23 @@ describe('CategoryService 통합테스트', () => {
     ]);
   });
 
+  it('회원 카테고리를 삭제한다.', async () => {
+    //given
+    await memberRepository.save(memberFixture);
+
+    //when
+    await saveMembersCategory(memberFixture);
+    await saveDefaultCategory();
+    const categoryId = (
+      await categoryService.findUsingCategories(memberFixture)
+    ).pop().id;
+
+    //then
+    await expect(
+      categoryService.deleteCategoryById(memberFixture, categoryId),
+    ).resolves.toBeUndefined();
+  });
+
   afterEach(async () => {
     await categoryRepository.query('delete from Category');
     await categoryRepository.query('delete from Member');

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -47,8 +47,6 @@ export class CategoryService {
     }
 
     if (!category.isOwnedBy(member)) {
-      console.log(member);
-      console.log(category.member);
       throw new UnauthorizedException();
     }
 

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -47,6 +47,8 @@ export class CategoryService {
     }
 
     if (!category.isOwnedBy(member)) {
+      console.log(member);
+      console.log(category.member);
       throw new UnauthorizedException();
     }
 

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -42,7 +42,6 @@ export class CategoryService {
     validateManipulatedToken(member);
 
     const category = await this.categoryRepository.findByCategoryId(categoryId);
-
     if (isEmpty(category)) {
       throw new CategoryNotFoundException();
     }

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -34,4 +34,6 @@ export class CategoryService {
 
     return categories.map(CategoryResponse.from);
   }
+
+  async deleteCategoryById(member: Member, categoryId: number) {}
 }

--- a/BE/src/member/entity/member.ts
+++ b/BE/src/member/entity/member.ts
@@ -1,5 +1,6 @@
 import { DefaultEntity } from 'src/app.entity';
 import { Column, Entity } from 'typeorm';
+import { objectEquals } from '../../util/util';
 
 @Entity({ name: 'Member' })
 export class Member extends DefaultEntity {
@@ -28,12 +29,6 @@ export class Member extends DefaultEntity {
   }
 
   equals(member: Member) {
-    for (const key of Object.keys(this)) {
-      if (member[key] !== this[key]) {
-        return false;
-      }
-    }
-
-    return true;
+    return objectEquals(this, member);
   }
 }

--- a/BE/src/member/entity/member.ts
+++ b/BE/src/member/entity/member.ts
@@ -26,4 +26,14 @@ export class Member extends DefaultEntity {
     this.nickname = nickname;
     this.profileImg = profileImg;
   }
+
+  equals(member: Member) {
+    for (const key of Object.keys(this)) {
+      if (member[key] !== this[key]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 }

--- a/BE/src/token/strategy/access.token.strategy.ts
+++ b/BE/src/token/strategy/access.token.strategy.ts
@@ -8,10 +8,7 @@ import { InvalidTokenException } from '../exception/token.exception';
 import { Request } from 'express';
 
 @Injectable()
-export class AccessTokenStrategy extends PassportStrategy(
-  Strategy,
-  'jwt-soft',
-) {
+export class AccessTokenStrategy extends PassportStrategy(Strategy, 'jwt') {
   constructor(private memberRepository: MemberRepository) {
     super({
       jwtFromRequest: (req: Request) => {

--- a/BE/src/util/util.ts
+++ b/BE/src/util/util.ts
@@ -1,0 +1,2 @@
+export const objectEquals = (obj1: object, obj2: object) =>
+  Object.entries(obj1).toString() === Object.entries(obj2).toString();


### PR DESCRIPTION
[![NDD-162](https://badgen.net/badge/JIRA/NDD-162/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-162) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

기획상의 추가사항 : 회원이 보고 싶지 않은 카테고리를 삭제해야 한다.
이를 적용하기 위해 카테고리를 삭제하는 기능을 만들었다. 

# How

카테고리 삭제시에, 카테고리 내의 질문들 또한 같이 삭제하게 추후에 구현해야 한다. (Question 구현시에 추가 예정)
삭제 시에 권한 확인을 해야한다.

# Result

```
// 비즈니스 로직
async deleteCategoryById(member: Member, categoryId: number) {
    validateManipulatedToken(member); // 토큰 조작 확인

    const category = await this.categoryRepository.findByCategoryId(categoryId);
     // id를 통해 Category를 가져올 때, Member는 eager로 설정되어있다. 
    if (isEmpty(category)) {
      throw new CategoryNotFoundException(); // 해당 id의 카테고리가 없을 시에 에러
    }

    if (!category.isOwnedBy(member)) {
      throw new UnauthorizedException(); // 카테고리에 N:1로 매핑되어있는 회원 검증
    }

    await this.categoryRepository.remove(category);
  }
```

[NDD-162]: https://milk717.atlassian.net/browse/NDD-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ