### PR TITLE
[NDD-140] 화면 소리연결 페이지 구현 (1h/2h)

### DIFF
--- a/FE/src/page/interviewSettingPage/VideoSettingPage.tsx
+++ b/FE/src/page/interviewSettingPage/VideoSettingPage.tsx
@@ -1,0 +1,118 @@
+import { videoSetting } from '@/atoms/interviewSetting';
+import Button from '@/components/foundation/Button/Button';
+import RecordStatus from '@/components/interviewPage/InterviewHeader/RecordStatus';
+import Description from '@/components/interviewSettingPage/Description';
+import useMedia from '@/hooks/useMedia';
+import { theme } from '@/styles/theme';
+import { css } from '@emotion/react';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+
+type VideoSettingPageProps = {
+  onNextClick?: () => void;
+  onPrevClick?: () => void;
+};
+
+const VideoSettingPage: React.FC<VideoSettingPageProps> = ({
+  onNextClick,
+  onPrevClick,
+}) => {
+  const [videoSettingState, setVideoSettingState] =
+    useRecoilState(videoSetting);
+
+  const { videoRef: mirrorVideoRef, connectStatus } = useMedia();
+
+  useEffect(() => {
+    if (connectStatus === 'connect') {
+      setVideoSettingState({
+        isSuccess: true,
+      });
+    } else {
+      setVideoSettingState({
+        isSuccess: false,
+      });
+    }
+  }, [connectStatus, setVideoSettingState]);
+
+  return (
+    <div
+      css={css`
+        padding-top: 3rem;
+      `}
+    >
+      <Description title="문제 선택">
+        - 면접 시작 전, 사용하시는 장치의 화면 및 소리가 정상적으로 연결되어
+        있는지 확인해 주세요.
+        <br />
+        - 헤드셋이나 이어폰을 사용하시면 더욱 명료한 소리로 면접에 참여하실 수
+        있습니다.
+        <br />
+        - 화면이나 소리에 문제가 있을 경우, 잠시 면접을 중단하시고 문제를 해결한
+        뒤 이어나가 주세요.
+        <br />- 기타 기술적인 문제나 화면 공유 문제가 있으시면, 채팅창이나
+        연락처를 통해 알려주시길 바랍니다.
+      </Description>
+      <div
+        css={css`
+          position: relative;
+          margin-top: 2rem;
+          height: 100%;
+        `}
+      >
+        <div
+          css={css`
+            position: absolute;
+            top: 1rem;
+            left: 1rem;
+            z-index: 1;
+            padding: 0.5rem;
+            border-radius: 0.5rem;
+            background-color: ${theme.colors.shadow.modalShadow};
+          `}
+        >
+          <RecordStatus isRecording={connectStatus === 'connect'} />
+        </div>
+        <video
+          ref={mirrorVideoRef}
+          autoPlay
+          muted
+          css={css`
+            height: 100%;
+            transform: scaleX(-1);
+            width: 100%;
+          `}
+        />
+      </div>
+      <div
+        css={css`
+          display: flex;
+          justify-content: center;
+          gap: 1rem;
+          margin-top: 2rem;
+        `}
+      >
+        <Button
+          onClick={onPrevClick}
+          size="lg"
+          css={css`
+            padding: 0.6rem 2rem;
+          `}
+        >
+          이전
+        </Button>
+        <Button
+          onClick={onNextClick}
+          size="lg"
+          css={css`
+            padding: 0.6rem 2rem;
+          `}
+          disabled={!videoSettingState.isSuccess}
+        >
+          다음
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default VideoSettingPage;

--- a/FE/src/page/interviewSettingPage/index.tsx
+++ b/FE/src/page/interviewSettingPage/index.tsx
@@ -1,7 +1,6 @@
 import InterviewSettingPageLayout from '@/components/interviewSettingPage/InterviewSettingPageLayout';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { SETTING_PATH } from '@/constants/path';
-import VideoSettingBox from '@/components/interviewSettingPage/VideoSettingBox';
 import StepPage from '@/components/foundation/StepPages';
 import ProgressStepBar from '@/components/common/ProgressStepBar/ProgressStepBar';
 import {
@@ -13,6 +12,7 @@ import { useRecoilValue } from 'recoil';
 import QuestionSettingPage from './QuestionSettingPage';
 import { css } from '@emotion/react';
 import RecordSettingPage from './RecordSettingPage';
+import VideoSettingPage from './VideoSettingPage';
 
 const InterviewSettingPage: React.FC = () => {
   const navigate = useNavigate();
@@ -32,7 +32,7 @@ const InterviewSettingPage: React.FC = () => {
       name: '화면과 소리설정',
       path: SETTING_PATH.CONNECTION,
       page: (
-        <VideoSettingBox
+        <VideoSettingPage
           onPrevClick={() => changeSearchParams(SETTING_PATH.QUESTION)}
           onNextClick={() => changeSearchParams(SETTING_PATH.RECORD)}
         />


### PR DESCRIPTION
[![NDD-140](https://badgen.net/badge/JIRA/NDD-140/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-140) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# How

성인님이 만들어주신 hook과 컴포넌트 때문에 너무 쉽게 끝나버렸네요 ㅎㅎㅎ 다만 제가 건들이기에는 사이드 이펙트가 너무 클것 같은것들이 있어서 PR본문으로만 남겨 보겠습니다.


## 포인트1
useMedia 내부에 보니까 connectStatus가 true로 trigger되는 것은 있지만 false가 되는 건 없더라고요 그래서 크롬에 권한을 켰다가 꺼도 connectStatus는 그대로 true로 유지가 됩니다.


## 포인트2
RecordStatus 재사용 가능하도록 분리
요것도 분리만 잘된다면 기존의 것을 사용하면서 스타일을 동시에 가져갈 수 있을것 같아요 지금은 text가 고정되어 있어서 녹화중이라고 뜨는데 text는 children으로 받게 만들고 common으로 뺀다면 동시에 사용할 수 있을것 같습니다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/49224104/00f23d06-55bd-4d52-bb30-cfaeeaf28b72)


## 포인트3
Mirror컴포넌트도 같은 이유인데요 이걸 직접 쓰기에는 css를 직접 조작해 주어야 해서 현제 페이지는 그냥 video태그로 만들었는데요 뭔가 props로 ...args를 받아 왔으면 어떨까 하는 생각이 있습니다.

# Result

![image](https://github.com/boostcampwm2023/web14-gomterview/assets/49224104/c4bf980c-19ec-4755-959a-e6a081224ae3)

집 이슈로 인한 결과물은 머리 위로 짤랐습니다 ㅎㅎ

## ETC
- 페이지 라우팅 처리를 추가로 하면서 페이지 내부에서 사용하는 중복되는 로직을 줄이도록 하겠습니다

[NDD-140]: https://milk717.atlassian.net/browse/NDD-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ