### PR TITLE
[NDD-236]: 비디오 DB에 등록 시 비디오 길이와 썸네일 URL도 저장할 수 있도록 API 변경 (1h / 1h)

### DIFF
--- a/BE/src/constant/constant.ts
+++ b/BE/src/constant/constant.ts
@@ -1,3 +1,5 @@
+import 'dotenv/config';
+
 export const companies = [
   '네이버',
   '카카오',
@@ -12,3 +14,5 @@ export const companies = [
   'Amazon',
   'Meta',
 ];
+
+export const DEFAULT_THUMBNAIL = process.env.DEFAULT_THUMBNAIL;

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -60,6 +60,8 @@ describe('VideoController 단위 테스트', () => {
       1,
       'test.webm',
       'https://test.com',
+      'https://thumbnail-test.com',
+      '01:12',
     );
 
     it('비디오 저장 성공 시 undefined를 반환한다.', async () => {

--- a/BE/src/video/dto/createVideoRequest.ts
+++ b/BE/src/video/dto/createVideoRequest.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Matches,
+} from 'class-validator';
 import { createPropertyOption } from 'src/util/swagger.util';
 
 export class CreateVideoRequest {
@@ -34,6 +40,9 @@ export class CreateVideoRequest {
   @ApiProperty(createPropertyOption('03:29', '비디오 길이', String))
   @IsString()
   @IsNotEmpty()
+  @Matches(/^\d{2}:\d{2}$/, {
+    message: `유효하지 않은 비디오 길이 형태입니다. "mm:ss" 형태로 요청해주세요.`,
+  })
   videoLength: string;
 
   constructor(

--- a/BE/src/video/dto/createVideoRequest.ts
+++ b/BE/src/video/dto/createVideoRequest.ts
@@ -14,15 +14,38 @@ export class CreateVideoRequest {
   videoName: string;
 
   @ApiProperty(
-    createPropertyOption('https://example.com', '비디오 URL', String),
+    createPropertyOption('https://video-example.com', '비디오 URL', String),
   )
   @IsString()
   @IsNotEmpty()
   url: string;
 
-  constructor(questionId: number, videoName: string, url: string) {
+  @ApiProperty(
+    createPropertyOption(
+      'https://thumb-example.com',
+      '비디오 썸네일 URL',
+      String,
+    ),
+  )
+  @IsString()
+  thumbnail: string;
+
+  @ApiProperty(createPropertyOption('03:29', '비디오 길이', String))
+  @IsString()
+  @IsNotEmpty()
+  videoLength: string;
+
+  constructor(
+    questionId: number,
+    videoName: string,
+    url: string,
+    thumbnail: string,
+    videoLength: string,
+  ) {
     this.questionId = questionId;
     this.videoName = videoName;
     this.url = url;
+    this.thumbnail = thumbnail;
+    this.videoLength = videoLength;
   }
 }

--- a/BE/src/video/dto/createVideoRequest.ts
+++ b/BE/src/video/dto/createVideoRequest.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
 import { createPropertyOption } from 'src/util/swagger.util';
 
 export class CreateVideoRequest {
@@ -28,7 +28,8 @@ export class CreateVideoRequest {
     ),
   )
   @IsString()
-  thumbnail: string;
+  @IsOptional()
+  thumbnail: string | null;
 
   @ApiProperty(createPropertyOption('03:29', '비디오 길이', String))
   @IsString()

--- a/BE/src/video/dto/singleVideoResponse.ts
+++ b/BE/src/video/dto/singleVideoResponse.ts
@@ -48,9 +48,9 @@ export class SingleVideoResponse {
   static from(video: Video) {
     return new SingleVideoResponse(
       video.id,
-      'https://test-thumbnail.com',
+      video.thumbnail,
       video.name,
-      '02:42',
+      video.videoLength,
       video.isPublic,
       video.createdAt.getTime(),
     );

--- a/BE/src/video/entity/video.ts
+++ b/BE/src/video/entity/video.ts
@@ -4,6 +4,7 @@ import { DefaultEntity } from 'src/app.entity';
 import { Member } from 'src/member/entity/member';
 import { Question } from 'src/question/entity/question';
 import { CreateVideoRequest } from '../dto/createVideoRequest';
+import { DEFAULT_THUMBNAIL } from 'src/constant/constant';
 
 @Entity({ name: 'Video' })
 export class Video extends DefaultEntity {
@@ -61,7 +62,7 @@ export class Video extends DefaultEntity {
       createVidoeRequest.questionId,
       createVidoeRequest.videoName,
       createVidoeRequest.url,
-      createVidoeRequest.thumbnail,
+      createVidoeRequest.thumbnail || DEFAULT_THUMBNAIL,
       createVidoeRequest.videoLength,
       false,
     );

--- a/BE/src/video/entity/video.ts
+++ b/BE/src/video/entity/video.ts
@@ -27,6 +27,12 @@ export class Video extends DefaultEntity {
   @Column()
   url: string;
 
+  @Column()
+  thumbnail: string;
+
+  @Column()
+  videoLength: string;
+
   @Column({ default: false })
   isPublic: boolean;
 
@@ -35,6 +41,8 @@ export class Video extends DefaultEntity {
     questionId: number,
     name: string,
     url: string,
+    thumbnail: string,
+    videoLength: string,
     isPublic: boolean,
   ) {
     super(undefined, new Date());
@@ -42,6 +50,8 @@ export class Video extends DefaultEntity {
     this.questionId = questionId;
     this.name = name;
     this.url = url;
+    this.thumbnail = thumbnail;
+    this.videoLength = videoLength;
     this.isPublic = isPublic;
   }
 
@@ -51,6 +61,8 @@ export class Video extends DefaultEntity {
       createVidoeRequest.questionId,
       createVidoeRequest.videoName,
       createVidoeRequest.url,
+      createVidoeRequest.thumbnail,
+      createVidoeRequest.videoLength,
       false,
     );
   }

--- a/BE/src/video/fixture/video.fixture.ts
+++ b/BE/src/video/fixture/video.fixture.ts
@@ -28,8 +28,24 @@ export const videoListExample = [
 ];
 
 export const videoListFixtureForTest = [
-  new Video(1, 1, '루이뷔통통튀기네', 'https://test.com', true),
-  new Video(1, 4, '루이뷔통통튀기네', 'https://foo.com', false),
+  new Video(
+    1,
+    1,
+    '루이뷔통통튀기네',
+    'https://test.com',
+    'https://thumbnail-test.com',
+    '03:29',
+    true,
+  ),
+  new Video(
+    1,
+    4,
+    '루이뷔통통튀기네',
+    'https://foo.com',
+    'https://bar-test.com',
+    '02:12',
+    false,
+  ),
 ];
 
 export const videoFixtureForTest = new Video(
@@ -37,5 +53,7 @@ export const videoFixtureForTest = new Video(
   1,
   '루이뷔통통튀기네',
   'https://test.com',
+  'https://thumbnail-test.com',
+  '03:29',
   true,
 );

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -39,10 +39,10 @@ export class VideoService {
     private questionRepository: QuestionRepository,
     private memberRepository: MemberRepository,
   ) {}
-  async createVideo(member: Member, createVidoeRequest: CreateVideoRequest) {
+  async createVideo(member: Member, createVideoRequest: CreateVideoRequest) {
     validateManipulatedToken(member);
 
-    const newVideo = Video.from(member, createVidoeRequest);
+    const newVideo = Video.from(member, createVideoRequest);
     await this.videoRepository.save(newVideo);
   }
 


### PR DESCRIPTION
[![NDD-236](https://badgen.net/badge/JIRA/NDD-236/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-236) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
이전에는 서버에서 비디오 정보를 토대로 썸네일을 만들고, 동영상 길이도 체크하여 클라이언트에게 해당 정보를 보내주는 로직으로 기능을 구현하려 했으나, 편의성과 로직의 합리성을 고려하였을 때 이런 작업들을 클라이언트에서 처리 후 서버에 보내주는 것이 바람직하다는 결론이 내려져 이를 원래 만들어 놓은 비디오를 DB에 등록하는 API에 반영

# How
비디오 정보 저장 API 변경을 위해 여러 부분에서의 수정이 필요했다.
### 비디오 정보 저장
- 비디오 등록 API의 요청 객체인 CreateVideoRequest에 비디오 썸네일과 비디오 길이 정보를 담을 속성을 추가
- 비디오 엔티티에 비디오의 썸네일과 길이를 담을 컬럼을 추가
- 클라이언트에서 썸네일 이미지를 받지 못할 경우(null)를 대비하여 곰터뷰의 커스텀 이미지를 미리 IDrive에 저장해두고, 저장한 이미지의 URL을 사용

### 비디오 전체 조회
- 비디오 전체 조회 시 DB에서 얻어낸 비디오 데이터에 저장된 썸네일 URL과 비디오의 길이까지 함께 반환하도록 구현

### 테스트 코드
- 테스트 코드에서 비디오 등록 API의 요청 객체인 CreateVideoRequest를 사용하는 부분을 변경

# Result
### 비디오 정보 저장
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/41a3f595-f609-4c63-bdce-fffc955e68c5)

### 비디오 전체 조회
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/6d47b521-4fbb-4e87-8972-ac487205cc59)

# Prize
기존에 구현을 해두었던 API를 수정하는 과정이라 크게 오래 걸리진 않았다. 
미리 확장성을 염두하여 최대한 역할 분리를 잘해가며 구현을 해왔기에 쉽게 수정을 하지 않았나 생각한다. 확장성을 고려한 로직 작성이 얼마나 중요한지 이번의 실제 구현 작업을 통해 깨달을 수 있었다.

또한 class-validator 중 해당 필드에 값이 없어도 되며, 값이 제공되지 않았을 때 유효성 검사를 통과시켜주는 @IsOptional()과 string이 정규표현식에 매치될 때 유효성 검사를 통과시켜주는 @Matches()라는 어노테이션에 대해 새롭게 학습할 수 있었다.

# Ref
https://velog.io/@jay2u8809/NestJs-Class-Validator-%EB%A1%9C-DTO-%ED%83%80%EC%9E%85-%EC%B2%B4%ED%81%AC%ED%95%98%EB%A9%B4%EC%84%9C-undefined%EB%A5%BC-%EB%B0%9B%EB%8A%94-%EB%B0%A9%EB%B2%95

[NDD-236]: https://milk717.atlassian.net/browse/NDD-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ