### PR TITLE
[NDD-153]: PATCH : /api/video/{videoId} 구현 (1h / 1h)

### DIFF
--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -25,6 +25,7 @@ import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import { CreatePreSignedUrlRequest } from '../dto/createPreSignedUrlRequest';
 import { VideoListResponse } from '../dto/videoListResponse';
 import { VideoDetailResponse } from '../dto/videoDetailResponse';
+import { VideoHashResponse } from '../dto/videoHashResponse';
 
 @Controller('/api/video')
 @ApiTags('video')
@@ -117,6 +118,13 @@ export class VideoController {
 
   @Patch(':videoId')
   @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '비디오 공개/비공개 상태를 전환',
+  })
+  @ApiResponse(
+    createApiResponseOption(200, '비디오 상태 전환 완료', VideoHashResponse),
+  )
   async toggleVideoStatus(
     @Param('videoId') videoId: number,
     @Req() req: Request,

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Param,
+  Patch,
   Post,
   Req,
   UseGuards,
@@ -110,8 +111,19 @@ export class VideoController {
       VideoDetailResponse,
     ),
   )
-  @UseGuards(AuthGuard('jwt'))
   async getVideoDetail(@Param('videoId') videoId: number, @Req() req: Request) {
     return await this.videoService.getVideoDetail(videoId, req.user as Member);
+  }
+
+  @Patch(':videoId')
+  @UseGuards(AuthGuard('jwt'))
+  async toggleVideoStatus(
+    @Param('videoId') videoId: number,
+    @Req() req: Request,
+  ) {
+    return await this.videoService.toggleVideoStatus(
+      videoId,
+      req.user as Member,
+    );
   }
 }

--- a/BE/src/video/dto/videoHashResponse.ts
+++ b/BE/src/video/dto/videoHashResponse.ts
@@ -1,4 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from 'src/util/swagger.util';
+
 export class VideoHashResponse {
+  @ApiProperty(
+    createPropertyOption(
+      '65f031b26799cc74755bdd3ef4a304eaec197e402582ef4a834edb58e71261a0',
+      '비디오의 URL 해시값',
+      String,
+    ),
+  )
+  @ApiProperty({ nullable: true })
   private hash: string;
   constructor(hash: string) {
     this.hash = hash;

--- a/BE/src/video/dto/videoHashResponse.ts
+++ b/BE/src/video/dto/videoHashResponse.ts
@@ -1,4 +1,4 @@
-export class VideoDetailResponse {
+export class VideoHashResponse {
   private hash: string;
   constructor(hash: string) {
     this.hash = hash;

--- a/BE/src/video/dto/videoHashResponse.ts
+++ b/BE/src/video/dto/videoHashResponse.ts
@@ -1,0 +1,6 @@
+export class VideoDetailResponse {
+  private hash: string;
+  constructor(hash: string) {
+    this.hash = hash;
+  }
+}

--- a/BE/src/video/repository/video.repository.ts
+++ b/BE/src/video/repository/video.repository.ts
@@ -29,4 +29,13 @@ export class VideoRepository {
   async findByUrl(url: string) {
     return await this.videoRepository.findOneBy({ url: url });
   }
+
+  async toggleVideoStatus(videoId: number) {
+    this.videoRepository
+      .createQueryBuilder()
+      .update(Video)
+      .set({ isPublic: () => 'NOT isPublic' })
+      .where('id = :id', { id: videoId })
+      .execute();
+  }
 }

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -68,10 +68,7 @@ export class VideoService {
     validateManipulatedToken(member);
     const memberId = member.id;
     const video = await this.videoRepository.findById(videoId);
-
-    if (isEmpty(video)) throw new VideoNotFoundException();
-    if (notEquals(memberId, video.memberId))
-      throw new VideoAccessForbiddenException();
+    this.validateVideoOwnership(video, memberId);
 
     const hash = video.isPublic ? this.getEncryptedurl(video.url) : null;
     return VideoDetailResponse.from(video, hash);
@@ -99,15 +96,18 @@ export class VideoService {
     validateManipulatedToken(member);
     const memberId = member.id;
     const video = await this.videoRepository.findById(videoId);
-
-    if (isEmpty(video)) throw new VideoNotFoundException();
-    if (notEquals(memberId, video.memberId))
-      throw new VideoAccessForbiddenException();
+    this.validateVideoOwnership(video, memberId);
 
     await this.videoRepository.toggleVideoStatus(videoId); // TODO: 좀 더 효율적인 Patch 로직이 있나 확인
 
     const hash = video.isPublic ? null : this.getEncryptedurl(video.url); // 현재가 public이었으면 토글 후 private이 되기에 null로 지정
     return new VideoHashResponse(hash);
+  }
+
+  private validateVideoOwnership(video: Video, memberId: number) {
+    if (isEmpty(video)) throw new VideoNotFoundException();
+    if (notEquals(memberId, video.memberId))
+      throw new VideoAccessForbiddenException();
   }
 
   private async getQuestionContent(questionId: number) {

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -94,6 +94,10 @@ export class VideoService {
     return VideoListResponse.from(videoList);
   }
 
+  async toggleVideoStatus(videoId: number, arg1: Member) {
+    throw new Error('Method not implemented.');
+  }
+
   private async getQuestionContent(questionId: number) {
     const question = await this.questionRepository.findById(questionId);
     return question ? question.content : '삭제된 질문';


### PR DESCRIPTION
[![NDD-153](https://badgen.net/badge/JIRA/NDD-153/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-153) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
사용자가 임의대로 원할 때마다 비디오의 상태를 공개/비공개로 전환하는 기능을 제공하기 위해 필요한 API이다.

save를 사용해서 Patch 작업을 할 수 있지만, save 메서드의 실제 동작 쿼리는 SELECT와 UPDATE 두 개의 SQL이 실행 되는 것이다. 비디오의 공개 여부만 변경하면 되는데 불필요한 SELECT 구문이 실행되기에 save가 아닌 QueryBuilder를 사용하도록 하여 효율적인 동작이 가능하도록 하였다.

또한 비디오의 주인이 아닌 사람이 비디오 상태 변경 API의 엔드포인트를 알아내 비디오의 공개/비공개 여부를 변경하면 안 되기에 소유권을 검증하는 로직을 추가할 필요가 있었다.


# How
- 쿠키로부터 API를 요청한 멤버의 ID와 videoId를 토대로 알아낸 비디오의 실제 주인의 ID가 일치하는지 확인
- 일치한다면 비디오의 공개 상태를 토글
- 비디오의 공개/비공개 여부에 따라 비디오 url의 해시값/null을 반환
```javascript
// 서비스 로직
async toggleVideoStatus(videoId: number, member: Member) {
    validateManipulatedToken(member);
    const memberId = member.id;
    const video = await this.videoRepository.findById(videoId);
    this.validateVideoOwnership(video, memberId);

    await this.videoRepository.toggleVideoStatus(videoId); // TODO: 좀 더 효율적인 Patch 로직이 있나 확인

    const hash = video.isPublic ? null : this.getEncryptedurl(video.url); // 현재가 public이었으면 토글 후 private이 되기에 null로 지정
    return new VideoHashResponse(hash);
  }

  private validateVideoOwnership(video: Video, memberId: number) {
    if (isEmpty(video)) throw new VideoNotFoundException();
    if (notEquals(memberId, video.memberId))
      throw new VideoAccessForbiddenException();
  }

// 레포지토리 로직
async toggleVideoStatus(videoId: number) {
    this.videoRepository
      .createQueryBuilder()
      .update(Video)
      .set({ isPublic: () => 'NOT isPublic' })
      .where('id = :id', { id: videoId })
      .execute();
}
```
# Result
### 비디오 공개 상태로 변경
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/d8801c50-b5e7-424b-b381-3da2b0d5d017)

### 비디오 비공개 상태로 변경
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/0ecc4f09-68e4-468d-bf3e-2038ef206c87)

### 다른 사용자의 비디오 공개 상태를 토글하려고 시도하는 경우
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/b135cced-c53b-4891-8f53-7a3ecfd1563e)

# Prize
단순하게 save 로직을 사용했으면, 더 빠른 구현이 가능했음에도 불구하고 더 효율적인 PATCH 로직을 찾기 위해 이에 대해 찾아보고 또 QueryBudiler를 사용하여 UPDATE 쿼리만 실행될 수 있게 하였다.
이로 인해 비디오 토글 API가 효율적으로 작동될 수 있게 구현하였다.

# Reference
https://velog.io/@siontama/typeORM-%ED%8A%B9%EC%A0%95-%EA%B0%92-update-%ED%95%98%EA%B8%B0

[NDD-153]: https://milk717.atlassian.net/browse/NDD-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ