### PR TITLE
[NDD-239] 나만의 질문 입력창 구현하기 (3h/3h)

### DIFF
--- a/FE/src/apis/category.ts
+++ b/FE/src/apis/category.ts
@@ -1,9 +1,9 @@
 import { API } from '@/constants/api';
-import { Category } from '@/types/category';
+import { CategoryResDto } from '@/types/category';
 import getAPIResponseData from '@/utils/getAPIResponseData';
 
 export const getCategory = async () => {
-  return await getAPIResponseData<Category[]>({
+  return await getAPIResponseData<CategoryResDto>({
     method: 'get',
     url: API.CATEGORY,
   });

--- a/FE/src/apis/question.ts
+++ b/FE/src/apis/question.ts
@@ -9,3 +9,20 @@ export const getQuestion = async (id: number) => {
     params: { category: id },
   });
 };
+
+export const postQuestion = async ({
+  categoryId,
+  content,
+}: {
+  categoryId: number;
+  content: string;
+}) => {
+  return await getAPIResponseData({
+    method: 'post',
+    url: API.QUESTION,
+    data: {
+      categoryId: categoryId,
+      content: content,
+    },
+  });
+};

--- a/FE/src/components/foundation/Toggle/Toggle.tsx
+++ b/FE/src/components/foundation/Toggle/Toggle.tsx
@@ -11,9 +11,10 @@ const Toggle: React.FC<ToggleProps> = ({ isToggled, ...args }) => {
   return (
     <>
       <input
+        readOnly
         id="toggle"
         type="checkbox"
-        defaultChecked={isToggled}
+        checked={isToggled}
         css={ToggleInputStyle}
         {...args}
       />

--- a/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionAccordion.tsx
+++ b/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionAccordion.tsx
@@ -73,9 +73,19 @@ const QuestionAccordion: React.FC<QuestionAccordionProps> = ({
           {question.questionContent}
         </Typography>
       </AccordionSummary>
-      <AccordionDetails>
+      <AccordionDetails
+        css={css`
+          justify-content: space-between;
+        `}
+      >
         <LeadingDot>
-          <Typography noWrap variant="body3">
+          <Typography
+            noWrap
+            variant="body3"
+            css={css`
+              min-width: 100%;
+            `}
+          >
             {question.answerContent}
           </Typography>
         </LeadingDot>

--- a/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionAddForm.tsx
+++ b/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionAddForm.tsx
@@ -1,0 +1,63 @@
+import Button from '@/components/foundation/Button/Button';
+import InputArea from '@/components/foundation/InputArea/InputArea';
+import useInput from '@/hooks/useInput';
+import useQuestionAdd from '@/hooks/useQuestionAdd';
+import { css } from '@emotion/react';
+
+type QuestionAddFormProps = {
+  categoryId: number;
+};
+
+const QuestionAddForm: React.FC<QuestionAddFormProps> = ({ categoryId }) => {
+  const { addQuestion } = useQuestionAdd(categoryId, {
+    onSuccess: () => {
+      clearInput();
+    },
+  });
+
+  const { value, onChange, clearInput, isEmpty } =
+    useInput<HTMLTextAreaElement>('');
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (isEmpty()) return;
+    addQuestion({
+      categoryId,
+      value,
+    });
+  };
+
+  return (
+    <form
+      css={css`
+        padding: 1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.3rem;
+      `}
+      onSubmit={onSubmit}
+    >
+      <InputArea
+        rows={1}
+        css={css`
+          padding: 0.5rem;
+        `}
+        value={value}
+        onChange={onChange}
+      />
+      <Button
+        size="md"
+        css={css`
+          flex: 1;
+          white-space: nowrap;
+        `}
+        type="submit"
+      >
+        추가
+      </Button>
+    </form>
+  );
+};
+
+export default QuestionAddForm;

--- a/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionSelectionBox.tsx
+++ b/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionSelectionBox.tsx
@@ -17,10 +17,20 @@ const QuestionSelectionBox = () => {
   //TODO: 현재 선택된 값은 임의 값임 Tabs를 변경한다면 가장 먼저 수정해야 할 사안.
   // HOW: 해당 state는 몇번째 Tab을 클릭했는지 저장하는 state이다. 따라서 Index값을 가지고 있고 이를 바탕으로 questionAPI 데이터를 가져와야 한다.
 
-  const { data: categoryData } = useCategoryQuery();
+  const { data: categoriesAPIData } = useCategoryQuery();
+
   const [{ isOpen, categoryId, question }, setModalState] = useRecoilState(
     QuestionAnswerSelectionModal
   );
+
+  if (!categoriesAPIData) return;
+
+  const myQuestionID = categoriesAPIData.customCategory.id;
+  const categoryData = [
+    ...categoriesAPIData.categories,
+    categoriesAPIData.customCategory,
+  ];
+
   return (
     <>
       {categoryId && question && (
@@ -67,7 +77,7 @@ const QuestionSelectionBox = () => {
             `}
             onTabChange={(_, value) => setSelectedTabIndex(value)}
           >
-            {categoryData?.map((category, index) => (
+            {categoryData.map((category, index) => (
               <Tabs.Tab value={index.toString()} key={category.id}>
                 <SelectionBox
                   id={`category-${category.id.toString()}`}
@@ -79,18 +89,18 @@ const QuestionSelectionBox = () => {
               </Tabs.Tab>
             ))}
           </Tabs.TabList>
-
           <div
             css={css`
               width: 100%;
               max-width: calc(100% - 12rem);
             `}
           >
-            {categoryData?.map((category, index) => (
+            {categoryData.map((category, index) => (
               <TabPanelItem
                 selectedTabIndex={selectedTabIndex}
                 tabIndex={index.toString()}
                 category={category}
+                type={category.id === myQuestionID ? 'custom' : 'default'}
                 key={category.id}
               />
             ))}

--- a/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionTabPanelItem.tsx
+++ b/FE/src/components/interviewSettingPage/QuestionSelectionBox/QuestionTabPanelItem.tsx
@@ -9,18 +9,26 @@ import { useRecoilValue } from 'recoil';
 import QuestionAccordion from './QuestionAccordion';
 import useQuestionCategoryQuery from '@/hooks/queries/useQuestionCategoryQuery';
 import Toggle from '@/components/foundation/Toggle/Toggle';
+import QuestionAddForm from './QuestionAddForm';
 
 type TabPanelItemProps = {
   selectedTabIndex: string;
   tabIndex: string;
   category: Category;
+  type: 'custom' | 'default';
 };
 
 const TabPanelItem: React.FC<TabPanelItemProps> = ({
   selectedTabIndex,
   category,
   tabIndex,
+  type,
 }) => {
+  const settingPage = useRecoilValue(questionSetting);
+  const selectedQuestions = settingPage.selectedData.filter(
+    (question) => question.categoryId === category.id
+  );
+
   const [onlySelectedOption, setOnlySelectedOption] = useState(false);
 
   const toggleShowSelectionOption = () => {
@@ -31,11 +39,6 @@ const TabPanelItem: React.FC<TabPanelItemProps> = ({
     categoryId: category.id,
     enabled: selectedTabIndex === tabIndex,
   });
-
-  const settingPage = useRecoilValue(questionSetting);
-  const selectedQuestions = settingPage.selectedData.filter(
-    (question) => question.categoryId === category.id
-  );
 
   const questionData = onlySelectedOption ? selectedQuestions : questionAPIData;
   if (!questionData) return;
@@ -65,6 +68,7 @@ const TabPanelItem: React.FC<TabPanelItemProps> = ({
         >
           {questionData.length}개의 질문
         </Typography>
+        {type === 'custom' && <QuestionAddForm categoryId={category.id} />}
         <div
           css={css`
             height: 100%;

--- a/FE/src/hooks/mutations/useQuestionMutation.ts
+++ b/FE/src/hooks/mutations/useQuestionMutation.ts
@@ -1,0 +1,37 @@
+import { postQuestion } from '@/apis/question';
+import { QUERY_KEY } from '@/constants/queryKey';
+import {
+  UseMutationOptions,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+const useQuestionMutation = (
+  categoryId: number,
+  options?: UseMutationOptions<
+    unknown,
+    Error,
+    {
+      categoryId: number;
+      content: string;
+    },
+    unknown
+  >
+) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, ...leftOption } = options || {};
+
+  return useMutation({
+    mutationFn: postQuestion,
+    onSuccess: (...args) => {
+      void queryClient.invalidateQueries({
+        queryKey: QUERY_KEY.QUESTION_CATEGORY(categoryId),
+      });
+      onSuccess?.(...args);
+    },
+    ...leftOption,
+  });
+};
+
+export default useQuestionMutation;

--- a/FE/src/hooks/useQuestionAdd.ts
+++ b/FE/src/hooks/useQuestionAdd.ts
@@ -15,9 +15,9 @@ const useQuestionAdd = (
     onSuccess: onSuccess,
   });
 
-  const createNewQuestion = (content: string, lastId: number = 0) => {
+  const createNewQuestion = (content: string, lastId: number = 1) => {
     return {
-      questionId: lastId + 1,
+      questionId: lastId - 1,
       questionContent: content,
       answerId: 0,
       answerContent: '',
@@ -38,11 +38,7 @@ const useQuestionAdd = (
         QUERY_KEY.QUESTION_CATEGORY(categoryId),
         (prev) => {
           if (!prev) return [createNewQuestion(value)];
-
-          return [
-            createNewQuestion(value, prev[prev.length - 1].questionId),
-            ...prev,
-          ];
+          return [createNewQuestion(value, prev[0].questionId), ...prev];
         }
       );
       onSuccess && onSuccess();

--- a/FE/src/hooks/useQuestionAdd.ts
+++ b/FE/src/hooks/useQuestionAdd.ts
@@ -1,0 +1,54 @@
+import { useQueryClient } from '@tanstack/react-query';
+import useQuestionMutation from './mutations/useQuestionMutation';
+import useUserInfo from './useUserInfo';
+import { Question } from '@/types/question';
+import { QUERY_KEY } from '@/constants/queryKey';
+
+const useQuestionAdd = (
+  categoryId: number,
+  { onSuccess }: { onSuccess?: () => void }
+) => {
+  const userInfo = useUserInfo();
+  const queryClient = useQueryClient();
+
+  const { mutate } = useQuestionMutation(categoryId, {
+    onSuccess: onSuccess,
+  });
+
+  const createNewQuestion = (content: string, lastId: number = 0) => {
+    return {
+      questionId: lastId + 1,
+      questionContent: content,
+      answerId: 0,
+      answerContent: '',
+    };
+  };
+
+  const addQuestion = ({
+    value,
+    categoryId,
+  }: {
+    value: string;
+    categoryId: number;
+  }) => {
+    if (userInfo) {
+      mutate({ content: value, categoryId: categoryId });
+    } else {
+      queryClient.setQueryData<Question[]>(
+        QUERY_KEY.QUESTION_CATEGORY(categoryId),
+        (prev) => {
+          if (!prev) return [createNewQuestion(value)];
+
+          return [
+            createNewQuestion(value, prev[prev.length - 1].questionId),
+            ...prev,
+          ];
+        }
+      );
+      onSuccess && onSuccess();
+    }
+  };
+  return { addQuestion };
+};
+
+export default useQuestionAdd;

--- a/FE/src/hooks/useUserInfo.ts
+++ b/FE/src/hooks/useUserInfo.ts
@@ -1,0 +1,11 @@
+import { QUERY_KEY } from '@/constants/queryKey';
+import { User } from '@/types/user';
+import { useQueryClient } from '@tanstack/react-query';
+
+const useUserInfo = () => {
+  const queryClient = useQueryClient();
+  const userInfo = queryClient.getQueryData<User | undefined>(QUERY_KEY.MEMBER);
+  return userInfo;
+};
+
+export default useUserInfo;

--- a/FE/src/mocks/handlers/category.ts
+++ b/FE/src/mocks/handlers/category.ts
@@ -4,24 +4,27 @@ import { HttpResponse, http } from 'msw';
 const categoryHandlers = [
   http.get(API.CATEGORY, () => {
     return HttpResponse.json(
-      [
-        {
-          id: 1,
-          name: 'FE',
-        },
-        {
-          id: 2,
-          name: 'BE',
-        },
-        {
-          id: 3,
-          name: 'CS',
-        },
-        {
+      {
+        customCategory: {
           id: 4,
           name: '나만의 질문',
         },
-      ],
+        categories: [
+          {
+            id: 1,
+            name: 'FE',
+          },
+          {
+            id: 2,
+            name: 'BE',
+          },
+          {
+            id: 3,
+            name: 'CS',
+          },
+        ],
+      },
+
       { status: 200 }
     );
   }),

--- a/FE/src/mocks/handlers/question.ts
+++ b/FE/src/mocks/handlers/question.ts
@@ -12,59 +12,59 @@ const questionHandlers = [
     console.log(category);
     return HttpResponse.json([
       {
-        questionId: '1',
+        questionId: 1,
         questionContent: 'CSS 선택자의 종류에 대해 설명해주세요.',
-        answerId: '123',
+        answerId: 123,
         answerContent:
           '선택자는 요소를 선택하는 방법을 말합니다. CSS 선택자는 CSS 규칙에 스타일을 적용할 요소를 선택하는 방법을 말합니다. CSS 선택자는 다음과 같이 세 가지 종류로 나눌 수 있습니다. 1. 타입 선택자 2. 클래스 선택자 3. 아이디 선택자',
       },
       {
-        questionId: '2',
+        questionId: 2,
         questionContent: 'JavaScript의 클로저(Closure)에 대해 설명해주세요.',
-        answerId: '1234',
+        answerId: 1234,
         answerContent:
           '클로저는 함수와 함수가 선언된 어휘적 환경의 조합입니다. 클로저를 이해하려면 자바스크립트의 어휘적 환경에 대한 이해가 필요합니다. 자바스크립트에서 함수는 객체입니다. 그리고 함수가 선언될 때, 그 함수의 LexicalEnvironment는 결정됩니다. LexicalEnvironment는 함수가 선언된 어휘적 환경을 의미합니다. 이 환경은 함수가 선언될 당시의 유효 범위 내에 있는 식별자들로 구성됩니다. 이 환경은 함수가 호출될 때, 그대로 함수와 함께 전달됩니다. 이렇게 함수와 그 함수가 선언된 어휘적 환경이 합쳐진 것을 클로저라고 합니다.',
       },
       {
-        questionId: '3',
+        questionId: 3,
         questionContent: 'HTML과 XHTML의 차이점은 무엇인가요?',
-        answerId: '12345',
+        answerId: 12345,
         answerContent:
           'HTML은 SGML(Standard Generalized Markup Language)의 약자이며, 웹 문서를 작성하기 위한 가장 기본적인 마크업 언어입니다. XHTML은 XML(Extensible Markup Language)의 약자이며, HTML을 XML로 재정의한 것입니다. XHTML은 HTML보다 엄격하게 작성되어 있습니다. XHTML은 HTML보다 더 많은 규칙을 가지고 있습니다. XHTML은 HTML보다 더 구조적이고 명확한 작성을 요구합니다.',
       },
       {
-        questionId: '4',
+        questionId: 4,
         questionContent:
           '반응형 웹 디자인과 적응형 웹 디자인의 차이점은 무엇인가요?',
-        answerId: '123456',
+        answerId: 123456,
         answerContent:
           '반응형 웹 디자인은 하나의 웹 사이트를 만들고, 그 웹 사이트를 여러 기기에 맞게 최적화하는 것을 의미합니다. 적응형 웹 디자인은 여러 개의 웹 사이트를 만들고, 각 기기에 맞게 웹 사이트를 제공하는 것을 의미합니다.',
       },
       {
-        questionId: '5',
+        questionId: 5,
         questionContent: 'CSS의 박스 모델(Box Model)에 대해 설명해주세요.',
-        answerId: '1234567',
+        answerId: 1234567,
         answerContent:
           'CSS의 박스 모델은 HTML 요소를 박스로 생각하고, 이 박스를 여러 개의 레이어로 구분한 것입니다. 박스 모델은 다음과 같이 구성됩니다. 1. 콘텐츠(Content) 2. 패딩(Padding) 3. 테두리(Border) 4. 마진(Margin)',
       },
       {
-        questionId: '6',
+        questionId: 6,
         questionContent: 'CSS의 position 속성에 대해 설명해주세요.',
-        answerId: '12345678',
+        answerId: 12345678,
         answerContent:
           'position 속성은 요소의 위치를 지정하는 속성입니다. position 속성은 다음과 같이 5가지 속성값을 가질 수 있습니다. 1. static 2. relative 3. absolute 4. fixed 5. sticky',
       },
       {
-        questionId: '7',
+        questionId: 7,
         questionContent: 'CSS의 float 속성에 대해 설명해주세요.',
-        answerId: '123456789',
+        answerId: 123456789,
         answerContent:
           'float 속성은 요소를 좌우 방향으로 띄우는 속성입니다. float 속성은 다음과 같이 3가지 속성값을 가질 수 있습니다. 1. left 2. right 3. none',
       },
       {
-        questionId: '8',
+        questionId: 8,
         questionContent: 'CSS의 flexbox에 대해 설명해주세요.',
-        answerId: '1234567890',
+        answerId: 1234567890,
         answerContent:
           'flexbox는 요소의 크기가 불분명하거나 동적인 경우에도, 요소를 정렬하기 위한 방법입니다. flexbox는 다음과 같이 2가지 속성을 가집니다. 1. flex container 2. flex item',
       },

--- a/FE/src/types/category.ts
+++ b/FE/src/types/category.ts
@@ -2,3 +2,8 @@ export type Category = {
   id: number;
   name: string;
 };
+
+export type CategoryResDto = {
+  customCategory: Category;
+  categories: Category[];
+};


### PR DESCRIPTION
[![NDD-239](https://badgen.net/badge/JIRA/NDD-239/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-239) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# How

## 변경점 1
카테고리 api이 바뀜에 따라 필요한 내용들을 수정했습니다. 그래서 customCategory는 자동으로 가장 아래에 오게끔 배치를 해두었습니다.
그리고 아직은 예정 사항에 없지만 추후에 TabPanelItem 디자인이 많이 달라진다 하면 바로 분리할 예정입니다


## 포인트 1
나만의 질문을 등록하는 과정은 다음과 같습니다. 먼저 유저가 로그인이 되었으면 나만의 질문을 api를 이용해 서버에 보내주고 질문 리스트를 갱신합니다.

유저가 로그인이 되어있지않으면 react-query내부의 chache에 직접 접근해서 추가한 데이터를 저장해 둡니다. 추후에 로그인 시에 이 데이터를 보내면 되는데 제 생각에는 이것도 엄현한 서버 상태가 아닐까? (서버에 있어야 하는 정보이니) 생각해서 일단 이렇게 작성하였습니다.


# Result

![image](https://github.com/boostcampwm2023/web14-gomterview/assets/49224104/cf2119f5-9e0d-4df6-8104-6a8243836888)


## 기타
비 로그인시를 테스트 해보고 싶으면 useUserInfo hook의 반환값을 undefined으로 설정한 후 테스트 하면 됩니다.

[NDD-239]: https://milk717.atlassian.net/browse/NDD-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ