### PR TITLE
[NDD-115]: 대표답변을 설정하는 기능 구현 (1h / 1h)

### DIFF
--- a/BE/src/answer/answer.module.ts
+++ b/BE/src/answer/answer.module.ts
@@ -8,13 +8,22 @@ import { AnswerService } from './service/answer.service';
 import { AnswerController } from './controller/answer.controller';
 import { QuestionRepository } from '../question/repository/question.repository';
 import { QuestionModule } from '../question/question.module';
+import { CategoryRepository } from '../category/repository/category.repository';
+import { CategoryModule } from '../category/category.module';
+import { Category } from '../category/entity/category';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Member, Answer, Question]),
+    TypeOrmModule.forFeature([Member, Answer, Question, Category]),
     QuestionModule,
+    CategoryModule,
   ],
-  providers: [AnswerRepository, AnswerService, QuestionRepository],
+  providers: [
+    AnswerRepository,
+    AnswerService,
+    QuestionRepository,
+    CategoryRepository,
+  ],
   controllers: [AnswerController],
 })
 export class AnswerModule {}

--- a/BE/src/answer/controller/answer.controller.spec.ts
+++ b/BE/src/answer/controller/answer.controller.spec.ts
@@ -6,6 +6,7 @@ import {
   memberFixture,
   memberFixturesOAuthRequest,
   mockReqWithMemberFixture,
+  oauthRequestFixture,
 } from '../../member/fixture/member.fixture';
 import {
   answerFixture,
@@ -26,7 +27,10 @@ import {
   addAppModules,
   createIntegrationTestModule,
 } from '../../util/test.util';
-import { categoryFixtureWithId } from '../../category/fixture/category.fixture';
+import {
+  beCategoryFixture,
+  categoryFixtureWithId,
+} from '../../category/fixture/category.fixture';
 import * as request from 'supertest';
 import { AuthService } from '../../auth/service/auth.service';
 import { AuthModule } from '../../auth/auth.module';
@@ -36,6 +40,7 @@ import { CreateAnswerRequest } from '../dto/createAnswerRequest';
 import { Token } from '../../token/entity/token';
 import { AnswerRepository } from '../repository/answer.repository';
 import { MemberRepository } from '../../member/repository/member.repository';
+import { DefaultAnswerRequest } from '../dto/defaultAnswerRequest';
 
 describe('AnswerController 단위테스트', () => {
   let controller: AnswerController;
@@ -237,6 +242,124 @@ describe('AnswerController 통합테스트', () => {
         .send(new CreateAnswerRequest(question.id, ''))
         .expect(400)
         .then(() => {});
+    });
+  });
+
+  describe('대표답변 변경', () => {
+    it('토큰을 가지고 존재하는 질문에 대해 존재하는 답변으로 대표답변 설정을 요청하면 성공적으로 변경해준다.', async () => {
+      //given
+      const member = await memberRepository.save(memberFixture);
+      const category = await categoryRepository.save(
+        Category.from(beCategoryFixture, member),
+      );
+      const question = await questionRepository.save(
+        Question.of(category, null, 'question'),
+      );
+      const answer = await answerRepository.save(
+        Answer.of('test', member, question),
+      );
+      //when&then
+      const token = await authService.login(memberFixturesOAuthRequest);
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .post('/api/answer/default')
+        .set('Cookie', [`accessToken=${token}`])
+        .send(new DefaultAnswerRequest(question.id, answer.id))
+        .expect(201);
+    });
+
+    it('토큰이 없으면 권한없음 처리한다.', async () => {
+      //given
+      const member = await memberRepository.save(memberFixture);
+      const category = await categoryRepository.save(
+        Category.from(beCategoryFixture, member),
+      );
+
+      const question = await questionRepository.save(
+        Question.of(category, null, 'question'),
+      );
+      const answer = await answerRepository.save(
+        Answer.of('test', member, question),
+      );
+
+      //when&then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .post('/api/answer/default')
+        .send(new DefaultAnswerRequest(question.id, answer.id))
+        .expect(401);
+    });
+
+    it('다른 사람의 질문 id로 대표답변을 수정하려하면 403코드를 반환한다', async () => {
+      //given
+      const member = await memberRepository.save(memberFixture);
+      const category = await categoryRepository.save(
+        Category.from(beCategoryFixture, member),
+      );
+
+      const question = await questionRepository.save(
+        Question.of(category, null, 'question'),
+      );
+      const answer = await answerRepository.save(
+        Answer.of('test', member, question),
+      );
+
+      //when&then
+      const token = await authService.login(oauthRequestFixture);
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .post('/api/answer/default')
+        .set('Cookie', [`accessToken=${token}`])
+        .send(new DefaultAnswerRequest(question.id, answer.id))
+        .expect(403);
+    });
+
+    it('질문 id가 존재하지 않으면 404코드를 반환한다', async () => {
+      //given
+      const member = await memberRepository.save(memberFixture);
+      const category = await categoryRepository.save(
+        Category.from(beCategoryFixture, member),
+      );
+
+      const question = await questionRepository.save(
+        Question.of(category, null, 'question'),
+      );
+      const answer = await answerRepository.save(
+        Answer.of('test', member, question),
+      );
+
+      //when&then
+      const token = await authService.login(memberFixturesOAuthRequest);
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .post('/api/answer/default')
+        .set('Cookie', [`accessToken=${token}`])
+        .send(new DefaultAnswerRequest(12341, answer.id))
+        .expect(404);
+    });
+
+    it('답변 id가 존재하지 않으면 404코드를 반환한다', async () => {
+      //given
+      const member = await memberRepository.save(memberFixture);
+      const category = await categoryRepository.save(
+        Category.from(beCategoryFixture, member),
+      );
+
+      const question = await questionRepository.save(
+        Question.of(category, null, 'question'),
+      );
+      const answer = await answerRepository.save(
+        Answer.of('test', member, question),
+      );
+
+      //when&then
+      const token = await authService.login(memberFixturesOAuthRequest);
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .post('/api/answer/default')
+        .set('Cookie', [`accessToken=${token}`])
+        .send(new DefaultAnswerRequest(question.id, 124321))
+        .expect(404);
     });
   });
 });

--- a/BE/src/answer/controller/answer.controller.spec.ts
+++ b/BE/src/answer/controller/answer.controller.spec.ts
@@ -10,6 +10,7 @@ import {
 import {
   answerFixture,
   createAnswerRequestFixture,
+  defaultAnswerRequestFixture,
 } from '../fixture/answer.fixture';
 import { INestApplication } from '@nestjs/common';
 import { CategoryRepository } from '../../category/repository/category.repository';
@@ -41,6 +42,7 @@ describe('AnswerController 단위테스트', () => {
 
   const mockAnswerService = {
     addAnswer: jest.fn(),
+    setDefaultAnswer: jest.fn(),
   };
 
   beforeAll(async () => {
@@ -75,6 +77,23 @@ describe('AnswerController 단위테스트', () => {
           mockReqWithMemberFixture,
         ),
       ).resolves.toEqual(AnswerResponse.from(answerFixture, memberFixture));
+    });
+  });
+
+  describe('대표답변 변경', () => {
+    it('각 질문에 대한 대표 답변을 설정할 수 있다.', async () => {
+      //given
+      mockAnswerService.setDefaultAnswer.mockResolvedValue(undefined);
+
+      //when
+
+      //then
+      await expect(
+        controller.updateDefaultAnswer(
+          defaultAnswerRequestFixture,
+          mockReqWithMemberFixture,
+        ),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/BE/src/answer/controller/answer.controller.ts
+++ b/BE/src/answer/controller/answer.controller.ts
@@ -13,6 +13,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { createApiResponseOption } from '../../util/swagger.util';
 import { Member } from '../../member/entity/member';
 import { AnswerResponse } from '../dto/answerResponse';
+import { DefaultAnswerRequest } from '../dto/defaultAnswerRequest';
 
 @ApiTags('answer')
 @Controller('/api/answer')
@@ -33,6 +34,24 @@ export class AnswerController {
   ) {
     return await this.answerService.addAnswer(
       createAnswerRequest,
+      req.user as Member,
+    );
+  }
+
+  @Post('default')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth()
+  @ApiBody({ type: DefaultAnswerRequest })
+  @ApiOperation({
+    summary: '질문의 대표답변 설정',
+  })
+  @ApiResponse(createApiResponseOption(201, '대표답변 설정 완료', null))
+  async updateDefaultAnswer(
+    @Body() defaultAnswerRequest: DefaultAnswerRequest,
+    @Req() req: Request,
+  ) {
+    return await this.answerService.setDefaultAnswer(
+      defaultAnswerRequest,
       req.user as Member,
     );
   }

--- a/BE/src/answer/dto/defaultAnswerRequest.ts
+++ b/BE/src/answer/dto/defaultAnswerRequest.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from '../../util/swagger.util';
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class DefaultAnswerRequest {
+  @ApiProperty(createPropertyOption(1, '문제 ID', Number))
+  @IsNumber()
+  @IsNotEmpty()
+  questionId: number;
+
+  @ApiProperty(createPropertyOption(1, '답변 ID', Number))
+  @IsNumber()
+  @IsNotEmpty()
+  answerId: number;
+
+  constructor(questionId: number, answerId: number) {
+    this.questionId = questionId;
+    this.answerId = answerId;
+  }
+}

--- a/BE/src/answer/exception/answer.exception.ts
+++ b/BE/src/answer/exception/answer.exception.ts
@@ -1,0 +1,9 @@
+import { HttpException } from '@nestjs/common';
+
+class AnswerNotFoundException extends HttpException {
+  constructor() {
+    super('해당 답변을 찾을 수 없습니다.', 404);
+  }
+}
+
+export { AnswerNotFoundException };

--- a/BE/src/answer/fixture/answer.fixture.ts
+++ b/BE/src/answer/fixture/answer.fixture.ts
@@ -2,6 +2,7 @@ import { Answer } from '../entity/answer';
 import { memberFixture } from '../../member/fixture/member.fixture';
 import { questionFixture } from '../../question/util/question.util';
 import { CreateAnswerRequest } from '../dto/createAnswerRequest';
+import { DefaultAnswerRequest } from '../dto/defaultAnswerRequest';
 
 export const answerFixture = Answer.of(
   'testContent',
@@ -12,4 +13,9 @@ export const answerFixture = Answer.of(
 export const createAnswerRequestFixture = new CreateAnswerRequest(
   questionFixture.id,
   'test',
+);
+
+export const defaultAnswerRequestFixture = new DefaultAnswerRequest(
+  questionFixture.id,
+  answerFixture.id,
 );

--- a/BE/src/answer/repository/answer.repository.ts
+++ b/BE/src/answer/repository/answer.repository.ts
@@ -13,6 +13,10 @@ export class AnswerRepository {
     return await this.repository.save(answer);
   }
 
+  async findById(id: number) {
+    return await this.repository.findOneBy({ id: id });
+  }
+
   async findByContentMemberIdAndQuestionId(
     content: string,
     memberId: number,

--- a/BE/src/answer/service/answer.service.spec.ts
+++ b/BE/src/answer/service/answer.service.spec.ts
@@ -29,16 +29,26 @@ describe('AnswerService 단위 테스트', () => {
   };
   const mockQuestionRepository = {
     findById: jest.fn(),
+    findWithOriginById: jest.fn(),
   };
+
+  const mockCategoryRepository = {};
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AnswerService, AnswerRepository, QuestionRepository],
+      providers: [
+        AnswerService,
+        AnswerRepository,
+        QuestionRepository,
+        CategoryRepository,
+      ],
     })
       .overrideProvider(AnswerRepository)
       .useValue(mockAnswerRepository)
       .overrideProvider(QuestionRepository)
       .useValue(mockQuestionRepository)
+      .overrideProvider(CategoryRepository)
+      .useValue(mockCategoryRepository)
       .compile();
 
     service = module.get<AnswerService>(AnswerService);
@@ -51,7 +61,9 @@ describe('AnswerService 단위 테스트', () => {
   describe('질문추가', () => {
     it('질문에 답변을 추가한다.', async () => {
       //given
-      mockQuestionRepository.findById.mockResolvedValue(questionFixture);
+      mockQuestionRepository.findWithOriginById.mockResolvedValue(
+        questionFixture,
+      );
 
       //when
       const answer = Answer.of('test', memberFixture, questionFixture);
@@ -65,7 +77,7 @@ describe('AnswerService 단위 테스트', () => {
 
     it('질문에 답변을 추가할 때 id로 질문을 확인할 수 없을 때 QuestionNotFoundException을 반환한다.', async () => {
       //given
-      mockQuestionRepository.findById.mockRejectedValue(
+      mockQuestionRepository.findWithOriginById.mockRejectedValue(
         new QuestionNotFoundException(),
       );
 
@@ -175,7 +187,7 @@ describe('AnswerService 통합테스트', () => {
       const answer = await answerRepository.findByContentMemberIdAndQuestionId(
         'testAnswer',
         member.id,
-        question.id,
+        originalQuestion.id,
       );
       expect(answerResponse).toEqual(AnswerResponse.from(answer, member));
     });

--- a/BE/src/answer/service/answer.service.spec.ts
+++ b/BE/src/answer/service/answer.service.spec.ts
@@ -8,7 +8,7 @@ import { questionFixture } from '../../question/util/question.util';
 import { CreateAnswerRequest } from '../dto/createAnswerRequest';
 import { AnswerResponse } from '../dto/answerResponse';
 import { QuestionNotFoundException } from '../../question/exception/question.exception';
-import { INestApplication, UnauthorizedException } from '@nestjs/common';
+import { INestApplication } from '@nestjs/common';
 import { CategoryRepository } from '../../category/repository/category.repository';
 import { MemberRepository } from '../../member/repository/member.repository';
 import { CategoryModule } from '../../category/category.module';
@@ -26,6 +26,7 @@ import {
   defaultAnswerRequestFixture,
 } from '../fixture/answer.fixture';
 import { DefaultAnswerRequest } from '../dto/defaultAnswerRequest';
+import { ForbiddenException } from '../../token/exception/token.exception';
 
 describe('AnswerService 단위 테스트', () => {
   let service: AnswerService;
@@ -67,7 +68,7 @@ describe('AnswerService 단위 테스트', () => {
     expect(service).toBeDefined();
   });
 
-  describe('질문추가', () => {
+  describe('답변 추가', () => {
     it('질문에 답변을 추가한다.', async () => {
       //given
       mockQuestionRepository.findWithOriginById.mockResolvedValue(
@@ -135,7 +136,7 @@ describe('AnswerService 단위 테스트', () => {
       ).rejects.toThrow(new QuestionNotFoundException());
     });
 
-    it('질문에 대한 카테고리가 본인의 소유가 UnauthorizedException 예외처리한다(해당 질문이 속한 카테고리는 본인의 소유여야 한다)', async () => {
+    it('질문에 대한 카테고리가 본인의 소유가 Forbidden 예외처리한다(해당 질문이 속한 카테고리는 본인의 소유여야 한다)', async () => {
       //given
 
       //when
@@ -157,7 +158,7 @@ describe('AnswerService 단위 테스트', () => {
       //then
       await expect(
         service.setDefaultAnswer(defaultAnswerRequestFixture, memberFixture),
-      ).rejects.toThrow(new UnauthorizedException());
+      ).rejects.toThrow(new ForbiddenException());
     });
   });
 });
@@ -199,7 +200,7 @@ describe('AnswerService 통합테스트', () => {
     await categoryRepository.query('delete from Member');
   });
 
-  describe('질문추가', () => {
+  describe('답변 추가', () => {
     it('질문에 대한 응답을 추가할 수 있다.', async () => {
       //given
       const member = await memberRepository.save(memberFixture);
@@ -270,7 +271,7 @@ describe('AnswerService 통합테스트', () => {
         Category.from(categoryFixtureWithId, member),
       );
       const question = await questionRepository.save(
-        Question.copyOf(questionFixture, category),
+        Question.of(category, null, 'test'),
       );
       const answer = await answerRepository.save(
         Answer.of('test', member, question),

--- a/BE/src/answer/service/answer.service.spec.ts
+++ b/BE/src/answer/service/answer.service.spec.ts
@@ -25,6 +25,7 @@ import {
   createAnswerRequestFixture,
   defaultAnswerRequestFixture,
 } from '../fixture/answer.fixture';
+import { DefaultAnswerRequest } from '../dto/defaultAnswerRequest';
 
 describe('AnswerService 단위 테스트', () => {
   let service: AnswerService;
@@ -258,6 +259,32 @@ describe('AnswerService 통합테스트', () => {
         originalQuestion.id,
       );
       expect(answerResponse).toEqual(AnswerResponse.from(answer, member));
+    });
+  });
+
+  describe('대표답변 설정', () => {
+    it('Member와 알맞은 Questin이 온다면, 정상적으로 대표 답변을 설정해준다.', async () => {
+      //given
+      const member = await memberRepository.save(memberFixture);
+      const category = await categoryRepository.save(
+        Category.from(categoryFixtureWithId, member),
+      );
+      const question = await questionRepository.save(
+        Question.copyOf(questionFixture, category),
+      );
+      const answer = await answerRepository.save(
+        Answer.of('test', member, question),
+      );
+
+      //when
+      await answerService.setDefaultAnswer(
+        new DefaultAnswerRequest(question.id, answer.id),
+        member,
+      );
+      const updatedQuestion = await questionRepository.findById(question.id);
+
+      //then
+      expect(updatedQuestion.defaultAnswer.id).toEqual(answer.id);
     });
   });
 });

--- a/BE/src/answer/service/answer.service.ts
+++ b/BE/src/answer/service/answer.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { AnswerRepository } from '../repository/answer.repository';
 import { QuestionRepository } from '../../question/repository/question.repository';
 import { QuestionNotFoundException } from '../../question/exception/question.exception';
@@ -10,6 +10,8 @@ import { Answer } from '../entity/answer';
 import { AnswerResponse } from '../dto/answerResponse';
 import { DefaultAnswerRequest } from '../dto/defaultAnswerRequest';
 import { CategoryRepository } from '../../category/repository/category.repository';
+import { ForbiddenException } from '../../token/exception/token.exception';
+import { AnswerNotFoundException } from '../exception/answer.exception';
 
 @Injectable()
 export class AnswerService {
@@ -52,12 +54,16 @@ export class AnswerService {
     );
 
     if (!category.isOwnedBy(member)) {
-      throw new UnauthorizedException();
+      throw new ForbiddenException();
     }
 
     const answer = await this.answerRepository.findById(
       defaultAnswerRequest.answerId,
     );
+
+    if (isEmpty(answer)) {
+      throw new AnswerNotFoundException();
+    }
 
     question.setDefaultAnswer(answer);
     await this.questionRepository.save(question);

--- a/BE/src/answer/service/answer.service.ts
+++ b/BE/src/answer/service/answer.service.ts
@@ -42,7 +42,7 @@ export class AnswerService {
     defaultAnswerRequest: DefaultAnswerRequest,
     member: Member,
   ) {
-    const question = await this.findQuestionById(
+    const question = await this.questionRepository.findById(
       defaultAnswerRequest.questionId,
     );
     if (isEmpty(question)) {
@@ -82,9 +82,5 @@ export class AnswerService {
     return isEmpty(question.origin)
       ? question
       : this.questionRepository.findById(question.origin.id);
-  }
-
-  private async findQuestionById(questionId: number) {
-    return await this.questionRepository.findById(questionId);
   }
 }

--- a/BE/src/answer/service/answer.service.ts
+++ b/BE/src/answer/service/answer.service.ts
@@ -10,8 +10,8 @@ import { Answer } from '../entity/answer';
 import { AnswerResponse } from '../dto/answerResponse';
 import { DefaultAnswerRequest } from '../dto/defaultAnswerRequest';
 import { CategoryRepository } from '../../category/repository/category.repository';
-import { ForbiddenException } from '../../token/exception/token.exception';
 import { AnswerNotFoundException } from '../exception/answer.exception';
+import { CategoryForbiddenException } from '../../category/exception/category.exception';
 
 @Injectable()
 export class AnswerService {
@@ -54,7 +54,7 @@ export class AnswerService {
     );
 
     if (!category.isOwnedBy(member)) {
-      throw new ForbiddenException();
+      throw new CategoryForbiddenException();
     }
 
     const answer = await this.answerRepository.findById(

--- a/BE/src/category/exception/category.exception.ts
+++ b/BE/src/category/exception/category.exception.ts
@@ -12,4 +12,14 @@ class CategoryNotFoundException extends HttpException {
   }
 }
 
-export { CategoryNameEmptyException, CategoryNotFoundException };
+class CategoryForbiddenException extends HttpException {
+  constructor() {
+    super('해당 카테고리/질문에 대한 권한이 없습니다.', 403);
+  }
+}
+
+export {
+  CategoryNameEmptyException,
+  CategoryNotFoundException,
+  CategoryForbiddenException,
+};

--- a/BE/src/question/repository/question.repository.ts
+++ b/BE/src/question/repository/question.repository.ts
@@ -21,6 +21,26 @@ export class QuestionRepository {
     return await this.repository.findOneBy({ id: questionId });
   }
 
+  async findWithOriginById(id: number): Promise<Question | null> {
+    const question = await this.repository
+      .createQueryBuilder('Question')
+      .leftJoinAndSelect('Question.origin', 'origin')
+      .where('Question.id = :id', { id })
+      .getOne();
+
+    if (!question) {
+      return null;
+    }
+
+    const originQuestion = question.origin as Question | null;
+
+    if (!originQuestion) {
+      return question;
+    }
+
+    return originQuestion;
+  }
+
   async remove(question: Question) {
     await this.repository.remove(question);
   }

--- a/BE/src/token/exception/token.exception.ts
+++ b/BE/src/token/exception/token.exception.ts
@@ -24,9 +24,16 @@ class NeedToLoginException extends HttpException {
   }
 }
 
+class ForbiddenException extends HttpException {
+  constructor() {
+    super('권한이 없습니다', 403);
+  }
+}
+
 export {
   InvalidTokenException,
   TokenExpiredException,
   ManipulatedTokenNotFiltered,
   NeedToLoginException,
+  ForbiddenException,
 };


### PR DESCRIPTION
[![NDD-115](https://badgen.net/badge/JIRA/NDD-115/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-115) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- 회원이 각자 자신만의 대표답변을 볼 수 있어야 한다.
- 회원과 질문은 근본적으로는 다대다 매핑을 한다. 
- 그렇게 되면 답변중 대표 답변도 질문.회원과 함께 다대다로 구조가 복잡해진다. 
- 이런 부분을 Question을 복사가능한 형태로 만들고, Question마다 Answer를 일대일로 매핑되게 할 수 있다.
   - 이 때 질문 A와 복사된 질문 a가 있을 때, 둘이 모두 같은 대표답변을 가질 수 있어야 한다. 
   - 이를 위해 대표 답변을 다대일로 관계를 가지게 했다.

# How

- 대표답변을 조회할 때, Question의 origin을 확인할 필요가 없었다. 
- 질문이 회원의 질문이 맞는지 Category를 통해 검증했다. 

# Result

<img width="977" alt="스크린샷 2023-11-22 19 19 14" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/714ca87a-dce5-4a60-940e-5d6ce6fa3829">
<img width="1115" alt="스크린샷 2023-11-22 19 29 14" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/d968e185-02fd-4bb4-93d4-61d4b27c3014">



[NDD-115]: https://milk717.atlassian.net/browse/NDD-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ