### PR TITLE
[NDD-183]: Video API Controller 단위 테스트 (3h / 3h)

### DIFF
--- a/BE/src/config/idrive.config.ts
+++ b/BE/src/config/idrive.config.ts
@@ -1,4 +1,5 @@
 import * as AWS from 'aws-sdk';
+import 'dotenv/config';
 
 export const IDRIVE_CONFIG = {
   endpoint: new AWS.Endpoint(process.env.IDRIVE_ENDPOINT),

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -430,4 +430,67 @@ describe('VideoController 단위 테스트', () => {
       }).rejects.toThrow(EncryptionException);
     });
   });
+
+  describe('deleteVideo', () => {
+    const member = mockReqWithMemberFixture;
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    } as unknown as Response;
+
+    it('비디오 삭제 성공 시 undefined를 반환한다.', async () => {
+      //given
+
+      //when
+      mockVideoService.deleteVideo.mockResolvedValue(undefined);
+
+      //then
+      await expect(
+        controller.deleteVideo(1, member, response),
+      ).resolves.toBeUndefined();
+    });
+
+    it('비디오 삭제 시 회원 객체가 없으면 ManipulatedTokenNotFilteredException을 반환한다.', async () => {
+      //given
+      const nullMember = { user: null } as unknown as Request;
+
+      //when
+      mockVideoService.deleteVideo.mockRejectedValue(
+        new ManipulatedTokenNotFiltered(),
+      );
+
+      //then
+      await expect(async () => {
+        await controller.deleteVideo(1, nullMember, response);
+      }).rejects.toThrow(ManipulatedTokenNotFiltered);
+    });
+
+    it('비디오 삭제 시 해당 비디오가 이미 삭제되었다면 VideoNotFoundException를 반환한다.', async () => {
+      // given
+
+      // when
+      mockVideoService.deleteVideo.mockRejectedValue(
+        new VideoNotFoundException(),
+      );
+
+      // then
+      await expect(async () => {
+        await controller.deleteVideo(1, member, response);
+      }).rejects.toThrow(VideoNotFoundException);
+    });
+
+    it('비디오 삭제 시 다른 회원의 비디오를 조회하려 한다면 VideoAccessForbiddenException를 반환한다.', async () => {
+      // given
+
+      // when
+      mockVideoService.deleteVideo.mockRejectedValue(
+        new VideoAccessForbiddenException(),
+      );
+
+      // then
+      await expect(async () => {
+        await controller.deleteVideo(1, member, response);
+      }).rejects.toThrow(VideoAccessForbiddenException);
+    });
+  });
 });

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -65,7 +65,7 @@ describe('VideoController 단위 테스트', () => {
       mockVideoService.createVideo.mockResolvedValue(undefined);
 
       //then
-      await expect(
+      expect(
         controller.createVideo(mockReqWithMemberFixture, createVideoRequest),
       ).resolves.toBeUndefined();
     });
@@ -80,9 +80,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       //then
-      await expect(async () => {
-        await controller.createVideo(member, createVideoRequest);
-      }).rejects.toThrow(ManipulatedTokenNotFiltered);
+      expect(
+        controller.createVideo(member, createVideoRequest),
+      ).rejects.toThrow(ManipulatedTokenNotFiltered);
     });
   });
 
@@ -115,12 +115,12 @@ describe('VideoController 단위 테스트', () => {
       mockVideoService.getPreSignedUrl.mockRejectedValue(new IDriveException());
 
       // then
-      await expect(async () => {
-        await controller.getPreSignedUrl(
+      expect(
+        controller.getPreSignedUrl(
           mockReqWithMemberFixture,
           createPreSignedUrlRequest,
-        );
-      }).rejects.toThrow(IDriveException);
+        ),
+      ).rejects.toThrow(IDriveException);
     });
 
     it('Pre-Signed URL 생성 시 회원 객체가 없으면 ManipulatedTokenNotFilteredException을 반환한다.', async () => {
@@ -133,9 +133,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.getPreSignedUrl(member, createPreSignedUrlRequest);
-      }).rejects.toThrow(ManipulatedTokenNotFiltered);
+      expect(
+        controller.getPreSignedUrl(member, createPreSignedUrlRequest),
+      ).rejects.toThrow(ManipulatedTokenNotFiltered);
     });
   });
 
@@ -185,9 +185,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.getAllVideo(member);
-      }).rejects.toThrow(ManipulatedTokenNotFiltered);
+      expect(controller.getAllVideo(member)).rejects.toThrow(
+        ManipulatedTokenNotFiltered,
+      );
     });
   });
 
@@ -220,9 +220,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.getVideoDetailByHash(hash);
-      }).rejects.toThrow(VideoAccessForbiddenException);
+      expect(controller.getVideoDetailByHash(hash)).rejects.toThrow(
+        VideoAccessForbiddenException,
+      );
     });
 
     it('해시로 비디오 조회 시 복호화에 실패하면 DecryptionException을 반환한다.', async () => {
@@ -234,9 +234,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.getVideoDetailByHash(hash);
-      }).rejects.toThrow(DecryptionException);
+      expect(controller.getVideoDetailByHash(hash)).rejects.toThrow(
+        DecryptionException,
+      );
     });
   });
 
@@ -288,9 +288,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.getVideoDetail(1, member);
-      }).rejects.toThrow(ManipulatedTokenNotFiltered);
+      expect(controller.getVideoDetail(1, member)).rejects.toThrow(
+        ManipulatedTokenNotFiltered,
+      );
     });
 
     it('비디오 상세 정보 조회 시 해당 비디오가 삭제되었다면 VideoNotFoundException를 반환한다.', async () => {
@@ -302,9 +302,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.getVideoDetail(1, mockReq);
-      }).rejects.toThrow(VideoNotFoundException);
+      expect(controller.getVideoDetail(1, mockReq)).rejects.toThrow(
+        VideoNotFoundException,
+      );
     });
 
     it('비디오 상세 정보 조회 시 다른 회원의 비디오를 조회하려 한다면 VideoAccessForbiddenException를 반환한다.', async () => {
@@ -316,9 +316,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.getVideoDetail(1, mockReq);
-      }).rejects.toThrow(VideoAccessForbiddenException);
+      expect(controller.getVideoDetail(1, mockReq)).rejects.toThrow(
+        VideoAccessForbiddenException,
+      );
     });
 
     it('비디오 상세 정보 조회 시 암호화에 실패하면 EncryptionException을 반환한다.', async () => {
@@ -330,9 +330,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.getVideoDetail(1, mockReq);
-      }).rejects.toThrow(EncryptionException);
+      expect(controller.getVideoDetail(1, mockReq)).rejects.toThrow(
+        EncryptionException,
+      );
     });
   });
 
@@ -383,9 +383,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.toggleVideoStatus(1, nullMember);
-      }).rejects.toThrow(ManipulatedTokenNotFiltered);
+      expect(controller.toggleVideoStatus(1, nullMember)).rejects.toThrow(
+        ManipulatedTokenNotFiltered,
+      );
     });
 
     it('비디오 상세 정보 조회 시 해당 비디오가 삭제되었다면 VideoNotFoundException를 반환한다.', async () => {
@@ -397,9 +397,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.toggleVideoStatus(1, member);
-      }).rejects.toThrow(VideoNotFoundException);
+      expect(controller.toggleVideoStatus(1, member)).rejects.toThrow(
+        VideoNotFoundException,
+      );
     });
 
     it('비디오 상세 정보 조회 시 다른 회원의 비디오를 조회하려 한다면 VideoAccessForbiddenException를 반환한다.', async () => {
@@ -411,9 +411,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.toggleVideoStatus(1, member);
-      }).rejects.toThrow(VideoAccessForbiddenException);
+      expect(controller.toggleVideoStatus(1, member)).rejects.toThrow(
+        VideoAccessForbiddenException,
+      );
     });
 
     it('비디오 상세 정보 조회 시 암호화에 실패하면 EncryptionException을 반환한다.', async () => {
@@ -425,9 +425,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.toggleVideoStatus(1, member);
-      }).rejects.toThrow(EncryptionException);
+      expect(controller.toggleVideoStatus(1, member)).rejects.toThrow(
+        EncryptionException,
+      );
     });
   });
 
@@ -445,7 +445,7 @@ describe('VideoController 단위 테스트', () => {
       mockVideoService.deleteVideo.mockResolvedValue(undefined);
 
       //then
-      await expect(
+      expect(
         controller.deleteVideo(1, member, response),
       ).resolves.toBeUndefined();
     });
@@ -460,9 +460,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       //then
-      await expect(async () => {
-        await controller.deleteVideo(1, nullMember, response);
-      }).rejects.toThrow(ManipulatedTokenNotFiltered);
+      expect(controller.deleteVideo(1, nullMember, response)).rejects.toThrow(
+        ManipulatedTokenNotFiltered,
+      );
     });
 
     it('비디오 삭제 시 해당 비디오가 이미 삭제되었다면 VideoNotFoundException를 반환한다.', async () => {
@@ -474,9 +474,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.deleteVideo(1, member, response);
-      }).rejects.toThrow(VideoNotFoundException);
+      expect(controller.deleteVideo(1, member, response)).rejects.toThrow(
+        VideoNotFoundException,
+      );
     });
 
     it('비디오 삭제 시 다른 회원의 비디오를 조회하려 한다면 VideoAccessForbiddenException를 반환한다.', async () => {
@@ -488,9 +488,9 @@ describe('VideoController 단위 테스트', () => {
       );
 
       // then
-      await expect(async () => {
-        await controller.deleteVideo(1, member, response);
-      }).rejects.toThrow(VideoAccessForbiddenException);
+      expect(controller.deleteVideo(1, member, response)).rejects.toThrow(
+        VideoAccessForbiddenException,
+      );
     });
   });
 });

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -238,4 +238,101 @@ describe('VideoController 단위 테스트', () => {
       }).rejects.toThrow(DecryptionException);
     });
   });
+
+  describe('getVideoDetail', () => {
+    const mockReq = mockReqWithMemberFixture;
+    const hash = 'fakeHash';
+    const video = videoFixtureForTest;
+
+    it('비디오 상세 정보 조회 성공 시 VideoDetailResponse 객체 형태로 응답된다.', async () => {
+      // given
+
+      // when
+      const mockVideoDetailWithHash = VideoDetailResponse.from(video, hash);
+      mockVideoService.getVideoDetail.mockResolvedValue(
+        mockVideoDetailWithHash,
+      );
+
+      // then
+      const result = await controller.getVideoDetail(1, mockReq);
+
+      expect(result).toBeInstanceOf(VideoDetailResponse);
+      expect(result).toBe(mockVideoDetailWithHash);
+    });
+
+    it('비디오 상세 정보 조회 성공 시 비디오가 private이라면 VideoDetailResponse의 hash는 null로 설정되어 반환한다.', async () => {
+      // given
+      const nullHash = null;
+
+      // when
+      const mockVideoDetailWithHash = VideoDetailResponse.from(video, nullHash);
+      mockVideoService.getVideoDetail.mockResolvedValue(
+        mockVideoDetailWithHash,
+      );
+
+      // then
+      const result = await controller.getVideoDetail(1, mockReq);
+
+      expect(result).toBeInstanceOf(VideoDetailResponse);
+      expect(result).toBe(mockVideoDetailWithHash);
+      expect(result.hash).toBe(nullHash);
+    });
+
+    it('비디오 상세 정보 조회 시 회원 객체가 없으면 ManipulatedTokenNotFilteredException을 반환한다.', async () => {
+      // given
+      const member = { user: null } as unknown as Request;
+
+      // when
+      mockVideoService.getVideoDetail.mockRejectedValue(
+        new ManipulatedTokenNotFiltered(),
+      );
+
+      // then
+      await expect(async () => {
+        await controller.getVideoDetail(1, member);
+      }).rejects.toThrow(ManipulatedTokenNotFiltered);
+    });
+
+    it('비디오 상세 정보 조회 시 해당 비디오가 삭제되었다면 VideoNotFoundException를 반환한다.', async () => {
+      // given
+
+      // when
+      mockVideoService.getVideoDetail.mockRejectedValue(
+        new VideoNotFoundException(),
+      );
+
+      // then
+      await expect(async () => {
+        await controller.getVideoDetail(1, mockReq);
+      }).rejects.toThrow(VideoNotFoundException);
+    });
+
+    it('비디오 상세 정보 조회 시 다른 회원의 비디오를 조회하려 한다면 VideoAccessForbiddenException를 반환한다.', async () => {
+      // given
+
+      // when
+      mockVideoService.getVideoDetail.mockRejectedValue(
+        new VideoAccessForbiddenException(),
+      );
+
+      // then
+      await expect(async () => {
+        await controller.getVideoDetail(1, mockReq);
+      }).rejects.toThrow(VideoAccessForbiddenException);
+    });
+
+    it('비디오 상세 정보 조회 시 암호화에 실패하면 EncryptionException을 반환한다.', async () => {
+      // given
+
+      // when
+      mockVideoService.getVideoDetail.mockRejectedValue(
+        new EncryptionException(),
+      );
+
+      // then
+      await expect(async () => {
+        await controller.getVideoDetail(1, mockReq);
+      }).rejects.toThrow(EncryptionException);
+    });
+  });
 });

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -1,0 +1,127 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { VideoController } from './video.controller';
+import { VideoService } from '../service/video.service';
+import { mockReqWithMemberFixture } from 'src/member/fixture/member.fixture';
+import { CreateVideoRequest } from '../dto/createVideoRequest';
+import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
+import { Request } from 'express';
+import { CreatePreSignedUrlRequest } from '../dto/createPreSignedUrlRequest';
+import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
+import { IDriveException } from '../exception/video.exception';
+
+describe('VideoController', () => {
+  let controller: VideoController;
+
+  const mockVideoService = {
+    createVideo: jest.fn(),
+    getPreSignedUrl: jest.fn(),
+    getVideoDetail: jest.fn(),
+    getVideoDetailByHash: jest.fn(),
+    toggleVmideoStatus: jest.fn(),
+    deleteVideo: jest.fn(),
+  };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [VideoController],
+      providers: [VideoService],
+    })
+      .overrideProvider(VideoService)
+      .useValue(mockVideoService)
+      .compile();
+
+    controller = module.get<VideoController>(VideoController);
+  });
+
+  it('videoController should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('createVideo', () => {
+    const createVideoRequest = new CreateVideoRequest(
+      1,
+      'test.webm',
+      'https://test.com',
+    );
+
+    it('비디오 저장 성공 시 undefined를 반환한다.', async () => {
+      //given
+
+      //when
+      mockVideoService.createVideo.mockResolvedValue(undefined);
+
+      //then
+      await expect(
+        controller.createVideo(mockReqWithMemberFixture, createVideoRequest),
+      ).resolves.toBeUndefined();
+    });
+
+    it('비디오 저장시 회원 객체가 없으면 ManipulatedTokenNotFilteredException을 반환한다.', async () => {
+      //given
+      const member = { user: null } as unknown as Request;
+
+      //when
+      mockVideoService.createVideo.mockRejectedValue(
+        new ManipulatedTokenNotFiltered(),
+      );
+
+      //then
+      await expect(async () => {
+        await controller.createVideo(member, createVideoRequest);
+      }).rejects.toThrow(ManipulatedTokenNotFiltered);
+    });
+  });
+
+  describe('getPreSignedUrl', () => {
+    const createPreSignedUrlRequest = new CreatePreSignedUrlRequest(1);
+
+    it('Pre-Signed URL 발급 완료 시 PreSignedUrlResponse 객체 형태로 응답된다.', async () => {
+      //given
+
+      //when
+      mockVideoService.getPreSignedUrl.mockResolvedValue(
+        new PreSignedUrlResponse('fakePreSignedUrl', 'fakeKey'),
+      );
+
+      //then
+      const result = await controller.getPreSignedUrl(
+        mockReqWithMemberFixture,
+        createPreSignedUrlRequest,
+      );
+
+      expect(result).toBeInstanceOf(PreSignedUrlResponse);
+      expect(result.preSignedUrl).toBe('fakePreSignedUrl');
+      expect(result.key).toBe('fakeKey');
+    });
+
+    it('Pre-Signed URL 생성 도중 에러가 발생하면 IDriveException을 반환해야한다.', async () => {
+      //given
+
+      // when
+      mockVideoService.getPreSignedUrl.mockRejectedValue(new IDriveException());
+
+      // then
+      await expect(async () => {
+        await controller.getPreSignedUrl(
+          mockReqWithMemberFixture,
+          createPreSignedUrlRequest,
+        );
+      }).rejects.toThrow(IDriveException);
+    });
+
+    it('Pre-Signed URL 생성 시 회원 객체가 없으면 ManipulatedTokenNotFilteredException을 반환한다.', async () => {
+      // given
+      const member = { user: null } as unknown as Request;
+
+      // when
+      mockVideoService.getPreSignedUrl.mockRejectedValue(
+        new ManipulatedTokenNotFiltered(),
+      );
+
+      // then
+      await expect(async () => {
+        await controller.getPreSignedUrl(member, createPreSignedUrlRequest);
+      }).rejects.toThrow(ManipulatedTokenNotFiltered);
+    });
+  });
+});

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -44,9 +44,12 @@ export class VideoController {
   @ApiResponse(createApiResponseOption(201, '비디오 정보 저장 완료', null))
   async createVideo(
     @Req() req: Request,
-    @Body() createVidoeRequest: CreateVideoRequest,
+    @Body() createVideoRequest: CreateVideoRequest,
   ) {
-    this.videoService.createVideo(req.user as Member, createVidoeRequest);
+    return this.videoService.createVideo(
+      req.user as Member,
+      createVideoRequest,
+    );
   }
 
   @Post('/pre-signed')

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -152,7 +152,10 @@ export class VideoController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
-    await this.videoService.deleteVideo(videoId, req.user as Member);
-    res.status(204).send();
+    return this.videoService
+      .deleteVideo(videoId, req.user as Member)
+      .then(() => {
+        res.status(204).send();
+      });
   }
 }

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -46,10 +46,7 @@ export class VideoController {
     @Req() req: Request,
     @Body() createVideoRequest: CreateVideoRequest,
   ) {
-    return this.videoService.createVideo(
-      req.user as Member,
-      createVideoRequest,
-    );
+    await this.videoService.createVideo(req.user as Member, createVideoRequest);
   }
 
   @Post('/pre-signed')
@@ -152,10 +149,7 @@ export class VideoController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
-    return this.videoService
-      .deleteVideo(videoId, req.user as Member)
-      .then(() => {
-        res.status(204).send();
-      });
+    await this.videoService.deleteVideo(videoId, req.user as Member);
+    res.status(204).send();
   }
 }

--- a/BE/src/video/dto/createPreSignedUrlRequest.ts
+++ b/BE/src/video/dto/createPreSignedUrlRequest.ts
@@ -7,4 +7,8 @@ export class CreatePreSignedUrlRequest {
   @IsNumber()
   @IsNotEmpty()
   questionId: number;
+
+  constructor(questionId: number) {
+    this.questionId = questionId;
+  }
 }

--- a/BE/src/video/dto/createVideoRequest.ts
+++ b/BE/src/video/dto/createVideoRequest.ts
@@ -19,4 +19,10 @@ export class CreateVideoRequest {
   @IsString()
   @IsNotEmpty()
   url: string;
+
+  constructor(questionId: number, videoName: string, url: string) {
+    this.questionId = questionId;
+    this.videoName = videoName;
+    this.url = url;
+  }
 }

--- a/BE/src/video/dto/videoHashResponse.ts
+++ b/BE/src/video/dto/videoHashResponse.ts
@@ -10,7 +10,7 @@ export class VideoHashResponse {
     ),
   )
   @ApiProperty({ nullable: true })
-  private hash: string;
+  readonly hash: string;
   constructor(hash: string) {
     this.hash = hash;
   }

--- a/BE/src/video/fixture/video.fixture.ts
+++ b/BE/src/video/fixture/video.fixture.ts
@@ -31,3 +31,11 @@ export const videoListFixtureForTest = [
   new Video(1, 1, '루이뷔통통튀기네', 'https://test.com', true),
   new Video(1, 4, '루이뷔통통튀기네', 'https://foo.com', false),
 ];
+
+export const videoFixtureForTest = new Video(
+  1,
+  1,
+  '루이뷔통통튀기네',
+  'https://test.com',
+  true,
+);

--- a/BE/src/video/fixture/video.fixture.ts
+++ b/BE/src/video/fixture/video.fixture.ts
@@ -1,3 +1,5 @@
+import { Video } from '../entity/video';
+
 export const videoListExample = [
   {
     id: 5,
@@ -23,4 +25,9 @@ export const videoListExample = [
     isPublic: false,
     createdAt: 1699858790176,
   },
+];
+
+export const videoListFixtureForTest = [
+  new Video(1, 1, '루이뷔통통튀기네', 'https://test.com', true),
+  new Video(1, 4, '루이뷔통통튀기네', 'https://foo.com', false),
 ];


### PR DESCRIPTION
[![NDD-183](https://badgen.net/badge/JIRA/NDD-183/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-183) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
Video API의 Controller 계층에 대한 테스트를 진행하기 위함

# How
각 API 별로 Controller 계층에서 발생할 수 있는 상황에 대한 모든 경우들을 테스트
1. POST -  비디오를 저장하는 API, 비디오를 저장하기 위한 Pre-Signed URL을 발급받는 API
2. GET - 비디오 전체 조회, 비디오 상세 정보 조회, 비디오 해시값으로 조회
3. PATCH - 비디오 상태를 토글하는 API
4. DELETE - 비디오를 삭제하는 API

우선 위의 4가지 메서드의 7개의 Controller 단위 테스트를 진행하였다.
각 Controller 메서드 별로 올바른 응답, 상황에 따른 다른 응답, 에러 처리(탈취된 토큰을 포함한 요청, 소유권이 없는 비디오에 대한 조작 등)와 같은 최대한 다양한 경우를 테스트하고자 노력하였다.

각 API별 세부 사항(에러 처리, 상황 별 응답의 차이)들은 아래 Result의 사진에서 확인할 수 있다.

# Result
28개의 테스트 케이스를 모두 통과하였음을 확인할 수 있다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/4855be1a-55b6-438e-8373-593f6768d24b)


# Prize
단위 테스트가 아직 익숙하지 않아서 계속 알아보고, 학습하는 시간을 많이 가진 것 같다.
여전히 계속 부족하기에 다음번에 Service 로직을 테스트할 때도 많은 학습과 함께 진행해야 할 것 같다.

테스트를 통해 VideoController가 VideoService의 상황에 맞게 알맞은 응답을 Client에게 전송함을 확인할 수 있었다.

[NDD-183]: https://milk717.atlassian.net/browse/NDD-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ