### PR TITLE
[NDD-233]: 면접 화면 전용 사용자 이름 조회 시 기업 이름도 Prefix로 추가되도록 API 변경 (0.5h / 1h)

### DIFF
--- a/BE/src/constant/constant.ts
+++ b/BE/src/constant/constant.ts
@@ -1,0 +1,14 @@
+export const companies = [
+  '네이버',
+  '카카오',
+  '라인',
+  '쿠팡',
+  '우아한형제들',
+  '당근',
+  '비바리퍼블리카',
+  'Microsoft',
+  'Apple',
+  'Google',
+  'Amazon',
+  'Meta',
+];

--- a/BE/src/member/service/member.service.ts
+++ b/BE/src/member/service/member.service.ts
@@ -5,6 +5,21 @@ import { MemberRepository } from '../repository/member.repository';
 import { getTokenValue } from 'src/util/token.util';
 import { MemberNicknameResponse } from '../dto/memberNicknameResponse';
 
+const companies = [
+  '네이버',
+  '카카오',
+  '라인',
+  '쿠팡',
+  '우아한형제들',
+  '당근',
+  '비바리퍼블리카',
+  'Microsoft',
+  'Apple',
+  'Google',
+  'Amazon',
+  'Meta',
+];
+
 @Injectable()
 export class MemberService {
   constructor(
@@ -12,7 +27,8 @@ export class MemberService {
     private memberRepository: MemberRepository,
   ) {}
   async getNameForInterview(req: Request) {
-    if (!req.cookies['accessToken']) return '면접자';
+    if (!req.cookies['accessToken'])
+      return new MemberNicknameResponse(`면접자`);
 
     // TODO: 추후에 랜덤 Prefix 생성할 필요가 있음
     return new MemberNicknameResponse(
@@ -20,8 +36,14 @@ export class MemberService {
     );
   }
 
-  async getMemberByToken(tokenValue: string) {
+  private async getMemberByToken(tokenValue: string) {
     const memberId = (await this.tokenService.getPayload(tokenValue)).id;
     return await this.memberRepository.findById(memberId);
+  }
+
+  private getNameWithPrefix(nickname: string) {
+    const randomCompany =
+      companies[Math.floor(Math.random() * companies.length)];
+    return `${randomCompany} 최종 면접에 들어온 ${nickname}`;
   }
 }

--- a/BE/src/member/service/member.service.ts
+++ b/BE/src/member/service/member.service.ts
@@ -4,21 +4,7 @@ import { TokenService } from 'src/token/service/token.service';
 import { MemberRepository } from '../repository/member.repository';
 import { getTokenValue } from 'src/util/token.util';
 import { MemberNicknameResponse } from '../dto/memberNicknameResponse';
-
-const companies = [
-  '네이버',
-  '카카오',
-  '라인',
-  '쿠팡',
-  '우아한형제들',
-  '당근',
-  '비바리퍼블리카',
-  'Microsoft',
-  'Apple',
-  'Google',
-  'Amazon',
-  'Meta',
-];
+import { companies } from 'src/constant/constant';
 
 @Injectable()
 export class MemberService {

--- a/BE/src/member/service/member.service.ts
+++ b/BE/src/member/service/member.service.ts
@@ -28,11 +28,13 @@ export class MemberService {
   ) {}
   async getNameForInterview(req: Request) {
     if (!req.cookies['accessToken'])
-      return new MemberNicknameResponse(`면접자`);
+      return new MemberNicknameResponse(this.getNameWithPrefix(`면접자`));
 
     // TODO: 추후에 랜덤 Prefix 생성할 필요가 있음
     return new MemberNicknameResponse(
-      (await this.getMemberByToken(getTokenValue(req))).nickname,
+      this.getNameWithPrefix(
+        (await this.getMemberByToken(getTokenValue(req))).nickname,
+      ),
     );
   }
 

--- a/BE/src/member/service/member.service.ts
+++ b/BE/src/member/service/member.service.ts
@@ -30,7 +30,6 @@ export class MemberService {
     if (!req.cookies['accessToken'])
       return new MemberNicknameResponse(this.getNameWithPrefix(`면접자`));
 
-    // TODO: 추후에 랜덤 Prefix 생성할 필요가 있음
     return new MemberNicknameResponse(
       this.getNameWithPrefix(
         (await this.getMemberByToken(getTokenValue(req))).nickname,


### PR DESCRIPTION
[![NDD-233](https://badgen.net/badge/JIRA/NDD-233/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-233) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
기획 명세에 따르면 면접 화면에서 쓰이는 사용자 이름을 조회 시에 기업 이름도 Prefix로 달아줘야 했는데, 이를 후순위로 두고 일단 사용자의 이름만 반환하는 API로 구현을 해둔 상태였다.
이제 실제로 FE에서 면접 화면에서 사용해야 하기에 이에 맞춰 API를 수정하였다. 

# How
- 유명한 IT 기업들을 companies 배열에 저장
- companies 배열에서 랜덤으로 하나의 회사를 뽑아서 Prefix를 만들고 이를 사용자 이름에 붙이는 getNameWithPrefix라는 메서드를 구현
- 위의 메서드를 사용해 비회원이라면 '면접자'를, 회원이라면 회원 닉네임을 getNameWithPrefix 메서드의 매개변수로 넘겨 면접 화면 전용 회원 이름을 얻을 수 있도록 구현 
```javascript
const companies = [
  '네이버',
  '카카오',
  '라인',
  '쿠팡',
  '우아한형제들',
  '당근',
  '비바리퍼블리카',
  'Microsoft',
  'Apple',
  'Google',
  'Amazon',
  'Meta',
];

@Injectable()
export class MemberService {
  constructor(
    private tokenService: TokenService,
    private memberRepository: MemberRepository,
  ) {}
  async getNameForInterview(req: Request) {
    if (!req.cookies['accessToken'])
      return new MemberNicknameResponse(this.getNameWithPrefix(`면접자`));

    return new MemberNicknameResponse(
      this.getNameWithPrefix(
        (await this.getMemberByToken(getTokenValue(req))).nickname,
      ),
    );
  }

  private async getMemberByToken(tokenValue: string) {
    const memberId = (await this.tokenService.getPayload(tokenValue)).id;
    return await this.memberRepository.findById(memberId);
  }

  private getNameWithPrefix(nickname: string) {
    const randomCompany =
      companies[Math.floor(Math.random() * companies.length)];
    return `${randomCompany} 최종 면접에 들어온 ${nickname}`;
  }
}
```

# Result
### 비회원의 경우
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/c9833212-9313-4076-acfd-e86b13ab8db2)

### 회원의 경우
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/c257a212-eb84-43e3-bc98-98af95638a9f)

[NDD-233]: https://milk717.atlassian.net/browse/NDD-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ