### PR TITLE
[NDD-255]: 해시로 조회 시 originUrl이 null일 때 핸들링이 안 되는 현상 픽스 (1h / 1h)

### DIFF
--- a/BE/src/member/exception/member.exception.ts
+++ b/BE/src/member/exception/member.exception.ts
@@ -1,0 +1,7 @@
+import { HttpException } from '@nestjs/common';
+
+export class MemberNotFoundException extends HttpException {
+  constructor() {
+    super('회원을 찾을 수 없습니다.', 404);
+  }
+}

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -27,6 +27,7 @@ import {
 import { VideoDetailResponse } from '../dto/videoDetailResponse';
 import { VideoHashResponse } from '../dto/videoHashResponse';
 import { SingleVideoResponse } from '../dto/singleVideoResponse';
+import { MemberNotFoundException } from 'src/member/exception/member.exception';
 
 describe('VideoController 단위 테스트', () => {
   let controller: VideoController;
@@ -247,6 +248,20 @@ describe('VideoController 단위 테스트', () => {
       // then
       expect(controller.getVideoDetailByHash(hash)).rejects.toThrow(
         VideoOfWithdrawnMemberException,
+      );
+    });
+
+    it('해시로 비디오 조회 시 비디오의 소유자를 찾을 수 없다면 MemberNotFoundException을 반환한다.', async () => {
+      // given
+
+      // when
+      mockVideoService.getVideoDetailByHash.mockRejectedValue(
+        new MemberNotFoundException(),
+      );
+
+      // then
+      expect(controller.getVideoDetailByHash(hash)).rejects.toThrow(
+        MemberNotFoundException,
       );
     });
 

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -31,6 +31,7 @@ import {
   saveToRedis,
 } from 'src/util/redis.util';
 import { SingleVideoResponse } from '../dto/singleVideoResponse';
+import { MemberNotFoundException } from 'src/member/exception/member.exception';
 
 @Injectable()
 export class VideoService {
@@ -82,9 +83,10 @@ export class VideoService {
     const originUrl = await getValueFromRedis(hash);
     const video = await this.videoRepository.findByUrl(originUrl);
     if (!video.isPublic) throw new VideoAccessForbiddenException();
+    if (isEmpty(video.memberId)) throw new VideoOfWithdrawnMemberException();
 
     const videoOwner = await this.memberRepository.findById(video.memberId);
-    if (!videoOwner) throw new VideoOfWithdrawnMemberException();
+    if (isEmpty(videoOwner)) throw new MemberNotFoundException();
 
     return VideoDetailResponse.from(video, videoOwner.nickname, hash);
   }


### PR DESCRIPTION
[![NDD-255](https://badgen.net/badge/JIRA/NDD-255/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-255) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
해시로 비디오 조회 시 다른 사람의 비디오가 조회되는 치명적인 버그가 있었다.
이는 Redis에서 해시로 원본의 URL을 알아내고, 이 원본 URL로 비디오 정보를 조회할 때 원본 URL이 null이면 DB상에서 가장 앞에 존재하는 비디오를 조회해오기 때문이었다.
```javascript
async findByUrl(url: string) {
  return await this.videoRepository.findOneBy({ url: url });
}
```
위의 코드를 보면 url 정보를 사용해 조회를 함을 알 수 있는데 이를 쿼리로 보면 `select * from Video {where Video.url = url}` 인데 여기서 url이 null이면 문제가 발생한다.
`select * from Video where Video.url = {null}`이 아니고, `select * from Video null`로 처리되기 때문에 findByUrl의 결과는 DB상 가장 첫 번째 비디오의 정보를 반환하는 것이다. 이는 DB의 보안성을 어기는 매우 치명적인 문제다.

이를 해결하기 위해 에러 핸들링 로직을 추가하였다.

# How
비디오의 회원 ID가 null인 경우에 대한 핸들링을 추가한다.

기존의 비디오의 실제 주인이 없을 때 사용하던 VideoOfWithdrawnMemberException을 비디오의 회원 ID가 없을 때 사용하도록하고, 그 회원 ID로 회원을 조회했을 때 조회되는 회원이 없다면 MemberNotFoundException을 반환하도록 구현을 변경하였다.
또한 이에 대한 테스트 코드도 추가적으로 작성하였다.

```javascript
// 서비스 로직
async getVideoDetailByHash(hash: string) {
  const originUrl = await getValueFromRedis(hash);
  const video = await this.videoRepository.findByUrl(originUrl);
  if (!video.isPublic) throw new VideoAccessForbiddenException();
  if (isEmpty(video.memberId)) throw new VideoOfWithdrawnMemberException(); // 변경된 부분

  const videoOwner = await this.memberRepository.findById(video.memberId);
  if (isEmpty(videoOwner)) throw new MemberNotFoundException(); // 추가된 부분

  return VideoDetailResponse.from(video, videoOwner.nickname, hash);
}

// 컨트롤러 테스트 코드
it('해시로 비디오 조회 시 비디오의 소유자를 찾을 수 없다면 MemberNotFoundException을 반환한다.', async () => {
  // given

  // when
  mockVideoService.getVideoDetailByHash.mockRejectedValue(
    new MemberNotFoundException(),
  );

  // then
  expect(controller.getVideoDetailByHash(hash)).rejects.toThrow(
    MemberNotFoundException,
  );
});
```
# Result
테스트를 정상적으로 통과함을 확인할 수 있음
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/3be69bfd-f8fa-41bd-b25e-7348643eea7f)

# Prize
해시로 비디오 조회 시 다른 사람의 비디오가 조회되는 치명적인 버그를 해결함으로써 API가 보안성을 어기지 않도록 변경할 수 있다.

[NDD-255]: https://milk717.atlassian.net/browse/NDD-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ