### PR TITLE
[NDD-220]: BE 배포를 위한 최적화 처리 (2h / 2h)

### DIFF
--- a/BE/Dockerfile
+++ b/BE/Dockerfile
@@ -1,9 +1,17 @@
-FROM node:20
+FROM node:20-alpine
 
 RUN mkdir -p /var/app/
-WORKDIR -p /var/app/
-COPY . .
+WORKDIR /var/app/
+
+COPY package.json .
+COPY package-lock.json .
+
 RUN npm install
+
+COPY . .
+
 RUN npm run build
+
+
 EXPOSE 8080
 CMD ["node", "dist/main.js"]

--- a/BE/src/auth/controller/auth.controller.ts
+++ b/BE/src/auth/controller/auth.controller.ts
@@ -57,7 +57,7 @@ export class AuthController {
         await this.authService.login(userRequest),
         COOKIE_OPTIONS,
       )
-      .redirect('https://www.gomterview.com/mypage');
+      .redirect(process.env.OAUTH_REDIRECT_URL);
   }
 
   @Delete('logout')


### PR DESCRIPTION
[![NDD-220](https://badgen.net/badge/JIRA/NDD-220/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-220) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

1. Dockerfile이 너무 느리다!(@adultlee)
2. 로그인 후의 redirect url을 배포된 상태에서, Localhost로 실행된 상태에서 다르게 처리되었으면 좋겠다!(@Yoon-Hae-Min @milk717)

# How

Dockerfile
- package.json & package-lock.json를 npm install한 후 COPY => package.json & package-lock.json을 COPY하고 npm install을 컨테이너 내부에서 하자!
```
async googleAuthCallback(
    @Req() req: Request,
    @Res() res: Response,
  ): Promise<void> {
    const { user } = req;
    const userRequest = user as OAuthRequest;
    res
      .status(201)
      .cookie(
        'accessToken',
        await this.authService.login(userRequest),
        COOKIE_OPTIONS,
      )
      .redirect('https:www.gomterview.com/mypage');
  }
```
위에서 Redirect 주소를 process.env로 처리하자

# Result

- Dockerfile 수정
- process.env.OAUTH_REDIRECT_URL로 리디렉션 url 수정

# Prize

- 기본의 Docker의 initial build에서 약 800초 정도의 시간이 걸렸었다.
   - 기존의 이미지를 다시 로드해도, npm install을 반복적으로 cached일지라도 시간이 걸렸다. <- npm install을 무조건적으로 실행해야했다.
=> 해당 시간을 initial에서 200s, 재 빌드시에 변경이 없다면 바로 FINISHED가 되게 수정되었다. 

[NDD-220]: https://milk717.atlassian.net/browse/NDD-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ