### PR TITLE
[NDD-178]: 회원 이름 반환 시 DTO로 반환하도록 변경 (0.3h / 1h)

### DIFF
--- a/BE/src/member/controller/member.controller.ts
+++ b/BE/src/member/controller/member.controller.ts
@@ -12,6 +12,7 @@ import { Member } from '../entity/member';
 import { createApiResponseOption } from 'src/util/swagger.util';
 import { MemberService } from '../service/member.service';
 import { validateManipulatedToken } from 'src/util/token.util';
+import { MemberNicknameResponse } from '../dto/memberNicknameResponse';
 
 @Controller('/api/member')
 @ApiTags('member')
@@ -45,7 +46,7 @@ export class MemberController {
     createApiResponseOption(
       200,
       `면접 화면에 표출할 이름(회원의 경우 저장된 이름을, 비회원의 경우 '면접자')을 반환한다.`,
-      String,
+      MemberNicknameResponse,
     ),
   )
   async getNameForInterview(@Req() req: Request) {

--- a/BE/src/member/dto/memberNicknameResponse.ts
+++ b/BE/src/member/dto/memberNicknameResponse.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { createPropertyOption } from 'src/util/swagger.util';
 
-export class NicknameResponse {
+export class MemberNicknameResponse {
   @ApiProperty(createPropertyOption('foobar', '회원의 닉네임', String))
   private nickname: string;
 

--- a/BE/src/member/dto/nicknameResponse.ts
+++ b/BE/src/member/dto/nicknameResponse.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from 'src/util/swagger.util';
+
+export class NicknameResponse {
+  @ApiProperty(createPropertyOption('foobar', '회원의 닉네임', String))
+  private nickname: string;
+
+  constructor(nickname: string) {
+    this.nickname = nickname;
+  }
+}

--- a/BE/src/member/service/member.service.ts
+++ b/BE/src/member/service/member.service.ts
@@ -3,6 +3,7 @@ import { Request } from 'express';
 import { TokenService } from 'src/token/service/token.service';
 import { MemberRepository } from '../repository/member.repository';
 import { getTokenValue } from 'src/util/token.util';
+import { MemberNicknameResponse } from '../dto/memberNicknameResponse';
 
 @Injectable()
 export class MemberService {
@@ -14,7 +15,9 @@ export class MemberService {
     if (!req.cookies['accessToken']) return '면접자';
 
     // TODO: 추후에 랜덤 Prefix 생성할 필요가 있음
-    return (await this.getMemberByToken(getTokenValue(req))).nickname;
+    return new MemberNicknameResponse(
+      (await this.getMemberByToken(getTokenValue(req))).nickname,
+    );
   }
 
   async getMemberByToken(tokenValue: string) {


### PR DESCRIPTION
[![NDD-178](https://badgen.net/badge/JIRA/NDD-178/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-178) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
Response의 형태가 반드시 JSON의 형태여야 FE에서의 추가적인 설정이 필요없다는 얘기가 나와서 이를 반영하기 위해 로직 변경

# How
원래 string으로 바로 반환했던 로직을 FE의 요청에 맞추어, MemberNicknameResponse라는 객체를 반환하도록 변경하여 최종적으로 JSON 형태의 응답을 FE가 받을 수 있도록 하였다.
```javascript
// memerNicknameResponse.ts
export class MemberNicknameResponse {
  @ApiProperty(createPropertyOption('foobar', '회원의 닉네임', String))
  private nickname: string;

  constructor(nickname: string) {
    this.nickname = nickname;
  }
}

// member.service.ts
return new MemberNicknameResponse(
      (await this.getMemberByToken(getTokenValue(req))).nickname,
    );
```

# Result
아래 사진처럼 응답이 JSON 형태로 넘어옴을 확인할 수 있다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/5486fea2-e40c-438e-a881-f9ee12c4b74e)

# Prize
모든 응답을 JSON으로 통일함으로써 FE에서의 추가적인 작업을 방지

[NDD-178]: https://milk717.atlassian.net/browse/NDD-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ