### PR TITLE
[NDD-145] video api 관련 react-query hooks 추가 (1h/2h)

### DIFF
--- a/FE/src/apis/video.ts
+++ b/FE/src/apis/video.ts
@@ -9,7 +9,7 @@ import {
   VideoPublicToggleResDto,
 } from '@/types/video';
 
-export const addVideo = async (body: VideoAddReqDto) => {
+export const postVideo = async (body: VideoAddReqDto) => {
   return await getAPIResponseData({
     method: 'post',
     url: API.VIDEO,
@@ -17,7 +17,7 @@ export const addVideo = async (body: VideoAddReqDto) => {
   });
 };
 
-export const getPreSignedUrl = async (body: VideoPreSignedReqDto) => {
+export const postPreSignedUrl = async (body: VideoPreSignedReqDto) => {
   return await getAPIResponseData<VideoPreSignedResDto, VideoPreSignedReqDto>({
     method: 'post',
     url: API.VIDEO_PRE_SIGNED,
@@ -46,7 +46,7 @@ export const getVideoById = async (videoId: number) => {
   });
 };
 
-export const toggleVideoPublic = async (videoId: number) => {
+export const patchVideoPublic = async (videoId: number) => {
   return await getAPIResponseData<VideoPublicToggleResDto>({
     method: 'patch',
     url: API.VIDEO_ID(videoId),

--- a/FE/src/apis/video.ts
+++ b/FE/src/apis/video.ts
@@ -1,0 +1,61 @@
+import getAPIResponseData from '@/utils/getAPIResponseData';
+import { API } from '@constants/api';
+import {
+  VideoAddReqDto,
+  VideoItemResDto,
+  VideoListResDto,
+  VideoPreSignedReqDto,
+  VideoPreSignedResDto,
+  VideoPublicToggleResDto,
+} from '@/types/video';
+
+export const addVideo = async (body: VideoAddReqDto) => {
+  return await getAPIResponseData({
+    method: 'post',
+    url: API.VIDEO,
+    data: body,
+  });
+};
+
+export const getPreSignedUrl = async (body: VideoPreSignedReqDto) => {
+  return await getAPIResponseData<VideoPreSignedResDto, VideoPreSignedReqDto>({
+    method: 'post',
+    url: API.VIDEO_PRE_SIGNED,
+    data: body,
+  });
+};
+
+export const getVideoList = async () => {
+  return await getAPIResponseData<VideoListResDto>({
+    method: 'get',
+    url: API.VIDEO_ALL,
+  });
+};
+
+export const getVideoByHash = async (hash: string) => {
+  return await getAPIResponseData<VideoItemResDto>({
+    method: 'get',
+    url: API.VIDEO_HASH(hash),
+  });
+};
+
+export const getVideoById = async (videoId: number) => {
+  return await getAPIResponseData<VideoItemResDto>({
+    method: 'get',
+    url: API.VIDEO_ID(videoId),
+  });
+};
+
+export const toggleVideoPublic = async (videoId: number) => {
+  return await getAPIResponseData<VideoPublicToggleResDto>({
+    method: 'patch',
+    url: API.VIDEO_ID(videoId),
+  });
+};
+
+export const deleteVideoById = async (videoId: number) => {
+  return await getAPIResponseData({
+    method: 'delete',
+    url: API.VIDEO_ID(videoId),
+  });
+};

--- a/FE/src/constants/queryKey.ts
+++ b/FE/src/constants/queryKey.ts
@@ -1,4 +1,6 @@
 export const QUERY_KEY = {
   QUESTION_ANSWER: (questionId: number) => ['answer', questionId],
   MEMBER: ['member'],
+  VIDEO: ['video'],
+  VIDEO_ID: (videoId: number) => ['video', videoId],
 };

--- a/FE/src/constants/queryKey.ts
+++ b/FE/src/constants/queryKey.ts
@@ -3,4 +3,5 @@ export const QUERY_KEY = {
   MEMBER: ['member'],
   VIDEO: ['video'],
   VIDEO_ID: (videoId: number) => ['video', videoId],
+  VIDEO_HASH: (videoHash: string) => ['video', videoHash],
 };

--- a/FE/src/hooks/mutations/video/useAddVideoMutation.ts
+++ b/FE/src/hooks/mutations/video/useAddVideoMutation.ts
@@ -1,0 +1,18 @@
+import { QUERY_KEY } from '@/constants/queryKey';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { addVideo } from '@/apis/video';
+import { VideoAddReqDto } from '@/types/video';
+
+const useAddVideoMutation = (body: VideoAddReqDto) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => addVideo(body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: QUERY_KEY.VIDEO,
+      });
+    },
+  });
+};
+
+export default useAddVideoMutation;

--- a/FE/src/hooks/mutations/video/useAddVideoMutation.ts
+++ b/FE/src/hooks/mutations/video/useAddVideoMutation.ts
@@ -1,12 +1,12 @@
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { addVideo } from '@/apis/video';
+import { postVideo } from '@/apis/video';
 import { VideoAddReqDto } from '@/types/video';
 
 const useAddVideoMutation = (body: VideoAddReqDto) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: () => addVideo(body),
+    mutationFn: () => postVideo(body),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: QUERY_KEY.VIDEO,

--- a/FE/src/hooks/mutations/video/useDeleteVideoMutation.ts
+++ b/FE/src/hooks/mutations/video/useDeleteVideoMutation.ts
@@ -1,0 +1,17 @@
+import { QUERY_KEY } from '@/constants/queryKey';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteVideoById } from '@/apis/video';
+
+const useDeleteVideoMutation = (videoId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => deleteVideoById(videoId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: QUERY_KEY.VIDEO,
+      });
+    },
+  });
+};
+
+export default useDeleteVideoMutation;

--- a/FE/src/hooks/mutations/video/useGetPreSignedUrlMutation.ts
+++ b/FE/src/hooks/mutations/video/useGetPreSignedUrlMutation.ts
@@ -1,0 +1,18 @@
+import { QUERY_KEY } from '@/constants/queryKey';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { getPreSignedUrl } from '@/apis/video';
+import { VideoPreSignedReqDto } from '@/types/video';
+
+const useGetPreSignedUrlMutation = (body: VideoPreSignedReqDto) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => getPreSignedUrl(body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: QUERY_KEY.VIDEO,
+      });
+    },
+  });
+};
+
+export default useGetPreSignedUrlMutation;

--- a/FE/src/hooks/mutations/video/useGetPreSignedUrlMutation.ts
+++ b/FE/src/hooks/mutations/video/useGetPreSignedUrlMutation.ts
@@ -1,12 +1,12 @@
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { getPreSignedUrl } from '@/apis/video';
+import { postPreSignedUrl } from '@/apis/video';
 import { VideoPreSignedReqDto } from '@/types/video';
 
 const useGetPreSignedUrlMutation = (body: VideoPreSignedReqDto) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: () => getPreSignedUrl(body),
+    mutationFn: () => postPreSignedUrl(body),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: QUERY_KEY.VIDEO,

--- a/FE/src/hooks/mutations/video/useToggleVideoPublicMutation.ts
+++ b/FE/src/hooks/mutations/video/useToggleVideoPublicMutation.ts
@@ -1,11 +1,11 @@
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { toggleVideoPublic } from '@/apis/video';
+import { patchVideoPublic } from '@/apis/video';
 
 const useToggleVideoPublicMutation = (videoId: number) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: () => toggleVideoPublic(videoId),
+    mutationFn: () => patchVideoPublic(videoId),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: QUERY_KEY.VIDEO_ID(videoId),

--- a/FE/src/hooks/mutations/video/useToggleVideoPublicMutation.ts
+++ b/FE/src/hooks/mutations/video/useToggleVideoPublicMutation.ts
@@ -1,0 +1,17 @@
+import { QUERY_KEY } from '@/constants/queryKey';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toggleVideoPublic } from '@/apis/video';
+
+const useToggleVideoPublicMutation = (videoId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => toggleVideoPublic(videoId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: QUERY_KEY.VIDEO_ID(videoId),
+      });
+    },
+  });
+};
+
+export default useToggleVideoPublicMutation;

--- a/FE/src/hooks/queries/video/useVideoHashQuery.ts
+++ b/FE/src/hooks/queries/video/useVideoHashQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '@constants/queryKey';
+import { getVideoByHash } from '@/apis/video';
+
+const useVideoHashQuery = (hash: string) => {
+  return useQuery({
+    queryKey: QUERY_KEY.VIDEO,
+    queryFn: () => getVideoByHash(hash),
+  });
+};
+
+export default useVideoHashQuery;

--- a/FE/src/hooks/queries/video/useVideoHashQuery.ts
+++ b/FE/src/hooks/queries/video/useVideoHashQuery.ts
@@ -4,7 +4,7 @@ import { getVideoByHash } from '@/apis/video';
 
 const useVideoHashQuery = (hash: string) => {
   return useQuery({
-    queryKey: QUERY_KEY.VIDEO,
+    queryKey: QUERY_KEY.VIDEO_HASH(hash),
     queryFn: () => getVideoByHash(hash),
   });
 };

--- a/FE/src/hooks/queries/video/useVideoItemQuery.ts
+++ b/FE/src/hooks/queries/video/useVideoItemQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '@constants/queryKey';
+import { getVideoById } from '@/apis/video';
+
+const useVideoItemQuery = (videoId: number) => {
+  return useQuery({
+    queryKey: QUERY_KEY.VIDEO_ID(videoId),
+    queryFn: () => getVideoById(videoId),
+  });
+};
+
+export default useVideoItemQuery;

--- a/FE/src/hooks/queries/video/useVideoListQuery.ts
+++ b/FE/src/hooks/queries/video/useVideoListQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '@constants/queryKey';
+import { getVideoList } from '@/apis/video';
+
+const useVideoListQuery = () => {
+  return useQuery({
+    queryKey: QUERY_KEY.VIDEO,
+    queryFn: () => getVideoList(),
+  });
+};
+
+export default useVideoListQuery;

--- a/FE/src/types/video.ts
+++ b/FE/src/types/video.ts
@@ -1,0 +1,60 @@
+export type VideoEntity = {
+  id: number;
+  memberId: number;
+  questionId: number;
+  videoName: string;
+  thumbnail: string;
+  videoLength: string;
+  url: string;
+  hash: string | null;
+  isPublic: boolean;
+  createdAt: string;
+};
+
+/**
+ * GET video/all
+ * 비디오 전체 리스트를 조회했을 때 응답 객체 타입
+ */
+export type VideoListResDto = Pick<
+  VideoEntity,
+  'id' | 'thumbnail' | 'videoName' | 'videoLength' | 'isPublic' | 'createdAt'
+>[];
+
+/**
+ * GET video/${videoId}
+ * 비디오 아이디로 비디오를 단건 조회했을 때 응답 객체 타입
+ */
+export type VideoItemResDto = Pick<
+  VideoEntity,
+  'id' | 'url' | 'hash' | 'videoName' | 'createdAt'
+>;
+
+/**
+ * POST video
+ * 비디오를 등록할 때 요청 객체 타입
+ */
+export type VideoAddReqDto = Pick<
+  VideoEntity,
+  'questionId' | 'videoName' | 'url'
+>;
+
+/**
+ * POST video/pre-signed
+ * 비디오 등록 전 질문 아이디로 비디오 등록용 pre-signed url을 요청하는 객체 타입
+ */
+export type VideoPreSignedReqDto = Pick<VideoEntity, 'questionId'>;
+
+/**
+ * POST video/pre-signed
+ * 비디오 등록 전 질문 아이디로 비디오 등록용 pre-signed url 응답 객체 타입
+ */
+export type VideoPreSignedResDto = {
+  preSignedUrl: string;
+  key: string; //비디오 파일 이름입니다.
+};
+
+/**
+ * PATCH video/${videoId}
+ * 비디오 공개, 비공개 토글시 응답 객체 타입
+ */
+export type VideoPublicToggleResDto = Pick<VideoEntity, 'hash'>;

--- a/FE/src/utils/getAPIResponseData.ts
+++ b/FE/src/utils/getAPIResponseData.ts
@@ -1,7 +1,7 @@
 import api from '@/apis/axios';
 import axios, { AxiosRequestConfig } from 'axios';
 
-const getAPIResponseData = async <T>(option: AxiosRequestConfig<T>) => {
+const getAPIResponseData = async <T, D = T>(option: AxiosRequestConfig<D>) => {
   try {
     const result = await api<T>(option);
     return result.data;


### PR DESCRIPTION
[![NDD-145](https://badgen.net/badge/JIRA/NDD-145/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-145) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
video api가 완전히 확정되지 않을 때 잡은 스토리포인트라서 2시간으로 잡았는데
막상 작업할 때는 명세가 나온 상태여서 금방 작업할 수 있었습니다.

video api 관련 부분은 마이페이지 뿐만 아니라 성인님 작업 부분에서도 사용되는 것이라서 따로 태스크를 분리해서 빠르게 올렸습니다~

# How

## API 요청과 응답에 대한 DTO 타입 생성
- `VideoEntity` 라는 타입을 하나 생성하고, 유틸 타입을 활용해 `VideoEntity`에서 파생된 하위 Dto 타입을 생성했습니다.
- 네이밍은 `${api 요청 이름}${Res or Req}Dto` 형식으로 작성했는데 네이밍 변경 의견이 있다면 적극적으로 반영하도록 하겠습니다~

## getAPIResponseData 제네릭 인수 추가
- AxiosRequestConfig의 제네릭(D)은 요청 body의 타입입니다.
- 현재 여기에 getAPIResponseData의 제네릭 인수인 T가 넘어가도로 되어있었는데 이는 응답 객체의 타입입니다.
- 따라서 두 가지 타입을 구분해줄 필요가 있어서 제네릭 인수를 추가했습니다.
### 사용된 곳
```tsx
export const getPreSignedUrl = async (body: VideoPreSignedReqDto) => {
  return await getAPIResponseData<VideoPreSignedResDto, VideoPreSignedReqDto>({
    method: 'post',
    url: API.VIDEO_PRE_SIGNED,
    data: body,
  });
};
```

## axios 함수 네이밍에 대한 고민
questionId를 보내면 이에 대한 pre-signed url을 내려주는 post 요청 함수의 네이밍에 대한 고민을 했습니다.
일단은 서버에서 pre-signed url을 가져오는 것이라서 `getPreSignedUrl`로 정했습니다.
하지만 이 네이밍으로 인해 이 요청이 post 가 아닌 get 요청으로 오인될 여지가 있다고 판단했습니다.
그래서 이름을 변경하려고 하는데 아래 이름중에서 추천해주세요~
- createVideoUploadUrl
- generateVideoPreSignedUrl
- fetchVideoUploadLink
- getVideoUploadPresignedUrl
- requestVideoUploadUrl


# Result

- video api과 관련된 axios, react query hooks 를 모두 추가했습니다.

[NDD-145]: https://milk717.atlassian.net/browse/NDD-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ