### PR TITLE
[NDD-134] question select box 컴포넌트 구현하기 (8h/5h)

### DIFF
--- a/FE/src/apis/answer.ts
+++ b/FE/src/apis/answer.ts
@@ -16,3 +16,14 @@ export const postAnswer = async (questionId: number, content: string) => {
     data: { questionId, content },
   });
 };
+
+export const postDefaultAnswer = async (
+  questionId: number,
+  answerId: number
+) => {
+  return await getAPIResponseData({
+    method: 'post',
+    url: API.ANSWER_DEFAULT,
+    data: { questionId, answerId },
+  });
+};

--- a/FE/src/apis/category.ts
+++ b/FE/src/apis/category.ts
@@ -1,8 +1,9 @@
 import { API } from '@/constants/api';
+import { Category } from '@/types/category';
 import getAPIResponseData from '@/utils/getAPIResponseData';
 
 export const getCategory = async () => {
-  return await getAPIResponseData({
+  return await getAPIResponseData<Category[]>({
     method: 'get',
     url: API.CATEGORY,
   });

--- a/FE/src/apis/category.ts
+++ b/FE/src/apis/category.ts
@@ -1,0 +1,9 @@
+import { API } from '@/constants/api';
+import getAPIResponseData from '@/utils/getAPIResponseData';
+
+export const getCategory = async () => {
+  return await getAPIResponseData({
+    method: 'get',
+    url: API.CATEGORY,
+  });
+};

--- a/FE/src/apis/question.ts
+++ b/FE/src/apis/question.ts
@@ -1,0 +1,10 @@
+import { API } from '@/constants/api';
+import getAPIResponseData from '@/utils/getAPIResponseData';
+
+export const getQuestion = async (id: number) => {
+  return await getAPIResponseData({
+    method: 'get',
+    url: API.QUESTION,
+    params: { category: id },
+  });
+};

--- a/FE/src/apis/question.ts
+++ b/FE/src/apis/question.ts
@@ -1,8 +1,9 @@
 import { API } from '@/constants/api';
+import { Question } from '@/types/question';
 import getAPIResponseData from '@/utils/getAPIResponseData';
 
 export const getQuestion = async (id: number) => {
-  return await getAPIResponseData({
+  return await getAPIResponseData<Question[]>({
     method: 'get',
     url: API.QUESTION,
     params: { category: id },

--- a/FE/src/atoms/interviewSetting.ts
+++ b/FE/src/atoms/interviewSetting.ts
@@ -1,17 +1,16 @@
+import { Question } from '@/types/question';
 import { atom } from 'recoil';
 
 type PageStatus = 'pending' | 'success' | 'error';
 type RecordMethod = 'local' | 'idrive' | 'none' | undefined;
 
-type SelectedData = {
-  id: number;
-  content: string;
-  answer: string;
+type SelectedQuestion = Question & {
+  categoryId: number;
 };
 
 export const questionSetting = atom<{
   status: PageStatus;
-  selectedData: SelectedData[];
+  selectedData: SelectedQuestion[];
 }>({
   key: 'questionSetting',
   default: {

--- a/FE/src/atoms/interviewSetting.ts
+++ b/FE/src/atoms/interviewSetting.ts
@@ -1,7 +1,6 @@
 import { Question } from '@/types/question';
 import { atom } from 'recoil';
 
-type PageStatus = 'pending' | 'success' | 'error';
 type RecordMethod = 'local' | 'idrive' | 'none' | undefined;
 
 type SelectedQuestion = Question & {
@@ -9,32 +8,32 @@ type SelectedQuestion = Question & {
 };
 
 export const questionSetting = atom<{
-  status: PageStatus;
+  isSuccess: boolean;
   selectedData: SelectedQuestion[];
 }>({
   key: 'questionSetting',
   default: {
-    status: 'pending',
+    isSuccess: false,
     selectedData: [],
   },
 });
 
 export const videoSetting = atom<{
-  status: PageStatus;
+  isSuccess: boolean;
 }>({
   key: 'videoSetting',
   default: {
-    status: 'pending',
+    isSuccess: false,
   },
 });
 
 export const recordSetting = atom<{
-  status: PageStatus;
+  isSuccess: boolean;
   method: RecordMethod;
 }>({
   key: 'recordSetting',
   default: {
-    status: 'pending',
+    isSuccess: false,
     method: undefined,
   },
 });

--- a/FE/src/components/foundation/Tabs/Tab.tsx
+++ b/FE/src/components/foundation/Tabs/Tab.tsx
@@ -1,14 +1,20 @@
-import React from 'react';
+import React, { SyntheticEvent, useContext } from 'react';
+import { TabContext } from '.';
 
 type TabProps = {
   children?: React.ReactNode;
   name?: string;
   value: string;
-  onClick?: (value: string) => void;
+  onTabChange?: (e: SyntheticEvent, value: string) => void;
 };
 
-const Tab: React.FC<TabProps> = ({ children, value, onClick }) => {
-  return <div onClick={() => onClick && onClick(value)}>{children}</div>;
+const Tab: React.FC<TabProps> = ({ children, value, onTabChange }) => {
+  const { handleTabChange } = useContext(TabContext);
+  const handleClick = (e: SyntheticEvent) => {
+    handleTabChange(value);
+    onTabChange && onTabChange(e, value);
+  };
+  return <div onClick={handleClick}>{children}</div>;
 };
 
 export default Tab;

--- a/FE/src/components/foundation/Tabs/TabList.tsx
+++ b/FE/src/components/foundation/Tabs/TabList.tsx
@@ -1,24 +1,24 @@
-import { SyntheticEvent, useContext } from 'react';
-import { TabContext } from '@foundation/Tabs/index';
+import { SyntheticEvent } from 'react';
 import { css } from '@emotion/react';
 import Tab from '@foundation/Tabs/Tab';
 import enhanceChildElement from '@/utils/enhanceChildElement';
+import { HTMLElementTypes } from '@/types/utils';
 
 type TabListProps = {
   children: React.ReactNode;
   name?: string;
   direction?: 'row' | 'column';
   gap?: string;
-  onChange: (e: SyntheticEvent, value: string) => void;
-};
+  onTabChange: (e: SyntheticEvent, value: string) => void;
+} & HTMLElementTypes<HTMLDivElement>;
 
 const TabList: React.FC<TabListProps> = ({
   children,
   direction = 'row',
   gap = '0.5rem',
+  onTabChange,
+  ...args
 }) => {
-  const { handleTabChange } = useContext(TabContext);
-
   return (
     <div
       css={css`
@@ -26,11 +26,12 @@ const TabList: React.FC<TabListProps> = ({
         flex-direction: ${direction};
         gap: ${gap};
       `}
+      {...args}
     >
       {enhanceChildElement({
         children,
         component: Tab,
-        newProps: { onClick: handleTabChange },
+        newProps: { onTabChange: onTabChange },
       })}
     </div>
   );

--- a/FE/src/components/foundation/Tabs/TabPanel.tsx
+++ b/FE/src/components/foundation/Tabs/TabPanel.tsx
@@ -1,19 +1,21 @@
 import { useContext } from 'react';
 import { TabContext } from '@foundation/Tabs/index';
 import { css } from '@emotion/react';
+import { HTMLElementTypes } from '@/types/utils';
 
 type TabPanelProps = {
   children: React.ReactNode;
   value: string;
-};
+} & HTMLElementTypes<HTMLDivElement>;
 
-const TabPanel: React.FC<TabPanelProps> = ({ children, value }) => {
+const TabPanel: React.FC<TabPanelProps> = ({ children, value, ...args }) => {
   const { selectedValue } = useContext(TabContext);
   return (
     <div
       css={css`
         display: ${selectedValue === value ? 'block' : 'none'};
       `}
+      {...args}
     >
       {children}
     </div>

--- a/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionAccordion.tsx
+++ b/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionAccordion.tsx
@@ -1,4 +1,3 @@
-import { questionSetting } from '@/atoms/interviewSetting';
 import {
   Accordion,
   AccordionDetails,
@@ -6,10 +5,10 @@ import {
 } from '@/components/foundation/Accordion';
 import { LeadingDot } from '@/components/foundation/LeadingDot/LeadingDot';
 import Typography from '@/components/foundation/Typography/Typography';
+import useSelectQuestions from '@/hooks/atoms/useSelectQuestions';
 import { theme } from '@/styles/theme';
 import { Question } from '@/types/question';
 import { css } from '@emotion/react';
-import { useRecoilState } from 'recoil';
 
 type QuestionAccordionProps = {
   question: Question;
@@ -25,36 +24,14 @@ const QuestionAccordion: React.FC<QuestionAccordionProps> = ({
   question,
   categoryId,
 }) => {
-  const [selectedQuestions, setSelectedQuestions] =
-    useRecoilState(questionSetting);
-
-  const isSelected = selectedQuestions.selectedData.some(
-    (item) =>
-      item.questionId === question.questionId && item.categoryId === categoryId
-  );
-
-  const handleChange = () => {
-    if (isSelected) {
-      setSelectedQuestions((prevState) => ({
-        isSuccess: true,
-        selectedData: prevState.selectedData.filter(
-          (item) => item.questionId !== question.questionId
-        ),
-      }));
-    } else {
-      setSelectedQuestions({
-        isSuccess: false,
-        selectedData: [
-          ...selectedQuestions.selectedData,
-          { ...question, categoryId: categoryId },
-        ],
-      });
-    }
-  };
+  const { isSelected, toggleSelected } = useSelectQuestions({
+    question: question,
+    categoryId: categoryId,
+  });
 
   return (
     <Accordion
-      onChange={handleChange}
+      onChange={toggleSelected}
       expanded={isSelected}
       css={css`
         margin-bottom: 1.2rem;

--- a/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionAccordion.tsx
+++ b/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionAccordion.tsx
@@ -11,7 +11,7 @@ import { Question } from '@/types/question';
 import { css } from '@emotion/react';
 import { useRecoilState } from 'recoil';
 
-type QuestionListItemProps = {
+type QuestionAccordionProps = {
   question: Question;
   categoryId: number;
 };
@@ -21,7 +21,7 @@ const selectedStyle = css`
   color: ${theme.colors.text.white};
 `;
 
-const QuestionListItem: React.FC<QuestionListItemProps> = ({
+const QuestionAccordion: React.FC<QuestionAccordionProps> = ({
   question,
   categoryId,
 }) => {
@@ -36,14 +36,14 @@ const QuestionListItem: React.FC<QuestionListItemProps> = ({
   const handleChange = () => {
     if (isSelected) {
       setSelectedQuestions((prevState) => ({
-        status: 'success',
+        isSuccess: true,
         selectedData: prevState.selectedData.filter(
           (item) => item.questionId !== question.questionId
         ),
       }));
     } else {
       setSelectedQuestions({
-        status: 'success',
+        isSuccess: false,
         selectedData: [
           ...selectedQuestions.selectedData,
           { ...question, categoryId: categoryId },
@@ -51,6 +51,7 @@ const QuestionListItem: React.FC<QuestionListItemProps> = ({
       });
     }
   };
+
   return (
     <Accordion
       onChange={handleChange}
@@ -82,4 +83,4 @@ const QuestionListItem: React.FC<QuestionListItemProps> = ({
   );
 };
 
-export default QuestionListItem;
+export default QuestionAccordion;

--- a/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionListItem.tsx
+++ b/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionListItem.tsx
@@ -1,0 +1,85 @@
+import { questionSetting } from '@/atoms/interviewSetting';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+} from '@/components/foundation/Accordion';
+import { LeadingDot } from '@/components/foundation/LeadingDot/LeadingDot';
+import Typography from '@/components/foundation/Typography/Typography';
+import { theme } from '@/styles/theme';
+import { Question } from '@/types/question';
+import { css } from '@emotion/react';
+import { useRecoilState } from 'recoil';
+
+type QuestionListItemProps = {
+  question: Question;
+  categoryId: number;
+};
+
+const selectedStyle = css`
+  background-color: ${theme.colors.point.secondary.default};
+  color: ${theme.colors.text.white};
+`;
+
+const QuestionListItem: React.FC<QuestionListItemProps> = ({
+  question,
+  categoryId,
+}) => {
+  const [selectedQuestions, setSelectedQuestions] =
+    useRecoilState(questionSetting);
+
+  const isSelected = selectedQuestions.selectedData.some(
+    (item) =>
+      item.questionId === question.questionId && item.categoryId === categoryId
+  );
+
+  const handleChange = () => {
+    if (isSelected) {
+      setSelectedQuestions((prevState) => ({
+        status: 'success',
+        selectedData: prevState.selectedData.filter(
+          (item) => item.questionId !== question.questionId
+        ),
+      }));
+    } else {
+      setSelectedQuestions({
+        status: 'success',
+        selectedData: [
+          ...selectedQuestions.selectedData,
+          { ...question, categoryId: categoryId },
+        ],
+      });
+    }
+  };
+  return (
+    <Accordion
+      onChange={handleChange}
+      expanded={isSelected}
+      css={css`
+        margin-bottom: 1.2rem;
+      `}
+    >
+      <AccordionSummary
+        css={[
+          css`
+            background-color: ${theme.colors.surface.default};
+          `,
+          isSelected && selectedStyle,
+        ]}
+      >
+        <Typography noWrap variant="body3">
+          {question.questionContent}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <LeadingDot>
+          <Typography noWrap variant="body3">
+            {question.answerContent}
+          </Typography>
+        </LeadingDot>
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+export default QuestionListItem;

--- a/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionSelectionBox.tsx
+++ b/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionSelectionBox.tsx
@@ -2,105 +2,182 @@ import Box from '@/components/foundation/Box/Box';
 import Button from '@/components/foundation/Button/Button';
 import { theme } from '@/styles/theme';
 import { css } from '@emotion/react';
-import SelectionBox from '../../foundation/SelectionBox/SelectionBox';
 import Typography from '@/components/foundation/Typography/Typography';
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-} from '@/components/foundation/Accordion';
-import { LeadingDot } from '@/components/foundation/LeadingDot/LeadingDot';
+
+import { useQuery } from '@tanstack/react-query';
+import { getCategory } from '@/apis/category';
+import QuestionItem from './QuestionListItem';
+import Tabs from '@/components/foundation/Tabs';
+import { useState } from 'react';
+import SelectionBox from '@/components/foundation/SelectionBox/SelectionBox';
+import { getQuestion } from '@/apis/question';
+import { useRecoilState } from 'recoil';
+import { questionSetting } from '@/atoms/interviewSetting';
+import { Category } from '@/types/category';
 
 const QuestionSelectionBox = () => {
+  const [tabIndex, setTabIndex] = useState('1');
+  //TODO: 현재 선택된 값은 임의 값임 Tabs를 변경한다면 가장 먼저 수정해야 할 사안.
+  // HOW: 해당 state는 몇번째 Tab을 클릭했는지 저장하는 state이다. 따라서 Index값을 가지고 있고 이를 바탕으로 questionAPI 데이터를 가져와야 한다.
+
+  const [showSelectionOption, setShowSelectionOption] = useState(false);
+
+  const toggleShowSelectionOption = () => {
+    setShowSelectionOption((prev) => !prev);
+  };
+
+  const { data: categoryData } = useQuery({
+    queryKey: ['categories'],
+    queryFn: getCategory,
+  });
+
+  const [selectedQuestions, setSelectedQuestions] =
+    useRecoilState(questionSetting);
+
+  // jsx 부분은 panel부분과 sidebar 부분으로 나누어서 관리하는게 좋을것 같음
   return (
     <Box
       css={css`
         background-color: ${theme.colors.surface.inner};
-        min-width: 46.875rem;
-        display: flex;
+        width: 100%;
         height: 40rem;
       `}
     >
-      <div
+      <Tabs
+        initialValue={tabIndex}
         css={css`
-          background-color: ${theme.colors.surface.default};
-          width: 12rem;
-          border-radius: 1rem 0 0 1rem;
-          padding-top: 6rem;
-
-          > * {
-            margin-bottom: 1rem;
-          }
-        `}
-      >
-        <SelectionBox id="전체" name="group">
-          <Typography variant="title4">전체</Typography>
-        </SelectionBox>
-        <SelectionBox id="FE" name="group">
-          <Typography variant="title4">FE</Typography>
-        </SelectionBox>
-        <SelectionBox id="BE" name="group">
-          <Typography variant="title4">BE</Typography>
-        </SelectionBox>
-        <SelectionBox id="my-page" name="group">
-          <Typography variant="title4">나만의 질문</Typography>
-        </SelectionBox>
-      </div>
-
-      <div
-        css={css`
-          position: relative;
+          display: flex;
           width: 100%;
-          padding: 1rem;
+          height: 100%;
+          row-gap: 1.5rem;
         `}
       >
-        <Typography variant="body3" color={theme.colors.text.subStrong}>
-          13개의 질문
-        </Typography>
-
-        <Accordion onChange={() => {}} title="FE" expanded={true}>
-          <AccordionSummary
-            css={css`
-              background-color: ${theme.colors.point.secondary.default};
-              color: ${theme.colors.text.white};
-            `}
-          >
-            FE
-          </AccordionSummary>
-          <AccordionDetails>
-            <LeadingDot>BE</LeadingDot>
-          </AccordionDetails>
-        </Accordion>
-
-        <Accordion onChange={() => {}} title="FE" expanded={true}>
-          <AccordionSummary>FE</AccordionSummary>
-          <AccordionDetails>BE</AccordionDetails>
-        </Accordion>
+        <Tabs.TabList
+          name="category"
+          css={css`
+            background-color: ${theme.colors.surface.default};
+            width: 12rem;
+            border-radius: 1rem 0 0 1rem;
+            padding-top: 6rem;
+            display: flex;
+            flex-direction: column;
+            > * {
+              margin-bottom: 1rem;
+            }
+          `}
+          onTabChange={(_, value) => setTabIndex(value)}
+        >
+          {categoryData?.map((category, index) => (
+            <Tabs.Tab value={category.id.toString()} key={category.id}>
+              <SelectionBox
+                id={`category-${category.id.toString()}`}
+                name="category"
+                defaultChecked={index === 0}
+              >
+                <Typography variant="title4">{category.name}</Typography>
+              </SelectionBox>
+            </Tabs.Tab>
+          ))}
+        </Tabs.TabList>
 
         <div
           css={css`
-            display: flex;
-            justify-content: flex-end;
-            position: absolute;
-            bottom: 0;
-            right: 0;
+            position: relative;
             padding: 1rem;
             width: 100%;
-            background-color: ${theme.colors.surface.default};
+            max-width: calc(100% - 12rem);
           `}
         >
-          <Button
+          {categoryData?.map((category, index) => (
+            <TabPanelItem
+              tabIndex={tabIndex}
+              tabValue={index.toString()}
+              category={category}
+              key={category.id}
+            />
+          ))}
+          ;
+          <div
             css={css`
-              margin-left: auto;
+              display: flex;
+              justify-content: flex-end;
+              position: absolute;
+              bottom: 0;
+              right: 0;
+              padding: 1rem;
+              width: 100%;
+              background-color: ${theme.colors.surface.default};
             `}
-            size="sm"
           >
-            선택된 질문만 보기
-          </Button>
+            <Button
+              css={css`
+                margin-left: auto;
+              `}
+              size="sm"
+              onClick={toggleShowSelectionOption}
+            >
+              선택된 질문만 보기
+            </Button>
+          </div>
         </div>
-      </div>
+      </Tabs>
     </Box>
   );
 };
 
 export default QuestionSelectionBox;
+
+type TabPanelItemProps = {
+  tabIndex: string;
+  tabValue: string;
+  category: Category;
+};
+
+const TabPanelItem: React.FC<TabPanelItemProps> = ({
+  tabIndex,
+  category,
+  tabValue,
+}) => {
+  const { data: questionData } = useQuery({
+    queryKey: ['questions', tabValue],
+    queryFn: () => getQuestion(Number(tabValue)),
+    enabled: tabIndex === tabValue,
+  });
+
+  // option 형태에 따라서 보여지는 데이터가 달라짐 따라서 해당 부분에 대한 변수 하나를 토대로 데이터를 변경하는 로직 필요
+  // 대충 갂는데 얼마나 걸릴려나
+
+  return (
+    <>
+      <Tabs.TabPanel
+        key={`category.id-${category.id}`}
+        value={tabValue}
+        css={css`
+          margin-top: 2rem;
+          max-height: 90%;
+          overflow-y: auto;
+        `}
+      >
+        <Typography
+          component="p"
+          variant="body3"
+          color={theme.colors.text.subStrong}
+          css={css`
+            position: absolute;
+            top: 1rem;
+          `}
+        >
+          {questionData?.length}개의 질문
+        </Typography>
+        {questionData &&
+          questionData.map((question) => (
+            <QuestionItem
+              question={question}
+              key={question.questionId}
+              categoryId={category.id}
+            />
+          ))}
+      </Tabs.TabPanel>
+    </>
+  );
+};

--- a/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionSelectionBox.tsx
+++ b/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionSelectionBox.tsx
@@ -1,40 +1,20 @@
 import Box from '@/components/foundation/Box/Box';
-import Button from '@/components/foundation/Button/Button';
 import { theme } from '@/styles/theme';
 import { css } from '@emotion/react';
 import Typography from '@/components/foundation/Typography/Typography';
 
-import { useQuery } from '@tanstack/react-query';
-import { getCategory } from '@/apis/category';
-import QuestionItem from './QuestionListItem';
 import Tabs from '@/components/foundation/Tabs';
 import { useState } from 'react';
 import SelectionBox from '@/components/foundation/SelectionBox/SelectionBox';
-import { getQuestion } from '@/apis/question';
-import { useRecoilState } from 'recoil';
-import { questionSetting } from '@/atoms/interviewSetting';
-import { Category } from '@/types/category';
+import TabPanelItem from './QuestionTabPanelItem';
+import useCategoryQuery from '@/hooks/queries/useCategoryQuery';
 
 const QuestionSelectionBox = () => {
-  const [tabIndex, setTabIndex] = useState('1');
+  const [selectedTabIndex, setSelectedTabIndex] = useState('0');
   //TODO: 현재 선택된 값은 임의 값임 Tabs를 변경한다면 가장 먼저 수정해야 할 사안.
   // HOW: 해당 state는 몇번째 Tab을 클릭했는지 저장하는 state이다. 따라서 Index값을 가지고 있고 이를 바탕으로 questionAPI 데이터를 가져와야 한다.
 
-  const [showSelectionOption, setShowSelectionOption] = useState(false);
-
-  const toggleShowSelectionOption = () => {
-    setShowSelectionOption((prev) => !prev);
-  };
-
-  const { data: categoryData } = useQuery({
-    queryKey: ['categories'],
-    queryFn: getCategory,
-  });
-
-  const [selectedQuestions, setSelectedQuestions] =
-    useRecoilState(questionSetting);
-
-  // jsx 부분은 panel부분과 sidebar 부분으로 나누어서 관리하는게 좋을것 같음
+  const { data: categoryData } = useCategoryQuery();
   return (
     <Box
       css={css`
@@ -44,7 +24,7 @@ const QuestionSelectionBox = () => {
       `}
     >
       <Tabs
-        initialValue={tabIndex}
+        initialValue={selectedTabIndex}
         css={css`
           display: flex;
           width: 100%;
@@ -65,10 +45,10 @@ const QuestionSelectionBox = () => {
               margin-bottom: 1rem;
             }
           `}
-          onTabChange={(_, value) => setTabIndex(value)}
+          onTabChange={(_, value) => setSelectedTabIndex(value)}
         >
           {categoryData?.map((category, index) => (
-            <Tabs.Tab value={category.id.toString()} key={category.id}>
+            <Tabs.Tab value={index.toString()} key={category.id}>
               <SelectionBox
                 id={`category-${category.id.toString()}`}
                 name="category"
@@ -82,43 +62,18 @@ const QuestionSelectionBox = () => {
 
         <div
           css={css`
-            position: relative;
-            padding: 1rem;
             width: 100%;
             max-width: calc(100% - 12rem);
           `}
         >
           {categoryData?.map((category, index) => (
             <TabPanelItem
-              tabIndex={tabIndex}
-              tabValue={index.toString()}
+              selectedTabIndex={selectedTabIndex}
+              tabIndex={index.toString()}
               category={category}
               key={category.id}
             />
           ))}
-          ;
-          <div
-            css={css`
-              display: flex;
-              justify-content: flex-end;
-              position: absolute;
-              bottom: 0;
-              right: 0;
-              padding: 1rem;
-              width: 100%;
-              background-color: ${theme.colors.surface.default};
-            `}
-          >
-            <Button
-              css={css`
-                margin-left: auto;
-              `}
-              size="sm"
-              onClick={toggleShowSelectionOption}
-            >
-              선택된 질문만 보기
-            </Button>
-          </div>
         </div>
       </Tabs>
     </Box>
@@ -126,58 +81,3 @@ const QuestionSelectionBox = () => {
 };
 
 export default QuestionSelectionBox;
-
-type TabPanelItemProps = {
-  tabIndex: string;
-  tabValue: string;
-  category: Category;
-};
-
-const TabPanelItem: React.FC<TabPanelItemProps> = ({
-  tabIndex,
-  category,
-  tabValue,
-}) => {
-  const { data: questionData } = useQuery({
-    queryKey: ['questions', tabValue],
-    queryFn: () => getQuestion(Number(tabValue)),
-    enabled: tabIndex === tabValue,
-  });
-
-  // option 형태에 따라서 보여지는 데이터가 달라짐 따라서 해당 부분에 대한 변수 하나를 토대로 데이터를 변경하는 로직 필요
-  // 대충 갂는데 얼마나 걸릴려나
-
-  return (
-    <>
-      <Tabs.TabPanel
-        key={`category.id-${category.id}`}
-        value={tabValue}
-        css={css`
-          margin-top: 2rem;
-          max-height: 90%;
-          overflow-y: auto;
-        `}
-      >
-        <Typography
-          component="p"
-          variant="body3"
-          color={theme.colors.text.subStrong}
-          css={css`
-            position: absolute;
-            top: 1rem;
-          `}
-        >
-          {questionData?.length}개의 질문
-        </Typography>
-        {questionData &&
-          questionData.map((question) => (
-            <QuestionItem
-              question={question}
-              key={question.questionId}
-              categoryId={category.id}
-            />
-          ))}
-      </Tabs.TabPanel>
-    </>
-  );
-};

--- a/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionSelectionBox.tsx
+++ b/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionSelectionBox.tsx
@@ -1,0 +1,106 @@
+import Box from '@/components/foundation/Box/Box';
+import Button from '@/components/foundation/Button/Button';
+import { theme } from '@/styles/theme';
+import { css } from '@emotion/react';
+import SelectionBox from '../../foundation/SelectionBox/SelectionBox';
+import Typography from '@/components/foundation/Typography/Typography';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+} from '@/components/foundation/Accordion';
+import { LeadingDot } from '@/components/foundation/LeadingDot/LeadingDot';
+
+const QuestionSelectionBox = () => {
+  return (
+    <Box
+      css={css`
+        background-color: ${theme.colors.surface.inner};
+        min-width: 46.875rem;
+        display: flex;
+        height: 40rem;
+      `}
+    >
+      <div
+        css={css`
+          background-color: ${theme.colors.surface.default};
+          width: 12rem;
+          border-radius: 1rem 0 0 1rem;
+          padding-top: 6rem;
+
+          > * {
+            margin-bottom: 1rem;
+          }
+        `}
+      >
+        <SelectionBox id="전체" name="group">
+          <Typography variant="title4">전체</Typography>
+        </SelectionBox>
+        <SelectionBox id="FE" name="group">
+          <Typography variant="title4">FE</Typography>
+        </SelectionBox>
+        <SelectionBox id="BE" name="group">
+          <Typography variant="title4">BE</Typography>
+        </SelectionBox>
+        <SelectionBox id="my-page" name="group">
+          <Typography variant="title4">나만의 질문</Typography>
+        </SelectionBox>
+      </div>
+
+      <div
+        css={css`
+          position: relative;
+          width: 100%;
+          padding: 1rem;
+        `}
+      >
+        <Typography variant="body3" color={theme.colors.text.subStrong}>
+          13개의 질문
+        </Typography>
+
+        <Accordion onChange={() => {}} title="FE" expanded={true}>
+          <AccordionSummary
+            css={css`
+              background-color: ${theme.colors.point.secondary.default};
+              color: ${theme.colors.text.white};
+            `}
+          >
+            FE
+          </AccordionSummary>
+          <AccordionDetails>
+            <LeadingDot>BE</LeadingDot>
+          </AccordionDetails>
+        </Accordion>
+
+        <Accordion onChange={() => {}} title="FE" expanded={true}>
+          <AccordionSummary>FE</AccordionSummary>
+          <AccordionDetails>BE</AccordionDetails>
+        </Accordion>
+
+        <div
+          css={css`
+            display: flex;
+            justify-content: flex-end;
+            position: absolute;
+            bottom: 0;
+            right: 0;
+            padding: 1rem;
+            width: 100%;
+            background-color: ${theme.colors.surface.default};
+          `}
+        >
+          <Button
+            css={css`
+              margin-left: auto;
+            `}
+            size="sm"
+          >
+            선택된 질문만 보기
+          </Button>
+        </div>
+      </div>
+    </Box>
+  );
+};
+
+export default QuestionSelectionBox;

--- a/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionTabPanelItem.tsx
+++ b/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionTabPanelItem.tsx
@@ -1,0 +1,108 @@
+import { questionSetting } from '@/atoms/interviewSetting';
+import Button from '@/components/foundation/Button/Button';
+import Tabs from '@/components/foundation/Tabs';
+import Typography from '@/components/foundation/Typography/Typography';
+import { theme } from '@/styles/theme';
+import { Category } from '@/types/category';
+import { css } from '@emotion/react';
+import { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import QuestionAccordion from './QuestionAccordion';
+import useQuestionCategoryQuery from '@/hooks/queries/useQuestionCategoryQuery';
+
+type TabPanelItemProps = {
+  selectedTabIndex: string;
+  tabIndex: string;
+  category: Category;
+};
+
+const TabPanelItem: React.FC<TabPanelItemProps> = ({
+  selectedTabIndex,
+  category,
+  tabIndex,
+}) => {
+  const [onlySelectedOption, setOnlySelectedOption] = useState(false);
+
+  const toggleShowSelectionOption = () => {
+    setOnlySelectedOption((prev) => !prev);
+  };
+
+  const { data: questionAPIData } = useQuestionCategoryQuery({
+    categoryId: category.id,
+    enabled: selectedTabIndex === tabIndex,
+  });
+
+  const settingPage = useRecoilValue(questionSetting);
+  const selectedQuestions = settingPage.selectedData.filter(
+    (question) => question.categoryId === category.id
+  );
+
+  const questionData = onlySelectedOption ? selectedQuestions : questionAPIData;
+  if (!questionData) return;
+
+  return (
+    <Tabs.TabPanel
+      key={`category.id-${category.id}`}
+      value={tabIndex}
+      css={css`
+        height: 100%;
+      `}
+    >
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+        `}
+      >
+        <Typography
+          component="p"
+          variant="body3"
+          color={theme.colors.text.subStrong}
+          css={css`
+            padding: 1rem;
+          `}
+        >
+          {questionData.length}개의 질문
+        </Typography>
+        <div
+          css={css`
+            height: 100%;
+            overflow-y: auto;
+            flex: 1;
+            padding: 1rem;
+          `}
+        >
+          {questionData.map((question) => (
+            <QuestionAccordion
+              question={question}
+              key={question.questionId}
+              categoryId={category.id}
+            />
+          ))}
+        </div>
+        <div
+          css={css`
+            display: flex;
+            justify-content: flex-end;
+            width: 100%;
+            padding: 1rem;
+            background-color: ${theme.colors.surface.default};
+          `}
+        >
+          <Button
+            css={css`
+              margin-left: auto;
+            `}
+            size="sm"
+            onClick={toggleShowSelectionOption}
+          >
+            선택된 질문만 보기
+          </Button>
+        </div>
+      </div>
+    </Tabs.TabPanel>
+  );
+};
+
+export default TabPanelItem;

--- a/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionTabPanelItem.tsx
+++ b/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionTabPanelItem.tsx
@@ -88,6 +88,7 @@ const TabPanelItem: React.FC<TabPanelItemProps> = ({
             width: 100%;
             padding: 1rem;
             background-color: ${theme.colors.surface.default};
+            border-radius: 0 0 1rem 0;
           `}
         >
           <Button

--- a/FE/src/constants/api.ts
+++ b/FE/src/constants/api.ts
@@ -17,4 +17,6 @@ export const API = {
   ANSWER: '/answer',
   ANSWER_DEFAULT: '/answer/default',
   ANSWER_ID: (id?: Id) => `/answer/${id ?? ':id'}`,
-};
+  CATEGORY: '/category',
+  CATEGORY_ID: (id?: Id) => `/category/${id ?? ':id'}`,
+} as const;

--- a/FE/src/constants/queryKey.ts
+++ b/FE/src/constants/queryKey.ts
@@ -1,4 +1,6 @@
 export const QUERY_KEY = {
   QUESTION_ANSWER: (questionId: number) => ['answer', questionId],
+  QUESTION_CATEGORY: (categoryId: number) => ['questions', categoryId],
+  CATEGORY: ['categories'],
   MEMBER: ['member'],
 };

--- a/FE/src/hooks/atoms/useSelectQuestions.ts
+++ b/FE/src/hooks/atoms/useSelectQuestions.ts
@@ -1,0 +1,44 @@
+import { questionSetting } from '@/atoms/interviewSetting';
+import { Question } from '@/types/question';
+import { useRecoilState } from 'recoil';
+
+const useSelectQuestions = ({
+  question,
+  categoryId,
+}: {
+  question: Question;
+  categoryId: number;
+}) => {
+  const [selectedQuestions, setSelectedQuestions] =
+    useRecoilState(questionSetting);
+
+  const setUnselected = () => {
+    setSelectedQuestions((prevState) => ({
+      isSuccess: true,
+      selectedData: prevState.selectedData.filter(
+        (item) => item.questionId !== question.questionId
+      ),
+    }));
+  };
+
+  const setSelected = () => {
+    setSelectedQuestions((prevState) => ({
+      isSuccess: true,
+      selectedData: [
+        ...prevState.selectedData,
+        { ...question, categoryId: categoryId },
+      ],
+    }));
+  };
+
+  const toggleSelected = () => (isSelected ? setUnselected() : setSelected());
+
+  const isSelected = selectedQuestions.selectedData.some(
+    (item) =>
+      item.questionId === question.questionId && item.categoryId === categoryId
+  );
+
+  return { isSelected, setUnselected, setSelected, toggleSelected };
+};
+
+export default useSelectQuestions;

--- a/FE/src/hooks/queries/useCategoryQuery.ts
+++ b/FE/src/hooks/queries/useCategoryQuery.ts
@@ -1,0 +1,12 @@
+import { getCategory } from '@/apis/category';
+import { QUERY_KEY } from '@/constants/queryKey';
+import { useQuery } from '@tanstack/react-query';
+
+const useCategoryQuery = () => {
+  return useQuery({
+    queryKey: QUERY_KEY.CATEGORY,
+    queryFn: getCategory,
+  });
+};
+
+export default useCategoryQuery;

--- a/FE/src/hooks/queries/useQuestionCategoryQuery.ts
+++ b/FE/src/hooks/queries/useQuestionCategoryQuery.ts
@@ -1,0 +1,19 @@
+import { getQuestion } from '@/apis/question';
+import { QUERY_KEY } from '@/constants/queryKey';
+import { useQuery } from '@tanstack/react-query';
+
+const useQuestionCategoryQuery = ({
+  categoryId,
+  enabled,
+}: {
+  categoryId: number;
+  enabled: boolean;
+}) => {
+  return useQuery({
+    queryKey: QUERY_KEY.QUESTION_CATEGORY(categoryId),
+    queryFn: () => getQuestion(categoryId),
+    enabled,
+  });
+};
+
+export default useQuestionCategoryQuery;

--- a/FE/src/mocks/handlers.ts
+++ b/FE/src/mocks/handlers.ts
@@ -2,10 +2,12 @@ import memberHandlers from './handlers/member';
 import questionHandlers from './handlers/question';
 import answerHandlers from './handlers/answer';
 import videoHandlers from '@/mocks/handlers/video';
+import categoryHandlers from './handlers/category';
 
 export const handlers = [
   ...memberHandlers,
   ...questionHandlers,
   ...answerHandlers,
   ...videoHandlers,
+  ...categoryHandlers,
 ];

--- a/FE/src/mocks/handlers/category.ts
+++ b/FE/src/mocks/handlers/category.ts
@@ -1,0 +1,30 @@
+import { API } from '@/constants/api';
+import { HttpResponse, http } from 'msw';
+
+const categoryHandlers = [
+  http.get(API.CATEGORY, () => {
+    return HttpResponse.json(
+      [
+        {
+          id: 1,
+          name: 'FE',
+        },
+        {
+          id: 2,
+          name: 'BE',
+        },
+        {
+          id: 3,
+          name: 'CS',
+        },
+        {
+          id: 4,
+          name: '나만의 질문',
+        },
+      ],
+      { status: 200 }
+    );
+  }),
+];
+
+export default categoryHandlers;

--- a/FE/src/mocks/handlers/question.ts
+++ b/FE/src/mocks/handlers/question.ts
@@ -12,20 +12,61 @@ const questionHandlers = [
     console.log(category);
     return HttpResponse.json([
       {
-        id: '1',
-        content: 'CSS 선택자의 종류에 대해 설명해주세요.',
+        questionId: '1',
+        questionContent: 'CSS 선택자의 종류에 대해 설명해주세요.',
+        answerId: '123',
+        answerContent:
+          '선택자는 요소를 선택하는 방법을 말합니다. CSS 선택자는 CSS 규칙에 스타일을 적용할 요소를 선택하는 방법을 말합니다. CSS 선택자는 다음과 같이 세 가지 종류로 나눌 수 있습니다. 1. 타입 선택자 2. 클래스 선택자 3. 아이디 선택자',
       },
       {
-        id: '2',
-        content: 'JavaScript의 클로저(Closure)에 대해 설명해주세요.',
+        questionId: '2',
+        questionContent: 'JavaScript의 클로저(Closure)에 대해 설명해주세요.',
+        answerId: '1234',
+        answerContent:
+          '클로저는 함수와 함수가 선언된 어휘적 환경의 조합입니다. 클로저를 이해하려면 자바스크립트의 어휘적 환경에 대한 이해가 필요합니다. 자바스크립트에서 함수는 객체입니다. 그리고 함수가 선언될 때, 그 함수의 LexicalEnvironment는 결정됩니다. LexicalEnvironment는 함수가 선언된 어휘적 환경을 의미합니다. 이 환경은 함수가 선언될 당시의 유효 범위 내에 있는 식별자들로 구성됩니다. 이 환경은 함수가 호출될 때, 그대로 함수와 함께 전달됩니다. 이렇게 함수와 그 함수가 선언된 어휘적 환경이 합쳐진 것을 클로저라고 합니다.',
       },
       {
-        id: '3',
-        content: 'HTML과 XHTML의 차이점은 무엇인가요?',
+        questionId: '3',
+        questionContent: 'HTML과 XHTML의 차이점은 무엇인가요?',
+        answerId: '12345',
+        answerContent:
+          'HTML은 SGML(Standard Generalized Markup Language)의 약자이며, 웹 문서를 작성하기 위한 가장 기본적인 마크업 언어입니다. XHTML은 XML(Extensible Markup Language)의 약자이며, HTML을 XML로 재정의한 것입니다. XHTML은 HTML보다 엄격하게 작성되어 있습니다. XHTML은 HTML보다 더 많은 규칙을 가지고 있습니다. XHTML은 HTML보다 더 구조적이고 명확한 작성을 요구합니다.',
       },
       {
-        id: '4',
-        content: '반응형 웹 디자인과 적응형 웹 디자인의 차이점은 무엇인가요?',
+        questionId: '4',
+        questionContent:
+          '반응형 웹 디자인과 적응형 웹 디자인의 차이점은 무엇인가요?',
+        answerId: '123456',
+        answerContent:
+          '반응형 웹 디자인은 하나의 웹 사이트를 만들고, 그 웹 사이트를 여러 기기에 맞게 최적화하는 것을 의미합니다. 적응형 웹 디자인은 여러 개의 웹 사이트를 만들고, 각 기기에 맞게 웹 사이트를 제공하는 것을 의미합니다.',
+      },
+      {
+        questionId: '5',
+        questionContent: 'CSS의 박스 모델(Box Model)에 대해 설명해주세요.',
+        answerId: '1234567',
+        answerContent:
+          'CSS의 박스 모델은 HTML 요소를 박스로 생각하고, 이 박스를 여러 개의 레이어로 구분한 것입니다. 박스 모델은 다음과 같이 구성됩니다. 1. 콘텐츠(Content) 2. 패딩(Padding) 3. 테두리(Border) 4. 마진(Margin)',
+      },
+      {
+        questionId: '6',
+        questionContent: 'CSS의 position 속성에 대해 설명해주세요.',
+        answerId: '12345678',
+        answerContent:
+          'position 속성은 요소의 위치를 지정하는 속성입니다. position 속성은 다음과 같이 5가지 속성값을 가질 수 있습니다. 1. static 2. relative 3. absolute 4. fixed 5. sticky',
+      },
+      {
+        questionId: '7',
+        questionContent: 'CSS의 float 속성에 대해 설명해주세요.',
+        answerId: '123456789',
+        answerContent:
+          'float 속성은 요소를 좌우 방향으로 띄우는 속성입니다. float 속성은 다음과 같이 3가지 속성값을 가질 수 있습니다. 1. left 2. right 3. none',
+      },
+      {
+        questionId: '8',
+        questionContent: 'CSS의 flexbox에 대해 설명해주세요.',
+        answerId: '1234567890',
+        answerContent:
+          'flexbox는 요소의 크기가 불분명하거나 동적인 경우에도, 요소를 정렬하기 위한 방법입니다. flexbox는 다음과 같이 2가지 속성을 가집니다. 1. flex container 2. flex item',
       },
     ]);
   }),

--- a/FE/src/types/category.ts
+++ b/FE/src/types/category.ts
@@ -1,0 +1,4 @@
+export type Category = {
+  id: number;
+  name: string;
+};

--- a/FE/src/types/question.ts
+++ b/FE/src/types/question.ts
@@ -1,0 +1,6 @@
+export type Question = {
+  questionId: number;
+  questionContent: string;
+  answerId: number;
+  answerContent: string;
+};


### PR DESCRIPTION
[![NDD-134](https://badgen.net/badge/JIRA/NDD-134/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-134) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

### 변경사항이 많습니다 조금 시간을 가지고 읽어주시기 바랍니다


# Why

상태가 생각보다 많아서 해당 상태의 흐름을 정리하느라 3시간 정도 작성했던것 같고 그 이외에 Tabpanel 내부의 스크롤을 구현하기 위해서 조금 오랜 시간이 걸렸던것 같습니다.


# How

기존의 방법은 React-query의 필드를 추가하는 방법을 기획했었는데 react-query에 저장하면서 서버의 데이터의 확장이니 뭔가 동기화를 시키면 좋지 않을까 생각했습니다 선택되었다는 상태를 react-query feild에 추가해서 사용을 하면서 만약 선택된 질문이 사용자가 삭제하는 동시성 문제를 해결하고자 했습니다
 하지만 해당 방법은 query를 refetch하면 상태가 초기화 되고 이걸 유지 시키려면 이전 상태와 비교를 해주어야 하는데 이 방법은 기존에 기대했던 동시성을 해결해 주지는 못합니다. 따라서 선택된 값들은 바로 recoil에 저장한 후 동기화 문제는 recoil과 react-query간의 관계를 맺어 주어서 해결하고자 합니다.


### css 문제점
```tsx
  <div
        css={css`
          display: flex;
          flex-direction: column;
          height: 100%;
        `}
      >
       ...
        <div
          css={css`
            height: 100%;
            overflow-y: auto;
            flex: 1;
            padding: 1rem;
          `}
        >
```

제가 하고 싶었던것은 header와 body footer가 있는데 body내부에서 해당 크기는 꽉 채워서 스크롤을 만들고 싶었습니다. flex: 1을 사용해서 body의 크기를 꽉채워서 자연스럽게 스크롤이 만들어지도록 가능 할 수 있었습니다.



## Description
<img width="803" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/49224104/3a3580a0-515b-47bf-8b7b-75575fd70ba8">

데이터 flow는 다음과 같습니다 기본적으로 category가 로딩이 되고 나서 question을 가져와야 하므로 TabList에서 먼저 category를 받아오고 랜더링을 해준후에 TabPanel을 랜더링 합니다.
그다음에 TabPanel에 있는 option을 기준으로 react-query의 데이터를 랜더링할것인지 선택된 questiob을 랜더링 할것인지에 대해서 판단하고 해당 데이터를 랜더링 해 줍니다.

TabPanel 내부에 QuestionAccordion을 통해서 클릭시에 전역 상태를 변경해 줍니다.

# Result

<img width="1440" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/49224104/9752144a-6965-4e2c-8054-d3b79cc9385f">


https://github.com/boostcampwm2023/web14-gomterview/assets/49224104/4ab32889-9cf7-4575-89cc-60e0f36c049e


## TODO
1. 나만의 질문에서 질문을 추가하는 로직은 새로운 테스크를 작성해서 진행 할 예정입니다.
2. 선택한 질문만 보기 버튼을 조금더 가시적으로 보일 필요가 있어 보입니다. 선택된 질문만 보기가 활성화 되었는지 활성화 되지 않았는지 구분하지 못합니다.

[NDD-134]: https://milk717.atlassian.net/browse/NDD-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ