### PR TITLE
[NDD-152]:  GET: /video/hash/${hash} 구현 (1h / 1h)

### DIFF
--- a/BE/src/token/strategy/access.token.strategy.ts
+++ b/BE/src/token/strategy/access.token.strategy.ts
@@ -8,10 +8,7 @@ import { InvalidTokenException } from '../exception/token.exception';
 import { Request } from 'express';
 
 @Injectable()
-export class AccessTokenStrategy extends PassportStrategy(
-  Strategy,
-  'jwt-soft',
-) {
+export class AccessTokenStrategy extends PassportStrategy(Strategy, 'jwt') {
   constructor(private memberRepository: MemberRepository) {
     super({
       jwtFromRequest: (req: Request) => {

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -83,6 +83,16 @@ export class VideoController {
   }
 
   @Get('/hash/:hash')
+  @ApiOperation({
+    summary: '해시값으로 비디오 정보 불러오기',
+  })
+  @ApiResponse(
+    createApiResponseOption(
+      200,
+      '해시값을 사용하여 비디오 정보 조회 완료',
+      VideoDetailResponse,
+    ),
+  )
   async getVideoDetailByHash(@Param('hash') hash: string) {
     return await this.videoService.getVideoDetailByHash(hash);
   }

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -82,6 +82,11 @@ export class VideoController {
     return await this.videoService.getAllVideosByMemberId(req.user as Member);
   }
 
+  @Get('/hash/:hash')
+  async getVideoDetailByHash(@Param('hash') hash: string) {
+    return await this.videoService.getVideoDetailByHash(hash);
+  }
+
   @Get(':videoId')
   @UseGuards(AuthGuard('jwt'))
   @ApiCookieAuth()

--- a/BE/src/video/repository/video.repository.ts
+++ b/BE/src/video/repository/video.repository.ts
@@ -25,4 +25,8 @@ export class VideoRepository {
   async findById(id: number) {
     return await this.videoRepository.findOneBy({ id: id });
   }
+
+  async findByUrl(url: string) {
+    return await this.videoRepository.findOneBy({ url: url });
+  }
 }

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -76,8 +76,12 @@ export class VideoService {
     return VideoDetailResponse.from(video, hash);
   }
 
-  getVideoDetailByHash(hash: string) {
-    throw new Error('Method not implemented.');
+  async getVideoDetailByHash(hash: string) {
+    const decryptedUrl = this.getDecryptedUrl(hash);
+    const video = await this.videoRepository.findByUrl(decryptedUrl);
+
+    if (!video.isPublic) throw new VideoAccessForbiddenException();
+    return VideoDetailResponse.from(video, hash);
   }
 
   async getAllVideosByMemberId(member: Member) {

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -76,6 +76,10 @@ export class VideoService {
     return VideoDetailResponse.from(video, hash);
   }
 
+  getVideoDetailByHash(hash: string) {
+    throw new Error('Method not implemented.');
+  }
+
   async getAllVideosByMemberId(member: Member) {
     validateManipulatedToken(member);
     const videoList = await this.videoRepository.findAllVideosByMemberId(


### PR DESCRIPTION
[![NDD-152](https://badgen.net/badge/JIRA/NDD-152/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-152) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
비디오를 public으로 전환 시에 만들어지는 실제 url을 암호화하여 만든 해시값을 가지고 비디오를 조회할 수 있는 로직이 필요했다.
또한 hash값을 미리 알고 있는 상태에서 비디오의 주인이 다시 private로 전환하였을 시에 그 비디오를 확인할 수 있도록 구현하면 안 되기에, 얻어낸 video가 public인지 매번 확인하는 로직도 추가해야했다.

# How
- 요청으로 들어온 hash값을 복호화하여 실제 url을 알아냄
- url을 사용하여 video 정보를 얻어냄
- 얻어낸 video가 public인지 확인
- video가 public이면 비디오 정보를 그대로 반환, private면 403 에러 반환
```javascript
async getVideoDetailByHash(hash: string) {
    const decryptedUrl = this.getDecryptedUrl(hash);
    const video = await this.videoRepository.findByUrl(decryptedUrl);

    if (!video.isPublic) throw new VideoAccessForbiddenException();
    return VideoDetailResponse.from(video, hash);
  }
```

# Result
아래처럼 정상적인 해시에 대한 요청이고, 그 비디오가 public이라면 비디오의 정보를 반환하여준다. 
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/12f36b8d-6f03-4f62-bb66-3f13475f3e28)

아래처럼 해시값에 이상이 있는 경우에는 복호화 중 오류 메시지를 반환한다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/725da0c0-154a-45c5-a7a5-c22eea262250)

# Prize
회원이 public으로 선택한 비디오를 다른 회원 또는 비회원도 확인할 수 있는 로직을 구현함으로써 프로젝트의 주요 서비스를 사용할 수 있게 된다.

[NDD-152]: https://milk717.atlassian.net/browse/NDD-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ