### PR TITLE
[NDD-129]: DELETE :  /video/${videoId} 구현 (1h / 1h) 

### DIFF
--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -1,16 +1,18 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Patch,
   Post,
   Req,
+  Res,
   UseGuards,
 } from '@nestjs/common';
 import { VideoService } from '../service/video.service';
 import { AuthGuard } from '@nestjs/passport';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import { Member } from 'src/member/entity/member';
 import { CreateVideoRequest } from '../dto/createVideoRequest';
 import {
@@ -133,5 +135,16 @@ export class VideoController {
       videoId,
       req.user as Member,
     );
+  }
+
+  @Delete(':videoId')
+  @UseGuards(AuthGuard('jwt'))
+  async deleteVideo(
+    @Param('videoId') videoId: number,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    await this.videoService.deleteVideo(videoId, req.user as Member);
+    res.status(204).send();
   }
 }

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -139,6 +139,11 @@ export class VideoController {
 
   @Delete(':videoId')
   @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '비디오 삭제',
+  })
+  @ApiResponse(createApiResponseOption(204, '비디오 삭제 완료', null))
   async deleteVideo(
     @Param('videoId') videoId: number,
     @Req() req: Request,

--- a/BE/src/video/repository/video.repository.ts
+++ b/BE/src/video/repository/video.repository.ts
@@ -38,4 +38,8 @@ export class VideoRepository {
       .where('id = :id', { id: videoId })
       .execute();
   }
+
+  async remove(video: Video) {
+    await this.videoRepository.remove(video);
+  }
 }

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -104,6 +104,10 @@ export class VideoService {
     return new VideoHashResponse(hash);
   }
 
+  async deleteVideo(videoId: number, member: Member) {
+    throw new Error('Method not implemented.');
+  }
+
   private validateVideoOwnership(video: Video, memberId: number) {
     if (isEmpty(video)) throw new VideoNotFoundException();
     if (notEquals(memberId, video.memberId))

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -119,12 +119,6 @@ export class VideoService {
       throw new VideoAccessForbiddenException();
   }
 
-  private validateVideoOwnership(video: Video, memberId: number) {
-    if (isEmpty(video)) throw new VideoNotFoundException();
-    if (notEquals(memberId, video.memberId))
-      throw new VideoAccessForbiddenException();
-  }
-
   private async getQuestionContent(questionId: number) {
     const question = await this.questionRepository.findById(questionId);
     return question ? question.content : '삭제된 질문';

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -105,7 +105,18 @@ export class VideoService {
   }
 
   async deleteVideo(videoId: number, member: Member) {
-    throw new Error('Method not implemented.');
+    validateManipulatedToken(member);
+    const memberId = member.id;
+    const video = await this.videoRepository.findById(videoId);
+    this.validateVideoOwnership(video, memberId);
+
+    await this.videoRepository.remove(video);
+  }
+
+  private validateVideoOwnership(video: Video, memberId: number) {
+    if (isEmpty(video)) throw new VideoNotFoundException();
+    if (notEquals(memberId, video.memberId))
+      throw new VideoAccessForbiddenException();
   }
 
   private validateVideoOwnership(video: Video, memberId: number) {


### PR DESCRIPTION
[![NDD-129](https://badgen.net/badge/JIRA/NDD-129/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-129) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
사용자가 저장한 비디오 중 더 이상 필요가 없거나 잘못 저장한 비디오를 삭제하기 위한 API가 필요하였기 때문이다.

비디오의 주인이 아닌 사람이 비디오 삭제 API의 엔드포인트를 알아내 비디오를 삭제할 수 있으면 안 되기에 소유권을 검증하는 로직을 추가할 필요가 있었다.


# How
- JWT로부터 회원의 정보를 얻어냄
- 얻어낸 회원의 ID와 API의 PathVariable로 넘어온 VideoId를 통해 조회한 비디오의 memberId가 일치하는지 체크
- 일치한다면 회원 삭제 로직 수행/일치하지 않는다면 에러 발생
```javascript
  async deleteVideo(videoId: number, member: Member) {
    validateManipulatedToken(member);
    const memberId = member.id;
    const video = await this.videoRepository.findById(videoId);
    this.validateVideoOwnership(video, memberId);

    await this.videoRepository.remove(video);
  }

private validateVideoOwnership(video: Video, memberId: number) {
    if (isEmpty(video)) throw new VideoNotFoundException();
    if (notEquals(memberId, video.memberId))
      throw new VideoAccessForbiddenException();
  }
```
# Result
### 비디오 삭제 완료
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/0db0489f-6032-47a1-b4d0-27b6ad16cf52)

### 다른 회원의 비디오 삭제를 요청한 경우
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/550d7af9-8355-4617-b394-a15b2b75381a)

# Prize
비디오 삭제 기능을 클라이언트에게 제공할 수 있게 되었다. 또한 악성 유저가 다른 사용자의 비디오를 삭제할 수 없다는 안전성도 확보할 수 있다. 

[NDD-129]: https://milk717.atlassian.net/browse/NDD-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ