### PR TITLE
[NDD-113] Answer 객체 구현 및 기존 로직에서 DefaultAnswer를 가지는 부분을 위한 추가 구현 (1h / 1h)

### DIFF
--- a/BE/src/answer/answer.module.ts
+++ b/BE/src/answer/answer.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Member } from '../member/entity/member';
 import { Answer } from './entity/answer';
+import { AnswerRepository } from './repository/answer.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Member, Answer])],
+  providers: [AnswerRepository],
 })
 export class AnswerModule {}

--- a/BE/src/answer/answer.module.ts
+++ b/BE/src/answer/answer.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Member } from '../member/entity/member';
+import { Answer } from './entity/answer';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Member, Answer])],
+})
+export class AnswerModule {}

--- a/BE/src/answer/answer.module.ts
+++ b/BE/src/answer/answer.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Member } from '../member/entity/member';
 import { Answer } from './entity/answer';
 import { AnswerRepository } from './repository/answer.repository';
+import { Question } from '../question/entity/question';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Member, Answer])],
+  imports: [TypeOrmModule.forFeature([Member, Answer, Question])],
   providers: [AnswerRepository],
 })
 export class AnswerModule {}

--- a/BE/src/answer/entity/answer.ts
+++ b/BE/src/answer/entity/answer.ts
@@ -1,0 +1,43 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { DefaultEntity } from '../../app.entity';
+import { Member } from '../../member/entity/member';
+import { Question } from '../../question/entity/question';
+
+@Entity()
+export class Answer extends DefaultEntity {
+  @Column()
+  content: string;
+
+  @ManyToOne(() => Member, { onDelete: 'CASCADE' })
+  @JoinColumn()
+  member: Member;
+
+  @ManyToOne(() => Question, { onDelete: 'CASCADE' })
+  @JoinColumn()
+  question: Question;
+
+  constructor(
+    id: number,
+    createdAt: Date,
+    content: string,
+    member: Member,
+    question: Question,
+  ) {
+    super(id, createdAt);
+    this.content = content;
+    this.member = member;
+    this.question = question;
+  }
+
+  static of(content: string, member: Member, question: Question) {
+    return new Answer(null, new Date(), content, member, question);
+  }
+
+  isOwnedBy(member: Member) {
+    return this.member.id === member.id;
+  }
+
+  isAnswerOf(question: Question) {
+    return this.question.id === question.id;
+  }
+}

--- a/BE/src/answer/repository/answer.repository.ts
+++ b/BE/src/answer/repository/answer.repository.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Answer } from '../entity/answer';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class AnswerRepository {
+  constructor(
+    @InjectRepository(Answer) private repository: Repository<Answer>,
+  ) {}
+}

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -9,6 +9,7 @@ import { TokenModule } from './token/token.module';
 import { QuestionModule } from './question/question.module';
 import { VideoModule } from './video/video.module';
 import { CategoryModule } from './category/category.module';
+import { AnswerModule } from './answer/answer.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { CategoryModule } from './category/category.module';
     QuestionModule,
     VideoModule,
     CategoryModule,
+    AnswerModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BE/src/question/dto/questionResponse.ts
+++ b/BE/src/question/dto/questionResponse.ts
@@ -1,6 +1,7 @@
 import { Question } from '../entity/question';
 import { ApiProperty } from '@nestjs/swagger';
 import { createPropertyOption } from '../../util/swagger.util';
+import { isEmpty } from 'class-validator';
 
 export class QuestionResponse {
   @ApiProperty(createPropertyOption(1, '질문의 ID', Number))
@@ -29,6 +30,15 @@ export class QuestionResponse {
   }
 
   static from(question: Question) {
-    return new QuestionResponse(question.id, question.content, null, null);
+    const answer = question.defaultAnswer;
+    if (isEmpty(answer))
+      return new QuestionResponse(question.id, question.content, null, null);
+
+    return new QuestionResponse(
+      question.id,
+      question.content,
+      answer.id,
+      answer.content,
+    );
   }
 }

--- a/BE/src/question/entity/question.ts
+++ b/BE/src/question/entity/question.ts
@@ -1,6 +1,7 @@
 import { DefaultEntity } from '../../app.entity';
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { Category } from '../../category/entity/category';
+import { Answer } from '../../answer/entity/answer';
 
 @Entity({ name: 'Question' })
 export class Question extends DefaultEntity {
@@ -15,24 +16,37 @@ export class Question extends DefaultEntity {
   @JoinColumn({ name: 'origin' })
   readonly origin: Question;
 
+  @ManyToOne(() => Answer, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'defaultQuestion' })
+  defaultQuestion: Question;
+
   constructor(
     id: number,
     content: string,
     category: Category,
     origin: Question,
     createdAt: Date,
+    defaultQuestion: Question,
   ) {
     super(id, createdAt);
     this.content = content;
     this.category = category;
     this.origin = origin;
+    this.defaultQuestion = defaultQuestion;
   }
 
   static of(category: Category, origin: Question, content: string) {
-    return new Question(null, content, category, origin, new Date());
+    return new Question(null, content, category, origin, new Date(), null);
   }
 
   static copyOf(question: Question, category: Category) {
-    return new Question(null, question.content, category, question, new Date());
+    return new Question(
+      null,
+      question.content,
+      category,
+      question,
+      new Date(),
+      question.defaultQuestion,
+    );
   }
 }

--- a/BE/src/question/entity/question.ts
+++ b/BE/src/question/entity/question.ts
@@ -16,9 +16,13 @@ export class Question extends DefaultEntity {
   @JoinColumn({ name: 'origin' })
   readonly origin: Question;
 
-  @ManyToOne(() => Answer, { nullable: true, onDelete: 'SET NULL' })
+  @ManyToOne(() => Answer, {
+    nullable: true,
+    onDelete: 'SET NULL',
+    eager: true,
+  })
   @JoinColumn({ name: 'defaultQuestion' })
-  defaultQuestion: Question;
+  defaultAnswer: Answer;
 
   constructor(
     id: number,
@@ -26,13 +30,13 @@ export class Question extends DefaultEntity {
     category: Category,
     origin: Question,
     createdAt: Date,
-    defaultQuestion: Question,
+    defaultAnswer: Answer,
   ) {
     super(id, createdAt);
     this.content = content;
     this.category = category;
     this.origin = origin;
-    this.defaultQuestion = defaultQuestion;
+    this.defaultAnswer = defaultAnswer;
   }
 
   static of(category: Category, origin: Question, content: string) {
@@ -46,7 +50,7 @@ export class Question extends DefaultEntity {
       category,
       question,
       new Date(),
-      question.defaultQuestion,
+      question.defaultAnswer,
     );
   }
 }

--- a/BE/src/question/entity/question.ts
+++ b/BE/src/question/entity/question.ts
@@ -53,4 +53,8 @@ export class Question extends DefaultEntity {
       question.defaultAnswer,
     );
   }
+
+  setDefaultAnswer(answer: Answer) {
+    this.defaultAnswer = answer;
+  }
 }

--- a/BE/src/question/question.module.ts
+++ b/BE/src/question/question.module.ts
@@ -9,12 +9,15 @@ import { QuestionRepository } from './repository/question.repository';
 import { CategoryModule } from '../category/category.module';
 import { CategoryRepository } from '../category/repository/category.repository';
 import { Member } from '../member/entity/member';
+import { AnswerModule } from '../answer/answer.module';
+import { Answer } from '../answer/entity/answer';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Question, Category, Member]),
+    TypeOrmModule.forFeature([Question, Category, Member, Answer]),
     TokenModule,
     CategoryModule,
+    AnswerModule,
   ],
   providers: [QuestionService, QuestionRepository, CategoryRepository],
   controllers: [QuestionController],

--- a/BE/src/question/service/question.service.spec.ts
+++ b/BE/src/question/service/question.service.spec.ts
@@ -88,7 +88,6 @@ describe('QuestionService', () => {
   });
 
   describe('카테고리별 질문 조회', () => {
-    // Todo: Answer API 구현시에 DefaultAnswer 까지 등록하기
     it('카테고리 id로 질문들을 조회하면, 해당 카테고리 내부 질문들이 반환된다.', async () => {
       //given
 

--- a/BE/src/question/service/question.service.spec.ts
+++ b/BE/src/question/service/question.service.spec.ts
@@ -24,6 +24,8 @@ import {
   QuestionNotFoundException,
 } from '../exception/question.exception';
 import { ManipulatedTokenNotFiltered } from '../../token/exception/token.exception';
+import { Answer } from '../../answer/entity/answer';
+import { AnswerModule } from '../../answer/answer.module';
 
 describe('QuestionService', () => {
   let service: QuestionService;
@@ -207,8 +209,13 @@ describe('QuestionService 통합 테스트', () => {
   let memberRepository: MemberRepository;
 
   beforeAll(async () => {
-    const modules = [QuestionModule, CategoryModule, MemberModule];
-    const entities = [Question, Category, Member];
+    const modules = [
+      QuestionModule,
+      CategoryModule,
+      MemberModule,
+      AnswerModule,
+    ];
+    const entities = [Question, Category, Member, Answer];
 
     const moduleFixture = await createIntegrationTestModule(modules, entities);
     app = moduleFixture.createNestApplication();

--- a/BE/src/question/util/question.util.ts
+++ b/BE/src/question/util/question.util.ts
@@ -8,6 +8,7 @@ export const questionFixture = new Question(
   categoryFixtureWithId,
   null,
   new Date(),
+  null,
 );
 
 export const createQuestionRequestFixture = new CreateQuestionRequest(


### PR DESCRIPTION
[![NDD-113](https://badgen.net/badge/JIRA/NDD-113/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-113) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- ERD의 단점 : 객체의 관계를 따로 테이블에 저장한다. 이는 데이터의 조회에서 join을 필수적으로 사용하게 한다. 
- 해결방안
    - Question : DefaultAnswer인스턴스를 두어, 질문을 조회할 때 eager로 default answer를 조회하게 기능 수정
    - Answer : Member와 Question을 인스턴스로 가지게 한다. Question은 후에 Question.origin에 저장하는 방식으로 구현예정
    - 현재 API에서 Answer가 사용될 때 사용될 방법
    - /api/question?category=${categoryId} : question.defaultAnswer를 가져와 반환하게 구현(현재 적용)
    - /api/answer/${questionId} : (구현예정)
        - answer테이블에서 question.origin.id를 가지는 Answer를 CreatedAt의 역순으로 정렬되게 DB 전체 반환
        - 해당 answer에서 answer.member가 본인인 답변들을 더 앞 인덱스로 뺀다.
        - question.defaultAnswer를 배열의 제일 앞으로 가져온다.

# How

```
@Entity({ name: 'Question' })
export class Question extends DefaultEntity {
  @Column({ type: 'text' })
  readonly content: string;

  @ManyToOne(() => Category, { onDelete: 'CASCADE', eager: true })
  @JoinColumn({ name: 'category' })
  readonly category: Category;

  @ManyToOne(() => Question, { nullable: true, onDelete: 'CASCADE' })
  @JoinColumn({ name: 'origin' })
  readonly origin: Question;

  @ManyToOne(() => Answer, {
    nullable: true,
    onDelete: 'SET NULL',
    eager: true,
  })
  @JoinColumn({ name: 'defaultQuestion' })
  defaultAnswer: Answer;
```
- 위의 방식으로 Question에 대한 대표응답 객체 구현
    - 다른 사람의 질문을 복사할 경우, Question.origin에 원본이 있기 때문에 질문마다 다른 DefaultAnswer를 사용 가능

```
@Entity()
export class Answer extends DefaultEntity {
  @Column()
  content: string;

  @ManyToOne(() => Member, { onDelete: 'CASCADE' })
  @JoinColumn()
  member: Member;

  @ManyToOne(() => Question, { onDelete: 'CASCADE' })
  @JoinColumn()
  question: Question;
```
- 질문의 작성자가 누구인지, 어떤 질문에 대한 대답인지 저장할 수 있다. 
    - 유의점 : 항상 Question.origin을 확인하고, 해당 질문이 origin이 없는 원본임을 확인하고 저장해야한다(원본이 아니면 원본에 저장한다)
- 결국, 원본 질문이 삭제될 때 해당 답변들 또한 삭제된다(기획상 사항)
- 회원이 탈퇴할 때 회원이 작성한 답변들도 삭제된다.

# Result

<img width="678" alt="스크린샷 2023-11-21 22 11 08" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/f566010c-bbdf-4d7b-bfdc-932eddcd4130">

- 대표답변을 조회하는 로직을 추가해도 정상적으로 테스트되는 것을 확인할 수 있다.


[NDD-113]: https://milk717.atlassian.net/browse/NDD-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ