### PR TITLE
[NDD-193] question setting page 페이지 흐름 작성 (4h/3h)

### DIFF
--- a/FE/src/AppRouter.tsx
+++ b/FE/src/AppRouter.tsx
@@ -1,18 +1,15 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
 import LandingPage from '@/page/LandingPage';
 import InterviewSettingPage from '@page/interviewSettingPage';
 import InterviewPage from '@page/interviewPage';
 import MyPage from './page/myPage';
 import InterviewVideoPage from './page/interviewVideoPage';
-import QuestionSelectionBox from '@components/interviewSettingPage/QustionSelectionBox';
-import VideoSettingBox from './components/interviewSettingPage/VideoSettingBox';
-import RecordMethodBox from './components/interviewSettingPage/RecordMethodBox';
 import { PATH } from '@constants/path';
 import { QueryClient } from '@tanstack/react-query';
 import { createBrowserRouter, Outlet, RouterProvider } from 'react-router-dom';
 import myPageLoader from '@routes/myPageLoader';
 import invalidPathLoader from '@routes/invalidPathLoader';
 import rootLoader from '@routes/rootLoader';
-import React from 'react';
 
 const routes = ({ queryClient }: { queryClient: QueryClient }) => {
   return createBrowserRouter([
@@ -32,20 +29,6 @@ const routes = ({ queryClient }: { queryClient: QueryClient }) => {
         {
           path: PATH.INTERVIEW_SETTING,
           element: <InterviewSettingPage />,
-          children: [
-            {
-              index: true,
-              element: <QuestionSelectionBox />,
-            },
-            {
-              path: PATH.CONNECTION,
-              element: <VideoSettingBox />,
-            },
-            {
-              path: PATH.RECORD,
-              element: <RecordMethodBox />,
-            },
-          ],
         },
         {
           path: PATH.MYPAGE,
@@ -67,9 +50,7 @@ const routes = ({ queryClient }: { queryClient: QueryClient }) => {
 };
 
 const AppRouter = ({ queryClient }: { queryClient: QueryClient }) => {
-  return (
-    <RouterProvider router={routes({queryClient: queryClient})} />
-  )
-}
+  return <RouterProvider router={routes({ queryClient: queryClient })} />;
+};
 
 export default AppRouter;

--- a/FE/src/components/common/ProgressStepBar/ProgressStepBar.tsx
+++ b/FE/src/components/common/ProgressStepBar/ProgressStepBar.tsx
@@ -1,0 +1,21 @@
+import { css } from '@emotion/react';
+import { PropsWithChildren } from 'react';
+import ProgressStepBarItem from './ProgressStepBarItem';
+
+const ProgressStepBar = ({ children }: PropsWithChildren) => {
+  return (
+    <div
+      css={css`
+        display: flex;
+        gap: 0.5rem;
+        overflow-x: auto;
+      `}
+    >
+      {children}
+    </div>
+  );
+};
+
+ProgressStepBar.Item = ProgressStepBarItem;
+
+export default ProgressStepBar;

--- a/FE/src/components/common/ProgressStepBar/ProgressStepBarItem.tsx
+++ b/FE/src/components/common/ProgressStepBar/ProgressStepBarItem.tsx
@@ -1,0 +1,37 @@
+import Typography from '@/components/foundation/Typography/Typography';
+import { theme } from '@/styles/theme';
+import { HTMLElementTypes } from '@/types/utils';
+import { css } from '@emotion/react';
+
+type ProgressStepBarItemProps = {
+  name?: string;
+  isCompleted?: boolean;
+} & HTMLElementTypes<HTMLDivElement>;
+
+const ProgressStepBarItem: React.FC<ProgressStepBarItemProps> = ({
+  name,
+  isCompleted,
+}) => {
+  return (
+    <div
+      css={css`
+        width: 100%;
+        text-align: center;
+      `}
+    >
+      <div
+        css={css`
+          height: 0.625rem;
+          border-radius: 1.25rem;
+          background-color: ${isCompleted
+            ? theme.colors.point.primary.default
+            : theme.colors.surface.weak};
+          margin-bottom: 1rem;
+        `}
+      ></div>
+      <Typography>{name}</Typography>
+    </div>
+  );
+};
+
+export default ProgressStepBarItem;

--- a/FE/src/components/foundation/StepPages/Step.tsx
+++ b/FE/src/components/foundation/StepPages/Step.tsx
@@ -1,0 +1,21 @@
+import { css } from '@emotion/react';
+
+type StepProps<T> = {
+  page: T;
+  path: T;
+  children: React.ReactNode;
+};
+
+const Step = <T,>({ page, children, path }: StepProps<T>) => {
+  return (
+    <div
+      css={css`
+        display: ${page === path ? 'block' : 'none'};
+      `}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Step;

--- a/FE/src/components/foundation/StepPages/index.tsx
+++ b/FE/src/components/foundation/StepPages/index.tsx
@@ -1,0 +1,25 @@
+import enhanceChildElement from '@/utils/enhanceChildElement';
+import Step from './Step';
+
+type StepPageProps<T> = {
+  page: T;
+  children?: React.ReactNode;
+};
+
+const StepPage = <T,>({ page, children }: StepPageProps<T>) => {
+  return (
+    <div>
+      {enhanceChildElement({
+        children,
+        component: Step<T>,
+        newProps: {
+          page,
+        },
+      })}
+    </div>
+  );
+};
+
+StepPage.step = Step;
+
+export default StepPage;

--- a/FE/src/components/interviewSettingPage/QustionSelectionBox.tsx
+++ b/FE/src/components/interviewSettingPage/QustionSelectionBox.tsx
@@ -1,6 +1,20 @@
 import Box from '@foundation/Box/Box';
+import Button from '../foundation/Button/Button';
 
-const QuestionSelectionBox: React.FC = () => {
-  return <Box>여기에는 Question Box가 들어갑니다</Box>;
+type QuestionSelectionBoxProps = {
+  onNextClick?: () => void;
+  onPrevClick?: () => void;
+};
+
+const QuestionSelectionBox: React.FC<QuestionSelectionBoxProps> = ({
+  onNextClick,
+  onPrevClick,
+}) => {
+  return (
+    <Box>
+      여기에는 Question Box가 들어갑니다
+      <Button onClick={onNextClick}>다음</Button>
+    </Box>
+  );
 };
 export default QuestionSelectionBox;

--- a/FE/src/components/interviewSettingPage/QustionSelectionBox.tsx
+++ b/FE/src/components/interviewSettingPage/QustionSelectionBox.tsx
@@ -12,6 +12,7 @@ const QuestionSelectionBox: React.FC<QuestionSelectionBoxProps> = ({
 }) => {
   return (
     <Box>
+      <Button onClick={onPrevClick}>이전</Button>
       여기에는 Question Box가 들어갑니다
       <Button onClick={onNextClick}>다음</Button>
     </Box>

--- a/FE/src/components/interviewSettingPage/RecordMethodBox.tsx
+++ b/FE/src/components/interviewSettingPage/RecordMethodBox.tsx
@@ -12,7 +12,8 @@ const RecordMethodBox: React.FC<RecordMethodBoxProps> = ({
 }) => {
   return (
     <Box>
-      SaveMethodBox 입니다 <Button onClick={onNextClick}>다음</Button>
+      <Button onClick={onPrevClick}>이전</Button>SaveMethodBox 입니다{' '}
+      <Button onClick={onNextClick}>다음</Button>
     </Box>
   );
 };

--- a/FE/src/components/interviewSettingPage/RecordMethodBox.tsx
+++ b/FE/src/components/interviewSettingPage/RecordMethodBox.tsx
@@ -1,6 +1,19 @@
 import Box from '@foundation/Box/Box';
+import Button from '@foundation/Button/Button';
 
-const RecordMethodBox: React.FC = () => {
-  return <Box>SaveMethodBox 입니다</Box>;
+type RecordMethodBoxProps = {
+  onNextClick?: () => void;
+  onPrevClick?: () => void;
+};
+
+const RecordMethodBox: React.FC<RecordMethodBoxProps> = ({
+  onNextClick,
+  onPrevClick,
+}) => {
+  return (
+    <Box>
+      SaveMethodBox 입니다 <Button onClick={onNextClick}>다음</Button>
+    </Box>
+  );
 };
 export default RecordMethodBox;

--- a/FE/src/components/interviewSettingPage/VideoSettingBox.tsx
+++ b/FE/src/components/interviewSettingPage/VideoSettingBox.tsx
@@ -12,7 +12,9 @@ const VideoSettingBox: React.FC<VideoBoxProps> = ({
 }) => {
   return (
     <Box>
-      videoSettionBox 입니다 <Button onClick={onNextClick}>다음</Button>
+      <Button onClick={onPrevClick}>이전</Button>
+      videoSettionBox 입니다
+      <Button onClick={onNextClick}>다음</Button>
     </Box>
   );
 };

--- a/FE/src/components/interviewSettingPage/VideoSettingBox.tsx
+++ b/FE/src/components/interviewSettingPage/VideoSettingBox.tsx
@@ -1,6 +1,19 @@
 import Box from '@foundation/Box/Box';
+import Button from '@foundation/Button/Button';
 
-const VideoSettingBox: React.FC = () => {
-  return <Box>videoSettionBox 입니다</Box>;
+type VideoBoxProps = {
+  onNextClick?: () => void;
+  onPrevClick?: () => void;
+};
+
+const VideoSettingBox: React.FC<VideoBoxProps> = ({
+  onNextClick,
+  onPrevClick,
+}) => {
+  return (
+    <Box>
+      videoSettionBox 입니다 <Button onClick={onNextClick}>다음</Button>
+    </Box>
+  );
 };
 export default VideoSettingBox;

--- a/FE/src/constants/path.ts
+++ b/FE/src/constants/path.ts
@@ -3,6 +3,7 @@ const SETTING = 'setting';
 const CONNECTION = 'connection';
 const RECORD = 'record';
 const MYPAGE = 'mypage';
+const QUESTION = 'question';
 
 export const PATH = {
   ROOT: '/',
@@ -11,7 +12,11 @@ export const PATH = {
   INTERVIEW_SETTING_CONNECTION: `/${INTERVIEW}/${SETTING}/${CONNECTION}`,
   INTERVIEW_SETTING_RECORD: `/${INTERVIEW}/${SETTING}/${RECORD}`,
   MYPAGE: `/${MYPAGE}`,
+  INTERVIEW_VIDEO: `/${INTERVIEW}/:videoId`,
+};
+
+export const SETTING_PATH = {
   CONNECTION: `${CONNECTION}`,
   RECORD: `${RECORD}`,
-  INTERVIEW_VIDEO: `/${INTERVIEW}/:videoId`,
+  QUESTION: `${QUESTION}`,
 };

--- a/FE/src/page/interviewSettingPage/index.tsx
+++ b/FE/src/page/interviewSettingPage/index.tsx
@@ -1,66 +1,53 @@
 import InterviewSettingPageLayout from '@/components/interviewSettingPage/InterviewSettingPageLayout';
-import { css } from '@emotion/react';
-import { Outlet, useLocation, useNavigate } from 'react-router-dom';
-import SettingProgressBar from '@/components/interviewSettingPage/SettingProgressBar';
-import Description from '@/components/interviewSettingPage/Description';
-import Button from '@/components/foundation/Button/Button';
-import { PATH } from '@constants/path';
+import { useSearchParams } from 'react-router-dom';
+import QuestionSelectionBox from '@/components/interviewSettingPage/QustionSelectionBox';
+import { PATH } from '@/constants/path';
+import VideoSettingBox from '@/components/interviewSettingPage/VideoSettingBox';
+import RecordMethodBox from '@/components/interviewSettingPage/RecordMethodBox';
+import StepPage from '@/components/foundation/StepPages';
 
 const InterviewSettingPage: React.FC = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
+  const data = [
+    {
+      name: '문제 선택',
+      path: 'question',
+      page: (
+        <QuestionSelectionBox
+          onNextClick={() => changeSearchParams(PATH.CONNECTION)}
+        />
+      ),
+    },
+    {
+      name: '화면과 소리설정',
+      path: PATH.CONNECTION,
+      page: <VideoSettingBox />,
+    },
+    {
+      name: '녹화 설정',
+      path: PATH.RECORD,
+      page: <RecordMethodBox />,
+    },
+  ];
 
-  function navigateNext() {
-    switch (location.pathname) {
-      case PATH.INTERVIEW_SETTING:
-        navigate(PATH.INTERVIEW_SETTING_CONNECTION);
-        break;
-      case PATH.INTERVIEW_SETTING_CONNECTION:
-        navigate(PATH.INTERVIEW_SETTING_RECORD);
-        break;
-      case PATH.INTERVIEW_SETTING_RECORD:
-        navigate(PATH.INTERVIEW);
-        break;
-      default:
-        navigate(PATH.ROOT);
-        break;
-    }
-  }
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  function navigatePrev() {
-    switch (location.pathname) {
-      case PATH.INTERVIEW_SETTING:
-        navigate(PATH.ROOT);
-        break;
-      case PATH.INTERVIEW_SETTING_CONNECTION:
-        navigate(PATH.INTERVIEW_SETTING);
-        break;
-      case PATH.INTERVIEW_SETTING_RECORD:
-        navigate(PATH.INTERVIEW_SETTING_CONNECTION);
-        break;
-      default:
-        navigate(PATH.ROOT);
-        break;
-    }
-  }
+  const changeSearchParams = (newPage: string) => {
+    const newSearchParams = new URLSearchParams(searchParams);
+    newSearchParams.set('page', newPage);
+    setSearchParams(newSearchParams);
+  };
+
+  const currentPage = searchParams.get('page');
 
   return (
     <InterviewSettingPageLayout>
-      <SettingProgressBar />
-      <Description />
-      <Outlet />
-      <div
-        css={css`
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          border: 1px solid red;
-          gap: 1.25rem;
-        `}
-      >
-        <Button onClick={navigatePrev}>이전</Button>
-        <Button onClick={navigateNext}>다음</Button>
-      </div>
+      <StepPage page={currentPage}>
+        {data.map((item) => (
+          <StepPage.step key={item.path} path={item.path} page={currentPage}>
+            {item.page}
+          </StepPage.step>
+        ))}
+      </StepPage>
     </InterviewSettingPageLayout>
   );
 };

--- a/FE/src/page/interviewSettingPage/index.tsx
+++ b/FE/src/page/interviewSettingPage/index.tsx
@@ -15,7 +15,7 @@ import { useRecoilValue } from 'recoil';
 
 const InterviewSettingPage: React.FC = () => {
   const navigate = useNavigate();
-  const data = [
+  const pageInfo = [
     {
       name: '문제 선택',
       path: SETTING_PATH.QUESTION,
@@ -50,7 +50,7 @@ const InterviewSettingPage: React.FC = () => {
       state: useRecoilValue(recordSetting),
     },
   ];
-  const validPagePaths = data.map((item) => item.path);
+  const validPagePaths = pageInfo.map((item) => item.path);
 
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -70,7 +70,7 @@ const InterviewSettingPage: React.FC = () => {
   return (
     <InterviewSettingPageLayout>
       <ProgressStepBar>
-        {data.map((item) => (
+        {pageInfo.map((item) => (
           <ProgressStepBar.Item
             key={item.name}
             name={item.name}
@@ -79,7 +79,7 @@ const InterviewSettingPage: React.FC = () => {
         ))}
       </ProgressStepBar>
       <StepPage page={currentPage}>
-        {data.map((item) => (
+        {pageInfo.map((item) => (
           <StepPage.step key={item.path} path={item.path} page={currentPage}>
             {item.page}
           </StepPage.step>

--- a/FE/src/page/interviewSettingPage/index.tsx
+++ b/FE/src/page/interviewSettingPage/index.tsx
@@ -1,33 +1,49 @@
 import InterviewSettingPageLayout from '@/components/interviewSettingPage/InterviewSettingPageLayout';
-import { useSearchParams } from 'react-router-dom';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import QuestionSelectionBox from '@/components/interviewSettingPage/QustionSelectionBox';
-import { PATH } from '@/constants/path';
+import { SETTING_PATH } from '@/constants/path';
 import VideoSettingBox from '@/components/interviewSettingPage/VideoSettingBox';
 import RecordMethodBox from '@/components/interviewSettingPage/RecordMethodBox';
 import StepPage from '@/components/foundation/StepPages';
+import ProgressStepBar from '@/components/common/ProgressStepBar/ProgressStepBar';
+import {
+  questionSetting,
+  recordSetting,
+  videoSetting,
+} from '@/atoms/interviewSetting';
+import { useRecoilValue } from 'recoil';
 
 const InterviewSettingPage: React.FC = () => {
+  const navigate = useNavigate();
   const data = [
     {
       name: '문제 선택',
-      path: 'question',
+      path: SETTING_PATH.QUESTION,
       page: (
         <QuestionSelectionBox
-          onNextClick={() => changeSearchParams(PATH.CONNECTION)}
+          onNextClick={() => changeSearchParams(SETTING_PATH.CONNECTION)}
         />
       ),
+      state: useRecoilValue(questionSetting),
     },
     {
       name: '화면과 소리설정',
-      path: PATH.CONNECTION,
-      page: <VideoSettingBox />,
+      path: SETTING_PATH.CONNECTION,
+      page: (
+        <VideoSettingBox
+          onNextClick={() => changeSearchParams(SETTING_PATH.RECORD)}
+        />
+      ),
+      state: useRecoilValue(videoSetting),
     },
     {
       name: '녹화 설정',
-      path: PATH.RECORD,
-      page: <RecordMethodBox />,
+      path: SETTING_PATH.RECORD,
+      page: <RecordMethodBox onNextClick={() => navigate('/interview')} />,
+      state: useRecoilValue(recordSetting),
     },
   ];
+  const validPagePaths = data.map((item) => item.path);
 
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -36,11 +52,25 @@ const InterviewSettingPage: React.FC = () => {
     newSearchParams.set('page', newPage);
     setSearchParams(newSearchParams);
   };
+  // TODO: 로직이 더 길어지면 hook으로 분리해도 나쁘지 않을듯
 
   const currentPage = searchParams.get('page');
 
+  if (!currentPage || !validPagePaths.includes(currentPage)) {
+    return <Navigate to={`?page=${SETTING_PATH.QUESTION}`} replace />;
+  }
+
   return (
     <InterviewSettingPageLayout>
+      <ProgressStepBar>
+        {data.map((item) => (
+          <ProgressStepBar.Item
+            key={item.name}
+            name={item.name}
+            isCompleted={item.state.isSuccess || currentPage === item.path}
+          ></ProgressStepBar.Item>
+        ))}
+      </ProgressStepBar>
       <StepPage page={currentPage}>
         {data.map((item) => (
           <StepPage.step key={item.path} path={item.path} page={currentPage}>

--- a/FE/src/page/interviewSettingPage/index.tsx
+++ b/FE/src/page/interviewSettingPage/index.tsx
@@ -21,6 +21,7 @@ const InterviewSettingPage: React.FC = () => {
       path: SETTING_PATH.QUESTION,
       page: (
         <QuestionSelectionBox
+          onPrevClick={() => navigate('/')}
           onNextClick={() => changeSearchParams(SETTING_PATH.CONNECTION)}
         />
       ),
@@ -31,6 +32,7 @@ const InterviewSettingPage: React.FC = () => {
       path: SETTING_PATH.CONNECTION,
       page: (
         <VideoSettingBox
+          onPrevClick={() => changeSearchParams(SETTING_PATH.QUESTION)}
           onNextClick={() => changeSearchParams(SETTING_PATH.RECORD)}
         />
       ),
@@ -39,7 +41,12 @@ const InterviewSettingPage: React.FC = () => {
     {
       name: '녹화 설정',
       path: SETTING_PATH.RECORD,
-      page: <RecordMethodBox onNextClick={() => navigate('/interview')} />,
+      page: (
+        <RecordMethodBox
+          onPrevClick={() => changeSearchParams(SETTING_PATH.CONNECTION)}
+          onNextClick={() => navigate('/interview')}
+        />
+      ),
       state: useRecoilValue(recordSetting),
     },
   ];
@@ -50,7 +57,7 @@ const InterviewSettingPage: React.FC = () => {
   const changeSearchParams = (newPage: string) => {
     const newSearchParams = new URLSearchParams(searchParams);
     newSearchParams.set('page', newPage);
-    setSearchParams(newSearchParams);
+    setSearchParams(newSearchParams, { replace: true });
   };
   // TODO: 로직이 더 길어지면 hook으로 분리해도 나쁘지 않을듯
 


### PR DESCRIPTION
[![NDD-193](https://badgen.net/badge/JIRA/NDD-193/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-193) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

작업자체의 난이도는 적었지만 기존에 사용하려고 했던 방식에 대해서 쓸모없어졌다를 깨닫고 난후에 어떻게 해야할지에 대한 고민이 많았습니다. 관련내용은 HOW에서 풀도록 하겠습니다.

# How

지금과 같이 queryString을 이용한 토스의 useFunnel을 채택한 것은 다음과 같았습니다. 
1. 페이지의 흐름을 마음대로 조절할 수 있다.
2. react-router-dom과의 의존성을 끊을 수 있다.
3. 페이지 내부에서는 설정 자체에 대한 흐름만 관심사를 두고 실제 페이지 내에서 어떤 일을 할 것인지에 대한 내용은 페이지 내부에서 정의하면된다.

그런데 코드를 짜다 보니 고려를 못한 부분이 있었습니다. 바로 우리의 세팅 페이지는 단방향으로 무조건 step이 있다는 것이죠 즉 1번의 페이지의 흐름을 마음대로 조절하는것이 아니라 이미 고정된 값을 사용해야 한다는 점입니다.

이는 다시말하면 react-router-dom과의 의존성을 가져도 상관이 없다는 것인데요. 흐름이 필요가 없으니 path만 정의해 둔다면 똑같은 흐름으로 정의할 수 있습니다. 진행 순서의 경우에는 children 순서대로 진행이 되게끔 저희끼리 규칙을 잡아 놓는다면 어떻게 추가해도 상관이 없는것이죠.

하지만 그럼에도 불구하고 제가 지금 방법을 사용한 이유는 progress setting bar 때문입니다.

progress setting bar안에는 설정 상태에 따라 색이 바뀌는 UI가 있어야 합니다 (아직 구현은 안되었지만) 만약에 페이지가 react-router-dom으로 관리가 된다면 해당 컴포넌트는 페이지 내부로 들어갈 것인데 이러면 해당 progress setting bar 컴포넌트는 어떤 페이지가 어떤게 있는지 알지 못합니다. 그래서 어떤것을 랜더링 해주야 할지 모르죠  이는 페이지 수정 사항이 있으면 progress stting bar와 페이지를 추가하는 변경점이 2개있고 관심사가 같은데요 응집도가 낮아진다는 단점이 있습니다.

하지만 페이지를 하나의 컴포넌트에서 지금과 같은 형태로 관리한다면 progress setting bar 컴포넌트는 어떤 페이지가 내부에 있는지 알며 응집도를 높일 수 있습니다.


``` tsx
      <ProgressStepBar>
        {data.map((item) => (
          <ProgressStepBar.Item
            key={item.name}
            name={item.name}
            isCompleted={item.state.isSuccess || currentPage === item.path}
          ></ProgressStepBar.Item>
        ))}
      </ProgressStepBar>

```
단순히 이렇게 작성하는것 만으로도 bar내부의 item 하나 하나를 컨트롤 할 수 있고 페이지를 추가하더라도 자동적으로 추가가 되게끔 작동을 합니다.

## 포인트1
현재 페이지 이동은 전부 replace true로 처리해 두어서 세팅 페이지에서 뒤로 가기시 이전 세팅으로 넘어가지 않습니다. 제 생각에는 이전 다음 다음 이전 등등으로 history 스텍을 쌓는것 보다는 뭔가 하나의 history로 관리하는게 좋다고 생각해서 일단 이렇게 작성하였습니다. 

이런식 입니다.

https://github.com/boostcampwm2023/web14-gomterview/assets/49224104/9a2a8e17-63fa-4bf5-8332-6a2618e44244


## 포인트 2
StepPage 와 같은 컴포넌트는 뭔가 Tabs랑 비슷한 기능을 지니고 있지만 Tabs는 내부의 상태를 사용하고 있고 StepPage는 외부의 상태에 따라서 내부가 랜더링이 되게끔 수행하는 동작을 합니다. 뭔가 합칠라면 합칠 수 있을것 같기는 한데 일단은 그냥 내비두고 새로 만든 컴포넌트 입니다.


## 이번 테스크 에서 고려하지 않는 사항
- 설정페이지 라우팅 처리: 쿼리스트링이 지정해놓은것과 다를 경우는 라우팅 처리가 되었지만 이전 step이 완료되지 않았으면 다음페이지로 넘어가는것을 막는건 아직 구현이 안되었습니다

- 페이지 내부는 테스트를 위해서 남겨둔 것으로 페이지를 완성하는 작업에서 전부 바뀔 예정입니다. 아마 코드자체가 중복된 부분들이 많은데 이는 아직 어떻게 뺄지 생각하지 못한 부분들입니다.


# Result

https://github.com/boostcampwm2023/web14-gomterview/assets/49224104/9721dbfb-5697-4c4b-8ba0-295775db09bc

[NDD-193]: https://milk717.atlassian.net/browse/NDD-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## 추가로 알아야 할 사항
보다보니 코드 스타일이나 리펙토링 해야할것들이 슬슬 보이기 시작하는데요 제가 봤을때 필요하다 싶은것들은 백로그에 하나 작성했으니 본문에 쭉 추가하는 식으로 작성해서 토요일에 맞춰보면 좋을것 같아요.
코드 작성하다 이거 소소하지만 맞춰봐야지 or 이거 리펙토링 했으면 좋겠다 이런부분들 추가해 주세요
https://milk717.atlassian.net/browse/NDD-234?atlOrigin=eyJpIjoiMTI1ZjU4YWYyMjY5NGZhMThhODlkMzE2MTlkMDQ5NGQiLCJwIjoiaiJ9