### PR TITLE
 [NDD-241]: 카테고리 리스트 응답 dto 구조 변경 && 테스트 실패 케이스 수정 (2h / 1h)

### DIFF
--- a/BE/src/category/category.module.ts
+++ b/BE/src/category/category.module.ts
@@ -6,9 +6,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Category } from './entity/category';
 import { Question } from '../question/entity/question';
 import { TokenModule } from '../token/token.module';
+import { Answer } from '../answer/entity/answer';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Category, Question]), TokenModule],
+  imports: [
+    TypeOrmModule.forFeature([Category, Question, Answer]),
+    TokenModule,
+  ],
   providers: [CategoryRepository, CategoryService],
   controllers: [CategoryController],
 })

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -65,8 +65,8 @@ export class CategoryController {
   async findCategories(@Req() req: Request) {
     const token = getTokenValue(req);
     const member = await this.tokenService.findMemberByToken(token);
-
     const categories = await this.categoryService.findUsingCategories(member);
+    console.log(categories);
 
     return CategoryListResponse.of(categories);
   }

--- a/BE/src/category/controller/category.controller.ts
+++ b/BE/src/category/controller/category.controller.ts
@@ -66,7 +66,6 @@ export class CategoryController {
     const token = getTokenValue(req);
     const member = await this.tokenService.findMemberByToken(token);
     const categories = await this.categoryService.findUsingCategories(member);
-    console.log(categories);
 
     return CategoryListResponse.of(categories);
   }

--- a/BE/src/category/dto/categoryListResponse.ts
+++ b/BE/src/category/dto/categoryListResponse.ts
@@ -1,9 +1,21 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { createPropertyOption } from '../../util/swagger.util';
 import { CategoryResponse } from './categoryResponse';
-import { categoryListResponseFixture } from '../fixture/category.fixture';
+import {
+  categoryListResponseFixture,
+  customCategoryFixture,
+} from '../fixture/category.fixture';
 
 export class CategoryListResponse {
+  @ApiProperty(
+    createPropertyOption(
+      CategoryResponse.from(customCategoryFixture),
+      '커스텀 카테고리 정보',
+      CategoryResponse,
+    ),
+  )
+  customCategory: CategoryResponse | null;
+
   @ApiProperty(
     createPropertyOption(categoryListResponseFixture, '카테고리 리스트 응답', [
       CategoryResponse,
@@ -11,11 +23,24 @@ export class CategoryListResponse {
   )
   categoryList: CategoryResponse[];
 
-  constructor(categoryList: CategoryResponse[]) {
+  constructor(
+    customCategory: CategoryResponse,
+    categoryList: CategoryResponse[],
+  ) {
+    this.customCategory = customCategory;
     this.categoryList = categoryList;
   }
 
   static of(categoryList: CategoryResponse[]) {
-    return new CategoryListResponse(categoryList);
+    const customCategory = categoryList.filter(
+      (each) => each.name == '나만의 질문',
+    )[0];
+
+    const others = categoryList.filter((each) => each.name != '나만의 질문');
+
+    return new CategoryListResponse(
+      customCategory ? customCategory : null,
+      others,
+    );
   }
 }

--- a/BE/src/category/repository/category.repository.ts
+++ b/BE/src/category/repository/category.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Category } from '../entity/category';
 import { Repository } from 'typeorm';
+import { isEmpty } from 'class-validator';
 
 @Injectable()
 export class CategoryRepository {
@@ -14,18 +15,13 @@ export class CategoryRepository {
   }
 
   async findAllByMemberId(memberId: number) {
-    const queryBuilder = this.repository.createQueryBuilder('Category');
-
-    if (memberId === null) {
-      // Case 1: memberId가 null일 때, 연관관계가 Null인 Category를 조회
-      return await queryBuilder
-        .leftJoinAndSelect('Category.member', 'member')
-        .where('Category.member IS NULL')
-        .getMany();
+    if (isEmpty(memberId)) {
+      return await this.findCategoriesWithNullMember();
     }
     // Case 2: memberId가 존재할 때, 해당 값을 id로 가지는 member와 매핑된 Category를 조회
-    return await queryBuilder
-      .leftJoinAndSelect('Category.member', 'member')
+    return await this.repository
+      .createQueryBuilder('Category')
+      .leftJoinAndSelect('Category.member', 'Member')
       .where('Member.id = :memberId', { memberId })
       .getMany();
   }
@@ -47,5 +43,17 @@ export class CategoryRepository {
 
   async query(query: string) {
     return await this.repository.query(query);
+  }
+
+  async findAll() {
+    return await this.repository.find({});
+  }
+
+  async findCategoriesWithNullMember() {
+    return await this.repository
+      .createQueryBuilder('category')
+      .leftJoin('category.member', 'member')
+      .where('member.id IS NULL') // member가 null인 경우
+      .getMany();
   }
 }

--- a/BE/src/category/service/category.service.spec.ts
+++ b/BE/src/category/service/category.service.spec.ts
@@ -23,6 +23,7 @@ import {
   customCategoryFixture,
   feCategoryFixture,
 } from '../fixture/category.fixture';
+import { Answer } from '../../answer/entity/answer';
 
 describe('CategoryService', () => {
   let service: CategoryService;
@@ -197,7 +198,7 @@ describe('CategoryService 통합테스트', () => {
 
   beforeAll(async () => {
     const modules = [CategoryModule, MemberModule];
-    const entities = [Member, Category, Question];
+    const entities = [Member, Category, Question, Answer];
     const moduleFixture = await createIntegrationTestModule(modules, entities);
 
     app = moduleFixture.createNestApplication();
@@ -237,7 +238,7 @@ describe('CategoryService 통합테스트', () => {
     );
 
     //then
-    expect(result).toBeUndefined();
+    expect(result.name).toEqual('tester');
     expect(category.pop().name).toEqual('tester');
   });
 

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -34,6 +34,7 @@ export class CategoryService {
     const categories = await this.categoryRepository.findAllByMemberId(
       isEmpty(member) ? null : member.id,
     );
+    console.log(categories);
 
     return categories.map(CategoryResponse.from);
   }

--- a/BE/src/question/controller/question.controller.spec.ts
+++ b/BE/src/question/controller/question.controller.spec.ts
@@ -32,6 +32,7 @@ import { CreateQuestionRequest } from '../dto/createQuestionRequest';
 import * as cookieParser from 'cookie-parser';
 import { QuestionResponseList } from '../dto/questionResponseList';
 import { QuestionRepository } from '../repository/question.repository';
+import { Answer } from '../../answer/entity/answer';
 
 describe('QuestionController', () => {
   let controller: QuestionController;
@@ -119,7 +120,7 @@ describe('QuestionController 통합테스트', () => {
 
   beforeAll(async () => {
     const modules = [QuestionModule, TokenModule, AuthModule];
-    const entities = [Member, Token, Category, Question];
+    const entities = [Member, Token, Category, Question, Answer];
 
     const moduleFixture: TestingModule = await createIntegrationTestModule(
       modules,

--- a/BE/src/token/service/token.service.ts
+++ b/BE/src/token/service/token.service.ts
@@ -65,7 +65,7 @@ export class TokenService {
         (await this.getPayload(singleToken)).id,
       );
     } catch (error) {
-      return undefined;
+      return null;
     }
   }
 


### PR DESCRIPTION
[![NDD-241](https://badgen.net/badge/JIRA/NDD-241/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-241) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- 클라이언트단에서 카테고리를 직접 순회해 확인해야한다. 이는 조작의 위험이 있다.

# How

```
{
  customCategory : 
    {
      id,
      name
    },
  categories : [
    {
      id,
      name
    }
  ]
}
```
의 구조로 수정
# Result
![스크린샷 2023-11-22 20 57 58](https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/55a3a2c2-b546-4dec-9d75-839e0229b796)

- 전체에서 단 하나의 테스트 케이스를 제외한 전체 리펙토링
- 비회원의 카테고리 조회 기능 DB 플로우 이상 발생. 학습 후 수정 예정

[NDD-241]: https://milk717.atlassian.net/browse/NDD-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ