### PR TITLE
[NDD-228]: 카테고리별 질문 조회 기능 구현 (1h / 1h) 

### DIFF
--- a/BE/src/app.entity.ts
+++ b/BE/src/app.entity.ts
@@ -22,4 +22,8 @@ export class DefaultEntity extends BaseEntity {
   static new(): DefaultEntity {
     return new DefaultEntity(undefined, new Date());
   }
+
+  getId() {
+    return this.id;
+  }
 }

--- a/BE/src/category/entity/category.ts
+++ b/BE/src/category/entity/category.ts
@@ -9,7 +9,7 @@ export class Category extends DefaultEntity {
   name: string;
 
   @ManyToOne(() => Member, { nullable: true, onDelete: 'CASCADE', eager: true })
-  @JoinColumn({ name: 'memberId' })
+  @JoinColumn({ name: 'member' })
   member: Member;
 
   constructor(id: number, name: string, member: Member, createdAt: Date) {

--- a/BE/src/category/repository/category.repository.ts
+++ b/BE/src/category/repository/category.repository.ts
@@ -34,8 +34,15 @@ export class CategoryRepository {
     await this.repository.remove(category);
   }
 
-  async findByCategoryId(categoryId) {
+  async findByCategoryId(categoryId: number) {
     return await this.repository.findOneBy({ id: categoryId });
+  }
+
+  async findByNameAndMember(name: string, memberId: number) {
+    return await this.repository.findOneBy({
+      name: name,
+      member: { id: memberId },
+    });
   }
 
   async query(query: string) {

--- a/BE/src/question/controller/question.controller.spec.ts
+++ b/BE/src/question/controller/question.controller.spec.ts
@@ -27,11 +27,13 @@ import { Question } from '../entity/question';
 import { Category } from '../../category/entity/category';
 import { CreateQuestionRequest } from '../dto/createQuestionRequest';
 import * as cookieParser from 'cookie-parser';
+import { QuestionResponseList } from '../dto/questionResponseList';
 
 describe('QuestionController', () => {
   let controller: QuestionController;
   const mockQuestionService = {
     createQuestion: jest.fn(),
+    findAllByCategory: jest.fn(),
   };
   const mockTokenService = {};
 
@@ -67,6 +69,19 @@ describe('QuestionController', () => {
         mockReqWithMemberFixture,
       ),
     ).resolves.toEqual(QuestionResponse.from(questionFixture));
+  });
+
+  it('조회시 QuestionResponseList객체를 반환한다.', async () => {
+    //given
+
+    //when
+    mockQuestionService.findAllByCategory.mockResolvedValue([
+      QuestionResponse.from(questionFixture),
+    ]);
+    //then
+    await expect(controller.findCategoryQuestions(1)).resolves.toEqual(
+      QuestionResponseList.of([QuestionResponse.from(questionFixture)]),
+    );
   });
 });
 

--- a/BE/src/question/controller/question.controller.ts
+++ b/BE/src/question/controller/question.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { QuestionService } from '../service/question.service';
 import { CreateQuestionRequest } from '../dto/createQuestionRequest';
 import { Request } from 'express';
@@ -13,6 +21,7 @@ import {
 import { createApiResponseOption } from '../../util/swagger.util';
 import { QuestionResponse } from '../dto/questionResponse';
 import { Member } from '../../member/entity/member';
+import { QuestionResponseList } from '../dto/questionResponseList';
 
 @ApiTags('question')
 @Controller('/api/question')
@@ -37,5 +46,22 @@ export class QuestionController {
       createQuestionRequest,
       req.user as Member,
     );
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: '카테고리별 질문 리스트 조회',
+  })
+  @ApiResponse(
+    createApiResponseOption(
+      200,
+      'QuestionResponse 리스트',
+      QuestionResponseList,
+    ),
+  )
+  async findCategoryQuestions(@Query('category') categoryId: number) {
+    const questionResponses =
+      await this.questionService.findAllByCategory(categoryId);
+    return QuestionResponseList.of(questionResponses);
   }
 }

--- a/BE/src/question/dto/questionResponseList.ts
+++ b/BE/src/question/dto/questionResponseList.ts
@@ -1,0 +1,13 @@
+import { QuestionResponse } from './questionResponse';
+
+export class QuestionResponseList {
+  questionResponses: QuestionResponse[];
+
+  constructor(questionResponses: QuestionResponse[]) {
+    this.questionResponses = questionResponses;
+  }
+
+  static of(questionResponses: QuestionResponse[]) {
+    return new QuestionResponseList(questionResponses);
+  }
+}

--- a/BE/src/question/exception/question.exception.ts
+++ b/BE/src/question/exception/question.exception.ts
@@ -8,7 +8,7 @@ class ContentNotFoundException extends HttpException {
 
 class NeedToFindByCategoryIdException extends HttpException {
   constructor() {
-    super('카테고리 id를 입력해주세요 합니다.', 400);
+    super('카테고리 id를 입력해주세요.', 400);
   }
 }
 

--- a/BE/src/question/exception/question.exception.ts
+++ b/BE/src/question/exception/question.exception.ts
@@ -6,4 +6,10 @@ class ContentNotFoundException extends HttpException {
   }
 }
 
-export { ContentNotFoundException };
+class NeedToFindByCategoryIdException extends HttpException {
+  constructor() {
+    super('카테고리 id를 입력해주세요 합니다.', 400);
+  }
+}
+
+export { ContentNotFoundException, NeedToFindByCategoryIdException };

--- a/BE/src/question/service/question.service.spec.ts
+++ b/BE/src/question/service/question.service.spec.ts
@@ -19,12 +19,14 @@ import { Member } from '../../member/entity/member';
 import { MemberModule } from '../../member/member.module';
 import { MemberRepository } from '../../member/repository/member.repository';
 import { memberFixture } from '../../member/fixture/member.fixture';
+import { NeedToFindByCategoryIdException } from '../exception/question.exception';
 
 describe('QuestionService', () => {
   let service: QuestionService;
 
   const mockQuestionRepository = {
     save: jest.fn(),
+    findByCategoryId: jest.fn(),
   };
 
   const mockCategoryRepository = {
@@ -73,6 +75,32 @@ describe('QuestionService', () => {
     await expect(
       service.createQuestion(createQuestionRequestFixture, memberFixture),
     ).rejects.toThrow(new CategoryNotFoundException());
+  });
+
+  // Todo: Answer API 구현시에 DefaultAnswer 까지 등록하기
+  it('카테고리 id로 질문들을 조회하면, 해당 카테고리 내부 질문들이 반환된다.', async () => {
+    //given
+
+    //when
+    mockQuestionRepository.findByCategoryId.mockResolvedValue([
+      questionFixture,
+    ]);
+
+    //then
+    await expect(service.findAllByCategory(1)).resolves.toEqual([
+      QuestionResponse.from(questionFixture),
+    ]);
+  });
+
+  it('카테고리 id가 isEmpty이면 NeedToFindByCategoryIdException을 발생시킨다..', async () => {
+    //given
+
+    //when
+
+    //then
+    await expect(service.findAllByCategory(null)).rejects.toThrow(
+      new NeedToFindByCategoryIdException(),
+    );
   });
 });
 

--- a/BE/src/question/service/question.service.spec.ts
+++ b/BE/src/question/service/question.service.spec.ts
@@ -148,4 +148,26 @@ describe('QuestionService 통합 테스트', () => {
       ),
     ).resolves.toEqual(QuestionResponse.from(questionFixture));
   });
+
+  it('카테고리의 질문을 조회하면 QuestionResponse의 배열로 반환된다.', async () => {
+    //given
+    const member = await memberRepository.save(memberFixture);
+    await categoryRepository.save(categoryFixtureWithId);
+    const response = await questionService.createQuestion(
+      createQuestionRequestFixture,
+      memberFixture,
+    );
+
+    //when
+
+    const category = await categoryRepository.findByNameAndMember(
+      categoryFixtureWithId.name,
+      member.id,
+    );
+
+    //then
+    await expect(
+      questionService.findAllByCategory(category.id),
+    ).resolves.toEqual([response]);
+  });
 });

--- a/BE/src/question/service/question.service.ts
+++ b/BE/src/question/service/question.service.ts
@@ -8,6 +8,7 @@ import { Question } from '../entity/question';
 import { Category } from '../../category/entity/category';
 import { QuestionResponse } from '../dto/questionResponse';
 import { Member } from '../../member/entity/member';
+import { NeedToFindByCategoryIdException } from '../exception/question.exception';
 
 @Injectable()
 export class QuestionService {
@@ -24,7 +25,7 @@ export class QuestionService {
       createQuestionRequest.categoryId,
     );
 
-    this.validateCreateRequest(category, createQuestionRequest.content);
+    this.validateCreateRequest(category);
 
     if (!category.isOwnedBy(member)) {
       throw new UnauthorizedException();
@@ -37,7 +38,17 @@ export class QuestionService {
     return QuestionResponse.from(question);
   }
 
-  private validateCreateRequest(category: Category, content: string) {
+  async findAllByCategory(categoryId: number) {
+    if (isEmpty(categoryId)) {
+      throw new NeedToFindByCategoryIdException();
+    }
+
+    const questions =
+      await this.questionRepository.findByCategoryId(categoryId);
+    return questions.map(QuestionResponse.from);
+  }
+
+  private validateCreateRequest(category: Category) {
     if (isEmpty(category)) {
       throw new CategoryNotFoundException();
     }

--- a/BE/src/token/strategy/access.token.strategy.ts
+++ b/BE/src/token/strategy/access.token.strategy.ts
@@ -25,7 +25,6 @@ export class AccessTokenStrategy extends PassportStrategy(Strategy, 'jwt') {
   }
 
   async validate(payload: TokenPayload) {
-    console.log(`토큰 파싱 결과 : ${payload}`);
     const id = payload.id;
     const user = await this.memberRepository.findById(id);
     if (!user) throw new InvalidTokenException(); // 회원이 조회가 되지 않았다면, 탈퇴한 회원의 token을 사용한 것이므로 유효하지 않은 토큰을 사용한 것임


### PR DESCRIPTION
[![NDD-228](https://badgen.net/badge/JIRA/NDD-228/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-228) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- 기획서상으로 카테고리별 질문을 조회할 때 ResponseList로 조회하기로 기획했다. 
    - 질문당 하나의 대표답변이 있어야 한다.
    - 질문은 질문의 id, content가 있어야 한다.
    - 대표답변은 id, content가 있어야 한다.
- 여기에서 Answer 객체가 구현되어있지 않아, QuestionList로 구현하고 후에 Answer를 구현할 때 추가하기로 했다.

# How

- 비즈니스로직에서는 repository를 통해 가져온 Question[]을 QuestionResponse[]로 반환한다. 
- 컨트롤러 로직에서는 QuestionResponse[]를 QuestionResponseList객체로 반환한다(json으로 캡슐화하기 위해)

# Result

```
// 비즈니스 로직
async findAllByCategory(categoryId: number) {
    if (isEmpty(categoryId)) {
      throw new NeedToFindByCategoryIdException();
    }

    const questions =
      await this.questionRepository.findByCategoryId(categoryId);
    return questions.map(QuestionResponse.from);
  }

//컨트롤러 로직
async findCategoryQuestions(@Query('category') categoryId: number) {
    const questionResponses =
      await this.questionService.findAllByCategory(categoryId);
    return QuestionResponseList.of(questionResponses);
  }
```

# Prize

<img width="502" alt="스크린샷 2023-11-21 13 50 15" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/bdbeeefe-b647-4aae-98f9-3dcfc2556704">
- Todo: 후에 Answer API의 객체와 리포지토리 구현시에 해당 데이터에 대한 Answer 추가 예정


[NDD-228]: https://milk717.atlassian.net/browse/NDD-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ