### PR TITLE
[NDD-184]: Video Service 단위 테스트 (4h / 3h)

### DIFF
--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -5,7 +5,6 @@ import {
   memberFixture,
   mockReqWithMemberFixture,
 } from 'src/member/fixture/member.fixture';
-import { CreateVideoRequest } from '../dto/createVideoRequest';
 import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
 import { Request, Response } from 'express';
 import { CreatePreSignedUrlRequest } from '../dto/createPreSignedUrlRequest';
@@ -21,6 +20,7 @@ import {
   VideoOfWithdrawnMemberException,
 } from '../exception/video.exception';
 import {
+  createVideoRequestFixture,
   videoFixture,
   videoListFixtureForTest,
 } from '../fixture/video.fixture';
@@ -59,13 +59,7 @@ describe('VideoController 단위 테스트', () => {
   });
 
   describe('createVideo', () => {
-    const createVideoRequest = new CreateVideoRequest(
-      1,
-      'test.webm',
-      'https://test.com',
-      'https://thumbnail-test.com',
-      '01:12',
-    );
+    const createVideoRequest = createVideoRequestFixture;
 
     it('비디오 저장 성공 시 undefined를 반환한다.', async () => {
       //given

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -21,7 +21,7 @@ import {
   VideoOfWithdrawnMemberException,
 } from '../exception/video.exception';
 import {
-  videoFixtureForTest,
+  videoFixture,
   videoListFixtureForTest,
 } from '../fixture/video.fixture';
 import { VideoDetailResponse } from '../dto/videoDetailResponse';
@@ -204,7 +204,7 @@ describe('VideoController 단위 테스트', () => {
 
     it('해시로 비디오 조회 성공 시 VideoDetailResponse 객체 형태로 응답된다.', async () => {
       // given
-      const video = videoFixtureForTest;
+      const video = videoFixture;
 
       // when
       const mockVideoDetailWithHash = VideoDetailResponse.from(
@@ -284,7 +284,7 @@ describe('VideoController 단위 테스트', () => {
     const mockReq = mockReqWithMemberFixture;
     const nickname = memberFixture.nickname;
     const hash = 'fakeHash';
-    const video = videoFixtureForTest;
+    const video = videoFixture;
 
     it('비디오 상세 정보 조회 성공 시 VideoDetailResponse 객체 형태로 응답된다.', async () => {
       // given

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -22,7 +22,7 @@ import {
   createPreSignedUrlRequestFixture,
   createVideoRequestFixture,
   videoFixture,
-  videoListFixtureForTest,
+  videoListFixture,
 } from '../fixture/video.fixture';
 import { VideoDetailResponse } from '../dto/videoDetailResponse';
 import { VideoHashResponse } from '../dto/videoHashResponse';
@@ -145,7 +145,7 @@ describe('VideoController 단위 테스트', () => {
   describe('getAllVideo', () => {
     it('비디오 전체 조회 성공 시 VideoListResponse 객체 형태로 응답된다.', async () => {
       //given
-      const videoList = videoListFixtureForTest;
+      const videoList = videoListFixture;
 
       //when
       const mockVideoListResponse = videoList.map(SingleVideoResponse.from);

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -7,7 +7,6 @@ import {
 } from 'src/member/fixture/member.fixture';
 import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
 import { Request, Response } from 'express';
-import { CreatePreSignedUrlRequest } from '../dto/createPreSignedUrlRequest';
 import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import {
   IDriveException,
@@ -20,6 +19,7 @@ import {
   VideoOfWithdrawnMemberException,
 } from '../exception/video.exception';
 import {
+  createPreSignedUrlRequestFixture,
   createVideoRequestFixture,
   videoFixture,
   videoListFixtureForTest,
@@ -90,7 +90,7 @@ describe('VideoController 단위 테스트', () => {
   });
 
   describe('getPreSignedUrl', () => {
-    const createPreSignedUrlRequest = new CreatePreSignedUrlRequest(1);
+    const createPreSignedUrlRequest = createPreSignedUrlRequestFixture;
 
     it('Pre-Signed URL 발급 완료 시 PreSignedUrlResponse 객체 형태로 응답된다.', async () => {
       //given

--- a/BE/src/video/dto/videoDetailResponse.ts
+++ b/BE/src/video/dto/videoDetailResponse.ts
@@ -7,7 +7,7 @@ export class VideoDetailResponse {
   readonly id: number;
 
   @ApiProperty(createPropertyOption('foobar', '회원의 닉네임', String))
-  private nickname: string;
+  readonly nickname: string;
 
   @ApiProperty(
     createPropertyOption('https://example-video.com', '비디오의 URL', String),

--- a/BE/src/video/fixture/video.fixture.ts
+++ b/BE/src/video/fixture/video.fixture.ts
@@ -1,3 +1,4 @@
+import { CreateVideoRequest } from '../dto/createVideoRequest';
 import { Video } from '../entity/video';
 
 export const videoListExample = [
@@ -48,7 +49,7 @@ export const videoListFixtureForTest = [
   ),
 ];
 
-export const videoFixtureForTest = new Video(
+export const videoFixture = new Video(
   1,
   1,
   '루이뷔통통튀기네',
@@ -56,4 +57,12 @@ export const videoFixtureForTest = new Video(
   'https://thumbnail-test.com',
   '03:29',
   true,
+);
+
+export const createVideoRequestFixture = new CreateVideoRequest(
+  1,
+  'foobar.webm',
+  'https://foo.com',
+  'https://bar.com',
+  '03:29',
 );

--- a/BE/src/video/fixture/video.fixture.ts
+++ b/BE/src/video/fixture/video.fixture.ts
@@ -1,3 +1,4 @@
+import { CreatePreSignedUrlRequest } from '../dto/createPreSignedUrlRequest';
 import { CreateVideoRequest } from '../dto/createVideoRequest';
 import { Video } from '../entity/video';
 
@@ -65,4 +66,8 @@ export const createVideoRequestFixture = new CreateVideoRequest(
   'https://foo.com',
   'https://bar.com',
   '03:29',
+);
+
+export const createPreSignedUrlRequestFixture = new CreatePreSignedUrlRequest(
+  1,
 );

--- a/BE/src/video/fixture/video.fixture.ts
+++ b/BE/src/video/fixture/video.fixture.ts
@@ -80,6 +80,16 @@ export const videoOfOtherFixture = new Video(
   false,
 );
 
+export const VideoOfWithdrawnMemberFixture = new Video(
+  null,
+  1,
+  '루이뷔통통튀기네',
+  'https://test.com',
+  'https://thumbnail-test.com',
+  '03:29',
+  true,
+);
+
 export const createVideoRequestFixture = new CreateVideoRequest(
   1,
   'foobar.webm',

--- a/BE/src/video/fixture/video.fixture.ts
+++ b/BE/src/video/fixture/video.fixture.ts
@@ -29,7 +29,7 @@ export const videoListExample = [
   },
 ];
 
-export const videoListFixtureForTest = [
+export const videoListFixture = [
   new Video(
     1,
     1,
@@ -58,6 +58,26 @@ export const videoFixture = new Video(
   'https://thumbnail-test.com',
   '03:29',
   true,
+);
+
+export const privateVideoFixture = new Video(
+  1,
+  1,
+  '루이뷔통통튀기네',
+  'https://test.com',
+  'https://thumbnail-test.com',
+  '03:29',
+  false,
+);
+
+export const videoOfOtherFixture = new Video(
+  999,
+  1,
+  '루이뷔통통튀기네',
+  'https://test.com',
+  'https://thumbnail-test.com',
+  '03:29',
+  false,
 );
 
 export const createVideoRequestFixture = new CreateVideoRequest(

--- a/BE/src/video/service/video.service.spec.ts
+++ b/BE/src/video/service/video.service.spec.ts
@@ -4,8 +4,12 @@ import { VideoRepository } from '../repository/video.repository';
 import { memberFixture } from 'src/member/fixture/member.fixture';
 import { QuestionRepository } from 'src/question/repository/question.repository';
 import { MemberRepository } from 'src/member/repository/member.repository';
-import { createVideoRequestFixture } from '../fixture/video.fixture';
+import {
+  createPreSignedUrlRequestFixture,
+  createVideoRequestFixture,
+} from '../fixture/video.fixture';
 import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
+import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 
 describe('VideoService', () => {
   let videoService: VideoService;
@@ -17,6 +21,10 @@ describe('VideoService', () => {
     findAllVideosByMemberId: jest.fn(),
     toggleVideoStatus: jest.fn(),
     remove: jest.fn(),
+  };
+
+  const mockQuestionRepository = {
+    findById: jest.fn(),
   };
 
   beforeAll(async () => {
@@ -33,7 +41,7 @@ describe('VideoService', () => {
       .overrideProvider(MemberRepository)
       .useValue({})
       .overrideProvider(QuestionRepository)
-      .useValue({})
+      .useValue(mockQuestionRepository)
       .compile();
 
     videoService = module.get<VideoService>(VideoService);
@@ -69,6 +77,22 @@ describe('VideoService', () => {
       expect(videoService.createVideo(member, request)).rejects.toThrow(
         ManipulatedTokenNotFiltered,
       );
+    });
+  });
+
+  describe('getPreSignedUrl', () => {
+    it('preSigned URL 얻기 성공시 PreSignedUrlResponse 형식으로 반환된다.', async () => {
+      // given
+      const member = memberFixture;
+      const request = createPreSignedUrlRequestFixture;
+
+      // when
+      const response = await videoService.getPreSignedUrl(member, request);
+      console.log(response);
+      // then
+      expect(response).toBeInstanceOf(PreSignedUrlResponse);
+      expect(response.key.endsWith('.webm')).toBeTruthy(); // 파일명은 반드시 webm이어야 함
+      expect(response.preSignedUrl.startsWith('https://videos')).toBeTruthy(); // 실제 Pre-Signed Url 구조를 따라가는지 확인하기 위함
     });
   });
 });

--- a/BE/src/video/service/video.service.spec.ts
+++ b/BE/src/video/service/video.service.spec.ts
@@ -224,4 +224,53 @@ describe('VideoService', () => {
       );
     });
   });
+
+  describe('getAllVideosByMemberId', () => {
+    const member = memberFixture;
+
+    it('비디오 전체 조회 성공 시 SingleVideoResponse의 배열의 형태로 반환된다.', async () => {
+      // give
+      const mockVideoList = videoListFixture;
+
+      // when
+      mockVideoRepository.findAllVideosByMemberId.mockResolvedValue(
+        mockVideoList,
+      );
+
+      // then
+      const result = await videoService.getAllVideosByMemberId(member);
+
+      expect(result).toHaveLength(mockVideoList.length);
+      expect(result).toEqual(mockVideoList.map(SingleVideoResponse.from));
+      result.forEach((element) => {
+        expect(element).toBeInstanceOf(SingleVideoResponse);
+      });
+    });
+
+    it('비디오 전체 조회 시 저장된 비디오가 없으면 빈 배열이 반환된다.', async () => {
+      // give
+      const emptyList = [];
+
+      // when
+      mockVideoRepository.findAllVideosByMemberId.mockResolvedValue(emptyList);
+
+      // then
+      const result = await videoService.getAllVideosByMemberId(member);
+
+      expect(result).toHaveLength(0);
+      expect(result).toEqual(emptyList);
+    });
+
+    it('비디오 전체 조회 시 member가 없으면 ManipulatedTokenNotFiltered을 반환한다.', () => {
+      // given
+      const member = undefined;
+
+      // when
+
+      // then
+      expect(videoService.getAllVideosByMemberId(member)).rejects.toThrow(
+        ManipulatedTokenNotFiltered,
+      );
+    });
+  });
 });

--- a/BE/src/video/service/video.service.spec.ts
+++ b/BE/src/video/service/video.service.spec.ts
@@ -7,22 +7,38 @@ import { MemberRepository } from 'src/member/repository/member.repository';
 import {
   createPreSignedUrlRequestFixture,
   createVideoRequestFixture,
+  privateVideoFixture,
+  videoFixture,
+  videoListFixture,
+  videoOfOtherFixture,
 } from '../fixture/video.fixture';
 import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
 import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import { S3 } from 'aws-sdk';
-import { IDriveException } from '../exception/video.exception';
+import {
+  IDriveException,
+  VideoAccessForbiddenException,
+  VideoNotFoundException,
+} from '../exception/video.exception';
+import { VideoDetailResponse } from '../dto/videoDetailResponse';
+import * as crypto from 'crypto';
+import { SingleVideoResponse } from '../dto/singleVideoResponse';
+import { getValueFromRedis } from 'src/util/redis.util';
 
 describe('VideoService', () => {
   let videoService: VideoService;
 
   const mockVideoRepository = {
     save: jest.fn(),
-    finById: jest.fn(),
+    findById: jest.fn(),
     findByUrl: jest.fn(),
     findAllVideosByMemberId: jest.fn(),
     toggleVideoStatus: jest.fn(),
     remove: jest.fn(),
+  };
+
+  const mockMemberRepository = {
+    findById: jest.fn(),
   };
 
   const mockQuestionRepository = {
@@ -41,7 +57,7 @@ describe('VideoService', () => {
       .overrideProvider(VideoRepository)
       .useValue(mockVideoRepository)
       .overrideProvider(MemberRepository)
-      .useValue({})
+      .useValue(mockMemberRepository)
       .overrideProvider(QuestionRepository)
       .useValue(mockQuestionRepository)
       .compile();
@@ -56,7 +72,7 @@ describe('VideoService', () => {
   describe('createVideo', () => {
     const request = createVideoRequestFixture;
 
-    it('비디오 저장 성공시 undefined로 반환된다.', async () => {
+    it('비디오 저장 성공시 undefined로 반환된다.', () => {
       // given
       const member = memberFixture;
 
@@ -69,7 +85,7 @@ describe('VideoService', () => {
       ).resolves.toBeUndefined();
     });
 
-    it('비디오 저장 시 member가 없으면 ManipulatedTokenNotFiltered을 반환한다.', async () => {
+    it('비디오 저장 시 member가 없으면 ManipulatedTokenNotFiltered을 반환한다.', () => {
       // given
       const member = undefined;
 
@@ -104,7 +120,7 @@ describe('VideoService', () => {
       expect(response.preSignedUrl.startsWith('https://videos')).toBeTruthy(); // 실제 Pre-Signed Url 구조를 따라가는지 확인하기 위함
     });
 
-    it('prSigned URL 얻기 성공 시 member가 없으면 ManipulatedTokenNotFiltered을 반환한다.', async () => {
+    it('prSigned URL 얻기 성공 시 member가 없으면 ManipulatedTokenNotFiltered을 반환한다.', () => {
       // given
       const member = undefined;
 
@@ -116,18 +132,95 @@ describe('VideoService', () => {
       );
     });
 
-    it('preSigned URL 얻기 시 IDrive Client가 Pre-Signed URL 발급에 실패하면 IDriveException을 반환한다.', async () => {
+    it('preSigned URL 얻기 시 IDrive Client가 Pre-Signed URL 발급에 실패하면 IDriveException을 반환한다.', () => {
       // given
       const member = memberFixture;
 
       // when
       const getSignedUrlMock = jest.fn();
       (S3.prototype.getSignedUrlPromise as jest.Mock) = getSignedUrlMock;
-      getSignedUrlMock.mockRejectedValueOnce(new IDriveException());
+      getSignedUrlMock.mockRejectedValue(new IDriveException());
 
       // then
       expect(videoService.getPreSignedUrl(member, request)).rejects.toThrow(
         IDriveException,
+      );
+    });
+  });
+
+  describe('getVideoDetail', () => {
+    const member = memberFixture;
+    const videoId = 1;
+
+    it('비디오 상세 정보 조회 성공 시 VideoDetailResponse 형식으로 반환된다.', async () => {
+      // given
+      const video = videoFixture;
+
+      // when
+      mockVideoRepository.findById.mockResolvedValue(video);
+      const response = await videoService.getVideoDetail(videoId, member);
+
+      // then
+      expect(response).toBeInstanceOf(VideoDetailResponse);
+      expect(response.id).toBe(video.getId());
+      expect(response.nickname).toBe(member.nickname);
+      expect(response.url).toBe(video.url);
+      expect(response.hash).toBe(
+        crypto.createHash('md5').update(video.url).digest('hex'),
+      );
+      expect(response.videoName).toBe(video.name);
+    });
+
+    it('비디오 상세 정보 조회 성공 시 비디오가 private이면 해시값으로 null을 반환한다.', async () => {
+      // given
+      const video = privateVideoFixture;
+
+      // when
+      mockVideoRepository.findById.mockResolvedValue(video);
+      const response = await videoService.getVideoDetail(videoId, member);
+
+      // then
+      expect(response).toBeInstanceOf(VideoDetailResponse);
+      expect(response.id).toBe(video.getId());
+      expect(response.nickname).toBe(member.nickname);
+      expect(response.url).toBe(video.url);
+      expect(response.hash).toBeNull();
+      expect(response.videoName).toBe(video.name);
+    });
+
+    it('비디오 상세 정보 조회 시 member가 없으면 ManipulatedTokenNotFiltered을 반환한다.', () => {
+      // given
+      const member = undefined;
+
+      // when
+
+      // then
+      expect(videoService.getVideoDetail(videoId, member)).rejects.toThrow(
+        ManipulatedTokenNotFiltered,
+      );
+    });
+
+    it('비디오 상세 정보 조회 시 이미 삭제된 비디오를 조회하려고 하면 VideoNotFoundException을 반환한다.', () => {
+      // given
+
+      // when
+      mockVideoRepository.findById.mockResolvedValue(undefined);
+
+      // then
+      expect(videoService.getVideoDetail(videoId, member)).rejects.toThrow(
+        VideoNotFoundException,
+      );
+    });
+
+    it('비디오 상세 정보 조회 시 자신의 것이 아닌 비디오를 조회하려고 하면 VideoAccessForbiddenException을 반환한다.', () => {
+      // given
+
+      // when
+      mockVideoRepository.findById.mockResolvedValue(videoOfOtherFixture);
+
+      // then
+      expect(videoService.getVideoDetail(videoId, member)).rejects.toThrow(
+        VideoAccessForbiddenException,
       );
     });
   });

--- a/BE/src/video/service/video.service.spec.ts
+++ b/BE/src/video/service/video.service.spec.ts
@@ -10,6 +10,8 @@ import {
 } from '../fixture/video.fixture';
 import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
 import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
+import { S3 } from 'aws-sdk';
+import { IDriveException } from '../exception/video.exception';
 
 describe('VideoService', () => {
   let videoService: VideoService;
@@ -52,10 +54,11 @@ describe('VideoService', () => {
   });
 
   describe('createVideo', () => {
+    const request = createVideoRequestFixture;
+
     it('비디오 저장 성공시 undefined로 반환된다.', async () => {
       // given
       const member = memberFixture;
-      const request = createVideoRequestFixture;
 
       // when
       mockVideoRepository.save.mockResolvedValue(undefined);
@@ -69,7 +72,6 @@ describe('VideoService', () => {
     it('비디오 저장 시 member가 없으면 ManipulatedTokenNotFiltered을 반환한다.', async () => {
       // given
       const member = undefined;
-      const request = createVideoRequestFixture;
 
       // when
 
@@ -81,18 +83,52 @@ describe('VideoService', () => {
   });
 
   describe('getPreSignedUrl', () => {
-    it('preSigned URL 얻기 성공시 PreSignedUrlResponse 형식으로 반환된다.', async () => {
+    const request = createPreSignedUrlRequestFixture;
+
+    it('preSigned URL 얻기 성공 시 PreSignedUrlResponse 형식으로 반환된다.', async () => {
       // given
       const member = memberFixture;
-      const request = createPreSignedUrlRequestFixture;
+      const content = 'mockContent';
+      (videoService as any).getQuestionContent = jest
+        .fn()
+        .mockResolvedValue(content);
 
       // when
       const response = await videoService.getPreSignedUrl(member, request);
-      console.log(response);
+
       // then
       expect(response).toBeInstanceOf(PreSignedUrlResponse);
-      expect(response.key.endsWith('.webm')).toBeTruthy(); // 파일명은 반드시 webm이어야 함
+      expect(response.key.includes(member.nickname)).toBeTruthy(); // 파일명엔 반드시 회원의 닉네임이 포함되어 있어야 함
+      expect(response.key.includes(content)).toBeTruthy(); // 파일명엔 반드시 문제의 제목이 포함되어 있어야 함
+      expect(response.key.endsWith('.webm')).toBeTruthy(); // 파일 확장자는 반드시 webm이어야 함
       expect(response.preSignedUrl.startsWith('https://videos')).toBeTruthy(); // 실제 Pre-Signed Url 구조를 따라가는지 확인하기 위함
+    });
+
+    it('prSigned URL 얻기 성공 시 member가 없으면 ManipulatedTokenNotFiltered을 반환한다.', async () => {
+      // given
+      const member = undefined;
+
+      // when
+
+      // then
+      expect(videoService.getPreSignedUrl(member, request)).rejects.toThrow(
+        ManipulatedTokenNotFiltered,
+      );
+    });
+
+    it('preSigned URL 얻기 시 IDrive Client가 Pre-Signed URL 발급에 실패하면 IDriveException을 반환한다.', async () => {
+      // given
+      const member = memberFixture;
+
+      // when
+      const getSignedUrlMock = jest.fn();
+      (S3.prototype.getSignedUrlPromise as jest.Mock) = getSignedUrlMock;
+      getSignedUrlMock.mockRejectedValueOnce(new IDriveException());
+
+      // then
+      expect(videoService.getPreSignedUrl(member, request)).rejects.toThrow(
+        IDriveException,
+      );
     });
   });
 });

--- a/BE/src/video/service/video.service.spec.ts
+++ b/BE/src/video/service/video.service.spec.ts
@@ -1,0 +1,74 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { VideoService } from './video.service';
+import { VideoRepository } from '../repository/video.repository';
+import { memberFixture } from 'src/member/fixture/member.fixture';
+import { QuestionRepository } from 'src/question/repository/question.repository';
+import { MemberRepository } from 'src/member/repository/member.repository';
+import { createVideoRequestFixture } from '../fixture/video.fixture';
+import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
+
+describe('VideoService', () => {
+  let videoService: VideoService;
+
+  const mockVideoRepository = {
+    save: jest.fn(),
+    finById: jest.fn(),
+    findByUrl: jest.fn(),
+    findAllVideosByMemberId: jest.fn(),
+    toggleVideoStatus: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VideoService,
+        VideoRepository,
+        MemberRepository,
+        QuestionRepository,
+      ],
+    })
+      .overrideProvider(VideoRepository)
+      .useValue(mockVideoRepository)
+      .overrideProvider(MemberRepository)
+      .useValue({})
+      .overrideProvider(QuestionRepository)
+      .useValue({})
+      .compile();
+
+    videoService = module.get<VideoService>(VideoService);
+  });
+
+  it('should be defined', () => {
+    expect(videoService).toBeDefined();
+  });
+
+  describe('createVideo', () => {
+    it('비디오 저장 성공시 undefined로 반환된다.', async () => {
+      // given
+      const member = memberFixture;
+      const request = createVideoRequestFixture;
+
+      // when
+      mockVideoRepository.save.mockResolvedValue(undefined);
+
+      // then
+      expect(
+        videoService.createVideo(member, request),
+      ).resolves.toBeUndefined();
+    });
+
+    it('비디오 저장 시 member가 없으면 ManipulatedTokenNotFiltered을 반환한다.', async () => {
+      // given
+      const member = undefined;
+      const request = createVideoRequestFixture;
+
+      // when
+
+      // then
+      expect(videoService.createVideo(member, request)).rejects.toThrow(
+        ManipulatedTokenNotFiltered,
+      );
+    });
+  });
+});

--- a/BE/src/video/service/video.service.spec.ts
+++ b/BE/src/video/service/video.service.spec.ts
@@ -530,4 +530,60 @@ describe('VideoService', () => {
       );
     });
   });
+
+  describe('deleteVideo', () => {
+    const member = memberFixture;
+
+    it('비디오 삭제 성공 시 undefined로 반환된다.', () => {
+      // given
+      const video = videoFixture;
+
+      // when
+      mockVideoRepository.remove.mockResolvedValue(undefined);
+
+      // then
+      expect(
+        videoService.deleteVideo(video.id, member),
+      ).resolves.toBeUndefined();
+    });
+
+    it('비디오 삭제 시 member가 없으면 ManipulatedTokenNotFiltered을 반환한다.', () => {
+      // given
+      const video = videoFixture;
+      const member = undefined;
+
+      // when
+
+      // then
+      expect(videoService.deleteVideo(video.id, member)).rejects.toThrow(
+        ManipulatedTokenNotFiltered,
+      );
+    });
+
+    it('비디오 삭제 시 이미 삭제된 비디오를 삭제하려고 하면 VideoNotFoundException을 반환한다.', () => {
+      // given
+      const video = videoFixture;
+
+      // when
+      mockVideoRepository.findById.mockResolvedValue(undefined);
+
+      // then
+      expect(videoService.deleteVideo(video.id, member)).rejects.toThrow(
+        VideoNotFoundException,
+      );
+    });
+
+    it('비디오 삭제 시 자신의 것이 아닌 비디오를 삭제하려고 하면 VideoAccessForbiddenException을 반환한다.', () => {
+      // given
+      const video = videoOfOtherFixture;
+
+      // when
+      mockVideoRepository.findById.mockResolvedValue(video);
+
+      // then
+      expect(videoService.deleteVideo(video.id, member)).rejects.toThrow(
+        VideoAccessForbiddenException,
+      );
+    });
+  });
 });

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -52,6 +52,8 @@ export class VideoService {
     member: Member,
     createPreSignedUrlRequest: CreatePreSignedUrlRequest,
   ) {
+    validateManipulatedToken(member);
+
     const content = await this.getQuestionContent(
       createPreSignedUrlRequest.questionId,
     );


### PR DESCRIPTION
[![NDD-184](https://badgen.net/badge/JIRA/NDD-184/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-184) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
Video Service 계층에 대한 단위 테스트를 진행하기 위함

Video Service에 속하지 않는 외부 모듈에서 불러온 메서드들의 결과를 모킹하는데 시간이 오래 걸렸다. service 계층 내의 repository의 메서드들은 쉽게 모킹을 진행할 수 있었지만, 외부의 모듈들은 모킹하는 방법 자체를 몰랐기에 이를 알아보고 이를 적용하는데 시간이 좀 걸렸다.
Mock을 사용할 때는 전체 파일을 모킹하려는 경우에, SpyOn을 사용할 때는 조건부로 모킹하려는 경우에 가장 알맞기에 이에 맞춰 외부 모듈을 알맞게 모킹하였다.
예를 들어 아래와 같이 모듈 전체를 import 해와서 테스트 중에 사용을 할 때에는 mock을 사용하였고
```javascript
import {
  deleteFromRedis,
  getValueFromRedis,
  saveToRedis,
} from 'src/util/redis.util';
jest.mock('src/util/redis.util');

const mockedGetValueFromRedis =
    getValueFromRedis as unknown as jest.MockedFunction<
      typeof getValueFromRedis
    >;
mockedGetValueFromRedis.mockRejectedValue(new RedisRetrieveException());
...
```
아래와 같이 전체 모듈 중 일부 메서드만 모킹을 해야할 때는 spyOn을 사용하여 모킹 후 테스트를 진행하였다.
```javascript
import * as crypto from 'crypto';

const createHashMock = jest.spyOn(crypto, 'createHash');
createHashMock.mockImplementationOnce(() => {
  throw new Md5HashException();
});
mockVideoRepository.findById.mockResolvedValue(video);
...
```

# How
각 API 별로 Service 계층에서 발생할 수 있는 상황에 대한 모든 경우들을 테스트

POST - 비디오를 저장하는 API, 비디오를 저장하기 위한 Pre-Signed URL을 발급받는 API
GET - 비디오 전체 조회, 비디오 상세 정보 조회, 비디오 해시값으로 조회
PATCH - 비디오 상태를 토글하는 API
DELETE - 비디오를 삭제하는 API
우선 위의 4가지 메서드의 7개의 API에 대한 Service 계층 단위 테스트를 진행하였다.
각 Service의 메서드 별로 올바른 응답, 또 다른 응답(비디오 정보 토글 시 hash가 null로 갈 때 등), 오류 상황(Redis 오류, 해시 중 오류 등) 같은 최대한 다양한 경우를 테스트하고자 노력하였다.

각 API별 세부 사항(에러 처리, 상황 별 응답의 차이)들은 아래 Result의 사진에서 확인할 수 있다.

# Result
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/c2c11447-145a-4abf-ac41-06fec92b9e7e)

# Prize
Controller 계층이 아닌 Service 계층에서의 테스트는 처음이었다. 그렇기 때문에 아래 Reference를 찾아보면서 mocking에 대한 학습을 많이 진행하였고, 단위 테스트에 대해 점점 더 익숙해졌다.

테스트를 통해 Video Service가 서비스 로직 내부의 상황에 맞게 알맞은 응답을 Controller 계층에 전송함을 확인할 수 있었다.

# Reference
https://www.developright.co.uk/posts/jest-mock-vs-jest-spyon-what-to-use-for-mocking.html

[NDD-184]: https://milk717.atlassian.net/browse/NDD-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ