### PR TITLE
[NDD-229]: 질문 삭제 로직 구현 && 테스트 (2h / 1h)

### DIFF
--- a/BE/src/category/controller/category.controller.spec.ts
+++ b/BE/src/category/controller/category.controller.spec.ts
@@ -289,8 +289,8 @@ describe('CategoryController 통합테스트', () => {
     //when
 
     //then
-    await categoryRepository.save(categoryFixtureWithId);
     const token = await authService.login(memberFixturesOAuthRequest);
+    await categoryRepository.save(categoryFixtureWithId);
     const agent = request.agent(app.getHttpServer());
     agent
       .delete(`/api/category?id=1`)

--- a/BE/src/category/repository/category.repository.ts
+++ b/BE/src/category/repository/category.repository.ts
@@ -10,7 +10,7 @@ export class CategoryRepository {
   ) {}
 
   async save(category: Category) {
-    await this.repository.save(category);
+    return await this.repository.save(category);
   }
 
   async findAllByMemberId(memberId: number) {

--- a/BE/src/question/controller/question.controller.ts
+++ b/BE/src/question/controller/question.controller.ts
@@ -1,15 +1,17 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Post,
   Query,
   Req,
+  Res,
   UseGuards,
 } from '@nestjs/common';
 import { QuestionService } from '../service/question.service';
 import { CreateQuestionRequest } from '../dto/createQuestionRequest';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import { AuthGuard } from '@nestjs/passport';
 import {
   ApiBody,
@@ -63,5 +65,24 @@ export class QuestionController {
     const questionResponses =
       await this.questionService.findAllByCategory(categoryId);
     return QuestionResponseList.of(questionResponses);
+  }
+
+  @Delete()
+  @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '질문 삭제',
+  })
+  @ApiResponse(createApiResponseOption(204, '질문 삭제', null))
+  async deleteQuestionById(
+    @Query('questionId') questionId: number,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    await this.questionService.deleteQuestionById(
+      questionId,
+      req.user as Member,
+    );
+    res.status(204).send();
   }
 }

--- a/BE/src/question/dto/questionResponse.ts
+++ b/BE/src/question/dto/questionResponse.ts
@@ -1,9 +1,19 @@
 import { Question } from '../entity/question';
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from '../../util/swagger.util';
 
 export class QuestionResponse {
+  @ApiProperty(createPropertyOption(1, '질문의 ID', Number))
   questionId: number;
+  @ApiProperty(
+    createPropertyOption('이장희는 누구인가요?', '질문 내용', String),
+  )
   questionContent: string;
+  @ApiProperty(createPropertyOption(1, '대표답변의 ID', Number))
   answerId: number;
+  @ApiProperty(
+    createPropertyOption('존잘 백엔드 캠퍼!', '대표답변 내용', String),
+  )
   answerContent: string;
 
   constructor(

--- a/BE/src/question/dto/questionResponseList.ts
+++ b/BE/src/question/dto/questionResponseList.ts
@@ -1,6 +1,16 @@
 import { QuestionResponse } from './questionResponse';
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from '../../util/swagger.util';
+import { questionFixture } from '../util/question.util';
 
 export class QuestionResponseList {
+  @ApiProperty(
+    createPropertyOption(
+      [QuestionResponse.from(questionFixture)],
+      '질문과 대표답변 리스트',
+      [QuestionResponse],
+    ),
+  )
   questionResponses: QuestionResponse[];
 
   constructor(questionResponses: QuestionResponse[]) {

--- a/BE/src/question/exception/question.exception.ts
+++ b/BE/src/question/exception/question.exception.ts
@@ -12,4 +12,14 @@ class NeedToFindByCategoryIdException extends HttpException {
   }
 }
 
-export { ContentNotFoundException, NeedToFindByCategoryIdException };
+class QuestionNotFoundException extends HttpException {
+  constructor() {
+    super('해당 질문을 찾을 수 없습니다.', 404);
+  }
+}
+
+export {
+  ContentNotFoundException,
+  NeedToFindByCategoryIdException,
+  QuestionNotFoundException,
+};

--- a/BE/src/question/service/question.service.spec.ts
+++ b/BE/src/question/service/question.service.spec.ts
@@ -265,4 +265,19 @@ describe('QuestionService 통합 테스트', () => {
       questionService.findAllByCategory(category.id),
     ).resolves.toEqual([response]);
   });
+
+  it('id로 질문을 삭제하면 undefined를 반환한다.', async () => {
+    //given
+    const member = await memberRepository.save(memberFixture);
+    const category = await categoryRepository.save(categoryFixtureWithId);
+    const question = await questionRepository.save(
+      Question.of(category, null, 'tester'),
+    );
+    //when
+
+    //then
+    await expect(
+      questionService.deleteQuestionById(question.id, member),
+    ).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
[![NDD-229](https://badgen.net/badge/JIRA/NDD-229/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-229) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- 질문의 id와 토큰을 받아 삭제하는 로직 구현
- 테스트를 통한 검증에서 생각보다 많은 시간을 쓰게 되었다. 
- 테스트 사항
    - 토큰 여부
    - 질문의 무결성
        - 질문이 존재하는가
        - 질문의 카테고리가 존재하는가
    - 질문의 카테고리가 회원의 소유인가

# How

```
//비즈니스 로직
async deleteQuestionById(questionId: number, member: Member) {
    validateManipulatedToken(member);

    const question = await this.questionRepository.findById(questionId);

    if (isEmpty(question)) {
      throw new QuestionNotFoundException();
    }

    await this.validateMembersCategoryById(question.category.id, member);

    await this.questionRepository.remove(question);
  }

//컨트롤러 로직
@Delete()
  @UseGuards(AuthGuard('jwt'))
  @ApiCookieAuth()
  @ApiOperation({
    summary: '질문 삭제',
  })
  @ApiResponse(createApiResponseOption(204, '질문 삭제', null))
  async deleteQuestionById(
    @Query('questionId') questionId: number,
    @Req() req: Request,
    @Res() res: Response,
  ) {
    await this.questionService.deleteQuestionById(
      questionId,
      req.user as Member,
    );
    res.status(204).send();
  }
}
```

# Result
![스크린샷 2023-11-21 18 07 11](https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/70595035-aa58-4a73-a5ba-ab66e5d24366)
![스크린샷 2023-11-21 18 17 26](https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/81b0df1b-0b03-4c29-a34a-8e9ffbf9acf4)


# Prize

- 삭제시 Answer도 onDeleteAction 적용
- 회원 탈퇴, 카테고리 탈퇴시 내부 내용도 delete하게 적용예정

[NDD-229]: https://milk717.atlassian.net/browse/NDD-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ