### PR TITLE
[NDD-238] 라우터 로더에서 에러 발생 시 리다이랙션 되지 않고 에러 페이지 표시되는 문제 해결 (0.3/1h)

### DIFF
--- a/FE/src/AppRouter.tsx
+++ b/FE/src/AppRouter.tsx
@@ -9,12 +9,12 @@ import { QueryClient } from '@tanstack/react-query';
 import { createBrowserRouter, Outlet, RouterProvider } from 'react-router-dom';
 import myPageLoader from '@routes/myPageLoader';
 import invalidPathLoader from '@routes/invalidPathLoader';
-import rootLoader from '@routes/rootLoader';
 import InterviewVideoPublicPage from '@page/interviewVideoPublicPage';
 import InterviewVideoPublicLoader from '@routes/interviewVideoPublicLoader';
+import rootLoader from '@routes/rootLoader';
 
-const routes = ({ queryClient }: { queryClient: QueryClient }) => {
-  return createBrowserRouter([
+const AppRouter = ({ queryClient }: { queryClient: QueryClient }) => {
+  const routes = createBrowserRouter([
     {
       path: PATH.ROOT,
       element: <Outlet />,
@@ -58,10 +58,7 @@ const routes = ({ queryClient }: { queryClient: QueryClient }) => {
       ],
     },
   ]);
-};
-
-const AppRouter = ({ queryClient }: { queryClient: QueryClient }) => {
-  return <RouterProvider router={routes({ queryClient: queryClient })} />;
+  return <RouterProvider router={routes} />;
 };
 
 export default AppRouter;

--- a/FE/src/routes/interviewVideoPublicLoader.ts
+++ b/FE/src/routes/interviewVideoPublicLoader.ts
@@ -3,6 +3,7 @@ import { QUERY_KEY } from '@constants/queryKey';
 import { Params, redirect } from 'react-router-dom';
 import { PATH } from '@constants/path';
 import { getVideoByHash } from '@/apis/video';
+import axios from 'axios';
 
 const interviewVideoPublicLoader = async ({
   params,
@@ -12,12 +13,18 @@ const interviewVideoPublicLoader = async ({
   queryClient: QueryClient;
 }) => {
   const { videoHash = '' } = params;
-  await queryClient.ensureQueryData({
-    queryKey: QUERY_KEY.VIDEO_HASH(videoHash),
-    queryFn: () => getVideoByHash(videoHash),
-  });
+  await queryClient
+    .ensureQueryData({
+      queryKey: QUERY_KEY.VIDEO_HASH(videoHash),
+      queryFn: () => getVideoByHash(videoHash),
+    })
+    .catch((e) => {
+      if (axios.isAxiosError(e)) {
+        process.env.NODE_ENV === 'development' && console.error(e.toJSON());
+      }
+    });
   const queryState = queryClient.getQueryState(QUERY_KEY.VIDEO_HASH(videoHash));
-  return queryState?.data ? null : redirect(PATH.NOT_FOUND);
+  return queryState?.data ? null : redirect(PATH.ROOT);
 };
 
 export default interviewVideoPublicLoader;

--- a/FE/src/routes/myPageLoader.ts
+++ b/FE/src/routes/myPageLoader.ts
@@ -3,12 +3,19 @@ import { QueryClient } from '@tanstack/react-query';
 import { redirect } from 'react-router-dom';
 import { PATH } from '@constants/path';
 import { getMemberInfo } from '@/apis/member';
+import axios from 'axios';
 
 const myPageLoader = async ({ queryClient }: { queryClient: QueryClient }) => {
-  await queryClient.ensureQueryData({
-    queryKey: QUERY_KEY.MEMBER,
-    queryFn: getMemberInfo,
-  });
+  await queryClient
+    .ensureQueryData({
+      queryKey: QUERY_KEY.MEMBER,
+      queryFn: getMemberInfo,
+    })
+    .catch((e) => {
+      if (axios.isAxiosError(e)) {
+        process.env.NODE_ENV === 'development' && console.error(e.toJSON());
+      }
+    });
   const queryState = queryClient.getQueryState(QUERY_KEY.MEMBER);
   return queryState?.data ? null : redirect(PATH.ROOT);
 };

--- a/FE/src/routes/rootLoader.ts
+++ b/FE/src/routes/rootLoader.ts
@@ -1,14 +1,21 @@
 import { QueryClient } from '@tanstack/react-query';
 import { QUERY_KEY } from '@constants/queryKey';
 import { getMemberInfo } from '@/apis/member';
+import axios from 'axios';
 
 const rootLoader = async ({ queryClient }: { queryClient: QueryClient }) => {
-  await queryClient.ensureQueryData({
-    queryKey: QUERY_KEY.MEMBER,
-    queryFn: getMemberInfo,
-  });
+  await queryClient
+    .ensureQueryData({
+      queryKey: QUERY_KEY.MEMBER,
+      queryFn: getMemberInfo,
+    })
+    .catch((e) => {
+      if (axios.isAxiosError(e)) {
+        process.env.NODE_ENV === 'development' && console.error(e.toJSON());
+      }
+    });
 
-  return null;
+  return true;
 };
 
 export default rootLoader;


### PR DESCRIPTION
[![NDD-238](https://badgen.net/badge/JIRA/NDD-238/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-238) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# How
## 로더 문제 해결
- 기존 로직은 로더에서 에러를 던지기 때문에 리다이랙션 처리가 되지 않고 에러 페이지가 보인다는 문제가 있었습니다.
- 따라서 에러를 상위로 던지지 않고 catch 하는 로직을 추가해 api 요청 실패시 리다이랙션 처리만 해줘서 문제를 해결했습니다.
## 앱 라우터 구조 변경
createBrowserRouter 객체를 AppRouter 내부에 넣어서 불필요하게 queryClient를 props로 전달하는 로직을 최소화했습니다.

# Result
- 로더에서 에러 발생 시 개발 모드일 때만 로그를 찍도록 했습니다.

[NDD-238]: https://milk717.atlassian.net/browse/NDD-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ