### PR TITLE
[NDD-254]: 개발용 토큰 반환 API 구현 (0.5h / 0.5h)

### DIFF
--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - dev
 
+defaults:
+  run:
+    working-directory: ./BE
+
 jobs:
   build:
     runs-on: self-hosted
@@ -20,4 +24,4 @@ jobs:
           sudo docker build -t ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}} --platform linux/amd64 .
           sudo docker push ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}}
       - name: Run Docker Container
-        run: sudo docker run -d -p 8080:8080 -e TZ=Asia/Seoul --name ${{secrets.BE_DOCKER_CONTAINER}} ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}}
+        run: sudo docker run -d -p 80:8080 -e TZ=Asia/Seoul --name ${{secrets.BE_DOCKER_CONTAINER}} ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}}

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -24,4 +24,4 @@ jobs:
           sudo docker build -t ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}} --platform linux/amd64 .
           sudo docker push ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}}
       - name: Run Docker Container
-        run: sudo docker run -d -p 80:8080 -e TZ=Asia/Seoul --name ${{secrets.BE_DOCKER_CONTAINER}} ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}}
+        run: docker run --oom-kill-disable --restart on-failure -d -p 80:8080 -e TZ=Asia/Seoul --name ${{secrets.BE_DOCKER_CONTAINER}} ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}}

--- a/BE/src/app.controller.ts
+++ b/BE/src/app.controller.ts
@@ -1,16 +1,19 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
+  @ApiExcludeEndpoint()
   async getHello() {
     return this.appService.getHello();
   }
 
   @Get('/initializeDummy')
+  @ApiExcludeEndpoint()
   async saveDummy() {
     await this.appService.saveDummy();
   }

--- a/BE/src/auth/service/auth.service.ts
+++ b/BE/src/auth/service/auth.service.ts
@@ -8,8 +8,7 @@ import { CategoryRepository } from '../../category/repository/category.repositor
 import { QuestionRepository } from '../../question/repository/question.repository';
 import { Category } from '../../category/entity/category';
 import { Question } from '../../question/entity/question';
-
-const BEARER_PREFIX: string = 'Bearer ';
+import { BEARER_PREFIX } from 'src/constant/constant';
 
 @Injectable()
 export class AuthService {

--- a/BE/src/constant/constant.ts
+++ b/BE/src/constant/constant.ts
@@ -1,5 +1,7 @@
 import 'dotenv/config';
 
+export const BEARER_PREFIX: string = 'Bearer ';
+
 export const companies = [
   '네이버',
   '카카오',

--- a/BE/src/token/service/token.service.ts
+++ b/BE/src/token/service/token.service.ts
@@ -70,7 +70,7 @@ export class TokenService {
   }
 
   async getDevToken() {
-    throw new Error('Method not implemented.');
+    return this.createToken(1); // 1번은 developndd 이메일로 가입한 개발자용 회원임
   }
 
   private async findByAccessToken(accessToken: string) {

--- a/BE/src/token/service/token.service.ts
+++ b/BE/src/token/service/token.service.ts
@@ -69,6 +69,10 @@ export class TokenService {
     }
   }
 
+  async getDevToken() {
+    throw new Error('Method not implemented.');
+  }
+
   private async findByAccessToken(accessToken: string) {
     return await this.tokenRepository.findByAccessToken(accessToken);
   }

--- a/BE/src/token/token.controller.ts
+++ b/BE/src/token/token.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { TokenService } from './service/token.service';
+
+@Controller('token')
+export class TokenController {
+  constructor(private tokenService: TokenService) {}
+
+  @Get()
+  async getDevToken() {
+    this.tokenService.getDevToken();
+  }
+}

--- a/BE/src/token/token.controller.ts
+++ b/BE/src/token/token.controller.ts
@@ -2,12 +2,14 @@ import { Controller, Get, Res } from '@nestjs/common';
 import { TokenService } from './service/token.service';
 import { Response } from 'express';
 import { BEARER_PREFIX } from 'src/constant/constant';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
 
 @Controller('/api/token')
 export class TokenController {
   constructor(private tokenService: TokenService) {}
 
   @Get()
+  @ApiExcludeEndpoint()
   async getDevToken(@Res() res: Response) {
     const devToken = await this.tokenService.getDevToken();
     res.setHeader('Authorization', `${BEARER_PREFIX} ${devToken}`).send();

--- a/BE/src/token/token.controller.ts
+++ b/BE/src/token/token.controller.ts
@@ -1,12 +1,15 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Res } from '@nestjs/common';
 import { TokenService } from './service/token.service';
+import { Response } from 'express';
+import { BEARER_PREFIX } from 'src/constant/constant';
 
-@Controller('token')
+@Controller('/api/token')
 export class TokenController {
   constructor(private tokenService: TokenService) {}
 
   @Get()
-  async getDevToken() {
-    this.tokenService.getDevToken();
+  async getDevToken(@Res() res: Response) {
+    const devToken = await this.tokenService.getDevToken();
+    res.setHeader('Authorization', `${BEARER_PREFIX} ${devToken}`).send();
   }
 }

--- a/BE/src/token/token.module.ts
+++ b/BE/src/token/token.module.ts
@@ -10,6 +10,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import 'dotenv/config';
 import { AccessTokenStrategy } from './strategy/access.token.strategy';
+import { TokenController } from './token.controller';
 
 @Module({
   imports: [
@@ -30,5 +31,6 @@ import { AccessTokenStrategy } from './strategy/access.token.strategy';
     AccessTokenStrategy,
   ],
   exports: [TokenService],
+  controllers: [TokenController],
 })
 export class TokenModule {}


### PR DESCRIPTION
[![NDD-254](https://badgen.net/badge/JIRA/NDD-254/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-254) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
DX 향상을 위해 개발용 토큰을 반환하는 API를 구현할 필요가 있기 때문이다.
또한 아래의 API들은 Swagger에서 나타낼 필요가 없기에 제외하였다.
- / (메인 Default API)
- DB에 더미데이터를 저장하는 API
- 개발용 토큰 반환 API

# How
팀 구글 이메일로 저장되어 있는 회원은 DB에 1번으로 저장되어 있기에 이를 사용하여 JWT를 만들어 반환
```javascript
async getDevToken() {
  return this.createToken(1); // 1번은 developndd 이메일로 가입한 개발자용 회원임
}

private async createToken(memberId: number) {
  const accessToken = await this.signToken(memberId, ACCESS_TOKEN_EXPIRES_IN);
  const refreshToken = await this.signToken(
    memberId,
    REFRESH_TOKEN_EXPIRES_IN,
  );
  const token = new Token(refreshToken, accessToken);
  await this.tokenRepository.save(token);
  return accessToken;
}
```

# Result
아래 사진처럼 원하는 대로 Bearer + jwt의 형태로 반환됨을 알 수 있음
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/e6d6e448-2a05-40ae-bb1c-d5880edc24d2)

# Prize
FE 개발자들의 DX 향상을 기대할 수 있음
Swagger API Docs에 꼭 필요한 API만 표시

[NDD-254]: https://milk717.atlassian.net/browse/NDD-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ