### PR TITLE
[NDD-232] 비디오 ID/HASH로 단건 조회 시 사용자의 닉네임도 포함하도록 API 변경 (1h / 1h)

### DIFF
--- a/BE/src/video/dto/videoDetailResponse.ts
+++ b/BE/src/video/dto/videoDetailResponse.ts
@@ -6,6 +6,9 @@ export class VideoDetailResponse {
   @ApiProperty(createPropertyOption(1, '비디오의 ID', Number))
   readonly id: number;
 
+  @ApiProperty(createPropertyOption('foobar', '회원의 닉네임', String))
+  private nickname: string;
+
   @ApiProperty(
     createPropertyOption('https://example-video.com', '비디오의 URL', String),
   )
@@ -33,21 +36,24 @@ export class VideoDetailResponse {
 
   constructor(
     id: number,
+    nickname: string,
     url: string,
     videoName: string,
     hash: string,
     createdAt: number,
   ) {
     this.id = id;
+    this.nickname = nickname;
     this.url = url;
     this.videoName = videoName;
     this.hash = hash;
     this.createdAt = createdAt;
   }
 
-  static from(video: Video, hash: string | null) {
+  static from(video: Video, nickname: string, hash: string | null) {
     return new VideoDetailResponse(
       video.id,
+      nickname,
       video.url,
       video.name,
       hash,

--- a/BE/src/video/exception/video.exception.ts
+++ b/BE/src/video/exception/video.exception.ts
@@ -29,3 +29,9 @@ export class DecryptionException extends HttpException {
     super('복호화 중 에러가 발생했습니다.', 500);
   }
 }
+
+export class VideoOfWithdrawnMemberException extends HttpException {
+  constructor() {
+    super('탈퇴한 회원의 비디오를 조회할 수 없습니다.', 404);
+  }
+}

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -71,15 +71,14 @@ export class VideoService {
     this.validateVideoOwnership(video, memberId);
 
     const hash = video.isPublic ? this.getEncryptedurl(video.url) : null;
-    return VideoDetailResponse.from(video, hash);
+    return VideoDetailResponse.from(video, member.nickname, hash);
   }
 
   async getVideoDetailByHash(hash: string) {
     const decryptedUrl = this.getDecryptedUrl(hash);
     const video = await this.videoRepository.findByUrl(decryptedUrl);
-
     if (!video.isPublic) throw new VideoAccessForbiddenException();
-    return VideoDetailResponse.from(video, hash);
+    return VideoDetailResponse.from(video, 'test', hash);
   }
 
   async getAllVideosByMemberId(member: Member) {

--- a/BE/src/video/video.module.ts
+++ b/BE/src/video/video.module.ts
@@ -6,10 +6,17 @@ import { Video } from './entity/video';
 import { VideoRepository } from './repository/video.repository';
 import { QuestionRepository } from 'src/question/repository/question.repository';
 import { Question } from 'src/question/entity/question';
+import { Member } from 'src/member/entity/member';
+import { MemberRepository } from 'src/member/repository/member.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Video, Question])],
+  imports: [TypeOrmModule.forFeature([Video, Question, Member])],
   controllers: [VideoController],
-  providers: [VideoService, VideoRepository, QuestionRepository],
+  providers: [
+    VideoService,
+    VideoRepository,
+    QuestionRepository,
+    MemberRepository,
+  ],
 })
 export class VideoModule {}


### PR DESCRIPTION
[![NDD-232](https://badgen.net/badge/JIRA/NDD-232/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-232) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
FE 측에서 비디오 단건 조회 시 사용자의 닉네임도 함께 반환되게 변경해달라는 요청이 있어 이를 반영하기 위함

처음에는 eager: true 옵션을 사용해서 비디오 조회 시 아예 member를 미리 불러오는 로직은 어떨까 고민을 했지만, 비디오 ID로 비디오 조회 시에는 이미 AuthGuard를 통해 쿠키로 회원 정보를 이미 알아낸 상태였고, hash로 조회 API 하나 때문에 모든  
비디오 API에서 member를 미리 불러오는 것은 비효율적이라고 생각되기에 그냥 hash 조회 시에만 단순 조회하는 방식으로 로직을 구현하였다.

# How
### 비디오 ID로 비디오 단건 조회
이전에 구현된 로직에 더하여 구현하였다. AuthGuard를 통해 쿠키에서 회원 정보를 얻어내었으므로, 이를 사용하여 구현하였다.
- AuthGuard를 통해 넘어온 회원 정보 중 nickname만 DTO에 넘겨주어 알맞게 응답되도록 구현
```javascript
async getVideoDetail(videoId: number, member: Member) {
    validateManipulatedToken(member);
    const memberId = member.id;
    const video = await this.videoRepository.findById(videoId);
    this.validateVideoOwnership(video, memberId);

    const hash = video.isPublic ? this.getEncryptedurl(video.url) : null;
    return VideoDetailResponse.from(video, member.nickname, hash); // member는 authguard를 통해 넘어온 회원 정보 객체
  }
```
### 비디오 HASH로 비디오 단건 조회
이전에 구현된 로직에 더하여 구현하였다. 비디오 정보는 이전 로직에서 이미 조회되어 있으므로 이 정보를 사용하여 구현하였다.
- 조회된 비디오의 회원의 ID를 사용하여 memberRepository에서 회원의 ID로 회원 정보 조회
- 회원 정보에서 nickname만 DTO에 넘겨주어 알맞게 응답되도록 구현 
```javascript
async getVideoDetailByHash(hash: string) {
    const decryptedUrl = this.getDecryptedUrl(hash);
    const video = await this.videoRepository.findByUrl(decryptedUrl);
    if (!video.isPublic) throw new VideoAccessForbiddenException();

    const videoOwner = await this.memberRepository.findById(video.memberId); // 조회된 비디오의 memberId를 사용하여 회원 정보를 조회
    if (!videoOwner) throw new VideoOfWithdrawnMemberException();

    return VideoDetailResponse.from(video, videoOwner.nickname, hash); // 조회한 회원 정보를 사용하여 nickname DTO로 넘겨줌
  }
```

### 테스트 코드 추가
해시로 비디오 조회 시의 예외 사항이 추가되어서 이에 대한 테스트 코드 작성
```javascript
    it('해시로 비디오 조회 시 비디오가 탈퇴한 회원의 비디오라면 VideoOfWithdrawnMemberException을 반환한다.', async () => {
      // given

      // when
      mockVideoService.getVideoDetailByHash.mockRejectedValue(
        new VideoOfWithdrawnMemberException(),
      );

      // then
      expect(controller.getVideoDetailByHash(hash)).rejects.toThrow(
        VideoOfWithdrawnMemberException,
      );
    });
```

# Result
아래 사진과 같이 비디오 ID/HASH로 단건 조회 시에 사용자의 닉네임도 포함하여 의도대로 응답함을 확인할 수 있다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/d4e7a027-01fb-461f-b1c8-d00fdd74db9a)

테스트 코드도 정상적으로 동작한다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/83efd136-260a-4e38-8265-2fa520d7e9ac)

# Prize
비디오 조회 시 해당 비디오 촬영자의 닉네임을 확인할 수 있도록 구현을 하였다. 이를 통해 FE의 요구사항을 달성하였다.

[NDD-232]: https://milk717.atlassian.net/browse/NDD-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ