### PR TITLE
[NDD-242] 🎉경축 DX 개선!! 드디어 골칫덩어리 쿠키를 물리쳤다🎉 (1h/2h)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 node_modules
 dist
-.env
-.env.production
-.env.development
+.env.*
 *.log
 .vscode
 .idea
+src/dev/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
-node_modules
-dist
-.env.*
-*.log
 .vscode
 .idea
-src/dev/

--- a/FE/.gitignore
+++ b/FE/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env.*
+*.log
+src/dev/

--- a/FE/package.json
+++ b/FE/package.json
@@ -4,9 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "npx webpack build --mode production --env production=true",
+    "build": "npx webpack build --mode production --env mode=production",
     "start": "webpack --mode development --env production=false",
-    "dev": "webpack serve --mode development --open --hot --env production=false"
+    "dev": "webpack serve --mode development --open --hot --env mode=development",
+    "local": "webpack serve --mode development --open --hot --env mode=local"
   },
   "author": "",
   "license": "ISC",

--- a/FE/src/components/landingPage/GoogleLoginButton.tsx
+++ b/FE/src/components/landingPage/GoogleLoginButton.tsx
@@ -5,7 +5,6 @@ import Icon from '@foundation/Icon/Icon';
 import { HTMLElementTypes } from '@/types/utils';
 import useUserInfo from '@hooks/useUserInfo';
 import { API, BASE_URL } from '@constants/api';
-import cookieGenerator from '@/dev/cookieGenerator';
 import { useNavigate } from 'react-router-dom';
 import { PATH } from '@constants/path';
 
@@ -17,7 +16,9 @@ const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({ ...args }) => {
 
   const handleGoogleLogin = async () => {
     if (process.env.NODE_ENV === 'development') {
-      await cookieGenerator().then((_) => navigate(PATH.MYPAGE));
+      const { cookieGenerator } = await import('@/dev/cookieGenerator');
+      void (await cookieGenerator());
+      navigate(PATH.MYPAGE);
       return;
     }
 
@@ -27,7 +28,7 @@ const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({ ...args }) => {
   return (
     !userInfo && (
       <button
-        onClick={() => handleGoogleLogin()}
+        onClick={() => void handleGoogleLogin()}
         css={css`
           display: flex;
           align-items: center;

--- a/FE/src/components/landingPage/GoogleLoginButton.tsx
+++ b/FE/src/components/landingPage/GoogleLoginButton.tsx
@@ -25,33 +25,33 @@ const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({ ...args }) => {
     window.location.href = `${BASE_URL}${API.LOGIN}`;
   };
 
-  return (
-    !userInfo && (
-      <button
-        onClick={() => void handleGoogleLogin()}
-        css={css`
-          display: flex;
-          align-items: center;
-          column-gap: 0.75rem;
-          padding: 1.5rem 3rem;
-          border-radius: 3.125rem;
-          border: 0.0625rem solid ${theme.colors.border.default};
-          transition: transform 0.15s ease-in-out;
-          background-color: ${theme.colors.surface.default};
-          z-index: 1000;
+  if (userInfo) return null;
 
-          &:hover {
-            transform: translateY(-0.25rem);
-          }
-        `}
-        {...args}
-      >
-        <Icon id="google-logo" width="1.25rem" height="1.25rem" />
-        <Typography variant="title3" color={theme.colors.text.default}>
-          Google로 시작하기
-        </Typography>
-      </button>
-    )
+  return (
+    <button
+      onClick={() => void handleGoogleLogin()}
+      css={css`
+        display: flex;
+        align-items: center;
+        column-gap: 0.75rem;
+        padding: 1.5rem 3rem;
+        border-radius: 3.125rem;
+        border: 0.0625rem solid ${theme.colors.border.default};
+        transition: transform 0.15s ease-in-out;
+        background-color: ${theme.colors.surface.default};
+        z-index: 1000;
+
+        &:hover {
+          transform: translateY(-0.25rem);
+        }
+      `}
+      {...args}
+    >
+      <Icon id="google-logo" width="1.25rem" height="1.25rem" />
+      <Typography variant="title3" color={theme.colors.text.default}>
+        Google로 시작하기
+      </Typography>
+    </button>
   );
 };
 

--- a/FE/src/components/landingPage/GoogleLoginButton.tsx
+++ b/FE/src/components/landingPage/GoogleLoginButton.tsx
@@ -5,6 +5,7 @@ import Icon from '@foundation/Icon/Icon';
 import { HTMLElementTypes } from '@/types/utils';
 import useUserInfo from '@hooks/useUserInfo';
 import { API, BASE_URL } from '@constants/api';
+import cookieGenerator from '@/dev/cookieGenerator';
 import { useNavigate } from 'react-router-dom';
 import { PATH } from '@constants/path';
 
@@ -14,9 +15,9 @@ const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({ ...args }) => {
   const userInfo = useUserInfo();
   const navigate = useNavigate();
 
-  const handleGoogleLogin = () => {
-    if (userInfo) {
-      navigate(PATH.MYPAGE);
+  const handleGoogleLogin = async () => {
+    if (process.env.NODE_ENV === 'development') {
+      await cookieGenerator().then((_) => navigate(PATH.MYPAGE));
       return;
     }
 
@@ -24,30 +25,32 @@ const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({ ...args }) => {
   };
 
   return (
-    <button
-      onClick={handleGoogleLogin}
-      css={css`
-        display: flex;
-        align-items: center;
-        column-gap: 0.75rem;
-        padding: 1.5rem 3rem;
-        border-radius: 3.125rem;
-        border: 0.0625rem solid ${theme.colors.border.default};
-        transition: transform 0.15s ease-in-out;
-        background-color: ${theme.colors.surface.default};
-        z-index: 1000;
+    !userInfo && (
+      <button
+        onClick={() => handleGoogleLogin()}
+        css={css`
+          display: flex;
+          align-items: center;
+          column-gap: 0.75rem;
+          padding: 1.5rem 3rem;
+          border-radius: 3.125rem;
+          border: 0.0625rem solid ${theme.colors.border.default};
+          transition: transform 0.15s ease-in-out;
+          background-color: ${theme.colors.surface.default};
+          z-index: 1000;
 
-        &:hover {
-          transform: translateY(-0.25rem);
-        }
-      `}
-      {...args}
-    >
-      {!userInfo && <Icon id="google-logo" width="1.25rem" height="1.25rem" />}
-      <Typography variant="title3" color={theme.colors.text.default}>
-        {userInfo ? '마이페이지로 이동하기' : 'Google로 시작하기'}
-      </Typography>
-    </button>
+          &:hover {
+            transform: translateY(-0.25rem);
+          }
+        `}
+        {...args}
+      >
+        <Icon id="google-logo" width="1.25rem" height="1.25rem" />
+        <Typography variant="title3" color={theme.colors.text.default}>
+          Google로 시작하기
+        </Typography>
+      </button>
+    )
   );
 };
 

--- a/FE/src/index.tsx
+++ b/FE/src/index.tsx
@@ -8,7 +8,9 @@ async function deferRender() {
   if (process.env.NODE_ENV !== 'development') {
     return;
   }
-  return worker.start();
+  return worker.start({
+    onUnhandledRequest: 'bypass',
+  });
 }
 
 //GA 추적 태그 설정

--- a/FE/tsconfig.json
+++ b/FE/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5", // 결과 파일 형식
-    "module": "es2015", // module 형식
+    "module": "es2020", // module 형식
     "esModuleInterop": true, // import시 namespace alias 가능
     "moduleResolution": "node",
     "jsx": "react-jsx",

--- a/FE/webpack.config.js
+++ b/FE/webpack.config.js
@@ -5,8 +5,12 @@ const CopyPlugin = require('copy-webpack-plugin');
 const Dotenv = require('dotenv-webpack');
 
 module.exports = (env) => {
-  const envPath =
-    env.production === 'true' ? '.env.production' : '.env.development';
+  const envMode = {
+    production: '.env.production',
+    development: '.env.development',
+    local: '.env.local',
+  };
+  const envPath = envMode[env.mode];
   return {
     mode: process.env.production === 'true' ? 'production' : 'development',
     devtool: process.env.production === 'true' ? 'hidden-source-map' : 'eval',


### PR DESCRIPTION
[![NDD-242](https://badgen.net/badge/JIRA/NDD-242/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-242) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

쿠키의 크로스 도메인 문제로 인해 개발환경에서 로그인을 테스트할 수 없다는 불편한 점이 있었습니다.
그래서 프로덕션 사이트에서 쿠키를 발급받은 후 localhost에서 수동으로 쿠키를 설정해서 테스트했는데 DX가 매우 좋지 않았습니다.
게다가 MSW를 사용하는 환경, 실제 서버를 사용하는 환경이 따로 구성되어 있어서 개발할 때 마다 env파일의 BASE_URL 경로, 웹팩 프록시 설정, MSW 설정 등을 직접 조정해야 했고, 이로 인한 실수도 많이 발생했습니다.
그래서 DX를 개선하고자 이 작업을 진행했습니다.

# How

## 쿠키 자동 발급
메인 화면에서 구글 로그인 버튼을 눌렀을 때 development 환경이라면 토큰을 자동으로 생성하도록 구현했습니다.
하지만 이 코드는 외부에 노출되면 안될 것 같아서 .gitignore에 포함시켰습니다. 이 내용은 노션의 팀 관리 페이지에 기록해놓겠습니다.

## 개발 환경 분리
총 3가지의 환경으로 분리했습니다.
- production: 배포용 환경
- development: local에서 실 서버에 요청을 보내는 환경
- local: msw를 사용하는 환경

## gitignore 분리
현재 BE는 BE폴더 내에 별도의 gitignore를 사용하고 있지만, 프론트는 최상위 gitignore를 사용하고있었습니다.
따라서 최상위 gitignore에는 공통으로 사용할 것만 두고, 나머지 내용은 프론트용 gitignore로 분리했습니다.

## 📌중요📌 tsconfig 모듈 버전 업그레이드
동적 import를 사용하기 위해 `"module": "es2015"` -> `"module": "es2020"` 로 업그레이드했습니다.
`cookieGenerator` 함수는 development에서만 사용되고 production에선 사용되지 않는데 import는 최상위에서 하기 때문에 클라우드 플레어에서 배포시 해당 파일이 존재하지 않아 빌드에 실패한다는 문제점이 있었습니다.
따라서 `cookieGenerator`를 동적 import로 가져오도록 변경했습니다.

## MSW 경고 제거
[처리되지 않은 Supertest 요청에 대한 MSW 로깅 경고](https://stackoverflow.com/questions/68024935/msw-logging-warnings-for-unhandled-supertest-requests)를 참고해서 웹팩의 assets 요청이나 ga 관련 요청에 MSW 경고가 뜨는 것을 제거했습니다.


# Result

https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/7ad73f08-639c-41be-b1fe-1667e5fd1282


# Prize

DX 개선!!!!

[NDD-242]: https://milk717.atlassian.net/browse/NDD-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ