### PR TITLE
[NDD-172]: 로그인 완료 시 마이페이지로 리다이렉트 되도록 구현  (1h / 1h) 

### DIFF
--- a/BE/src/auth/controller/auth.controller.ts
+++ b/BE/src/auth/controller/auth.controller.ts
@@ -57,7 +57,7 @@ export class AuthController {
         await this.authService.login(userRequest),
         COOKIE_OPTIONS,
       )
-      .send();
+      .redirect('https://www.gomterview.com/mypage');
   }
 
   @Delete('logout')
@@ -102,4 +102,5 @@ export class AuthController {
 const COOKIE_OPTIONS: CookieOptions = {
   httpOnly: true,
   path: '/',
+  sameSite: 'lax',
 };

--- a/BE/src/video/dto/createVideoRequest.ts
+++ b/BE/src/video/dto/createVideoRequest.ts
@@ -11,7 +11,7 @@ export class CreateVideoRequest {
   @ApiProperty(createPropertyOption('example.mp4', '비디오 파일 이름', String))
   @IsString()
   @IsNotEmpty()
-  name: string;
+  videoName: string;
 
   @ApiProperty(
     createPropertyOption('https://example.com', '비디오 URL', String),

--- a/BE/src/video/entity/video.ts
+++ b/BE/src/video/entity/video.ts
@@ -49,7 +49,7 @@ export class Video extends DefaultEntity {
     return new Video(
       member.id,
       createVidoeRequest.questionId,
-      createVidoeRequest.name,
+      createVidoeRequest.videoName,
       createVidoeRequest.url,
       false,
     );


### PR DESCRIPTION
[![NDD-172](https://badgen.net/badge/JIRA/NDD-172/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-172) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
FE에서 로그인 완료 시 마이페이지로 리다이렉트가 되도록 요청을 하셔서 이를 반영

# How
단순하게 로그인 완료 시 send로 클라이언트로 반환하던 로직을 redirect로 반환하도록 하여 마이페이지로 바로 리다이렉트 되도록 구현하였다.
```
  async googleAuthCallback(
    @Req() req: Request,
    @Res() res: Response,
  ): Promise<void> {
    const { user } = req;
    const userRequest = user as OAuthRequest;
    res
      .status(201)
      .cookie(
        'accessToken',
        await this.authService.login(userRequest),
        COOKIE_OPTIONS,
      )
      .redirect('https://www.gomterview.com/mypage');
  }
```

# Result
로그인 완료 시 마이페이지로 자동 리다이렉트

# Prize
바로 필요한 페이지로 리다이렉트 되기에 UX 향상 기대
FE에서 로그인 구현 편의성 증대

[NDD-172]: https://milk717.atlassian.net/browse/NDD-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ