### PR TITLE
[NDD-288] workbook 관련 api MSW, react query 작업 완료(2h/2h)

### DIFF
--- a/FE/src/apis/question.ts
+++ b/FE/src/apis/question.ts
@@ -1,5 +1,9 @@
 import { API } from '@/constants/api';
-import { Question } from '@/types/question';
+import {
+  Question,
+  QuestionCopyReqDto,
+  QuestionCopyResDto,
+} from '@/types/question';
 import getAPIResponseData from '@/utils/getAPIResponseData';
 
 export const getQuestion = async (id: number) => {
@@ -24,5 +28,13 @@ export const postQuestion = async ({
       categoryId: categoryId,
       content: content,
     },
+  });
+};
+
+export const postQuestionCopy = async (body: QuestionCopyReqDto) => {
+  return await getAPIResponseData<QuestionCopyResDto, QuestionCopyReqDto>({
+    method: 'post',
+    url: API.QUESTION_COPY,
+    data: body,
   });
 };

--- a/FE/src/apis/workbook.ts
+++ b/FE/src/apis/workbook.ts
@@ -38,10 +38,13 @@ export const getWorkbookById = async (workbookId: number) => {
   });
 };
 
-export const patchWorkbookById = async (
-  workbookId: number,
-  body: WorkbookPatchReqDto
-) => {
+export const patchWorkbookById = async ({
+  workbookId,
+  body,
+}: {
+  workbookId: number;
+  body: WorkbookPatchReqDto;
+}) => {
   return await getAPIResponseData<null, WorkbookPatchReqDto>({
     method: 'patch',
     url: API.WORKBOOK_ID(workbookId),

--- a/FE/src/apis/workbook.ts
+++ b/FE/src/apis/workbook.ts
@@ -1,0 +1,57 @@
+import getAPIResponseData from '@/utils/getAPIResponseData';
+import { API } from '@constants/api';
+import {
+  WorkbookAddReqDto,
+  WorkbookAddResDto,
+  WorkbookListResDto,
+  WorkbookPatchReqDto,
+  WorkbookResDto,
+  WorkbookTitleListResDto,
+} from '@/types/workbook';
+
+export const postWorkbook = async (body: WorkbookAddReqDto) => {
+  return await getAPIResponseData<WorkbookAddResDto, WorkbookAddReqDto>({
+    method: 'post',
+    url: API.WORKBOOK,
+    data: body,
+  });
+};
+
+export const getWorkbookByCategory = async (categoryId: number) => {
+  return await getAPIResponseData<WorkbookListResDto>({
+    method: 'get',
+    url: API.WORKBOOK_CATEGORY_ID(categoryId),
+  });
+};
+
+export const getWorkbookTitle = async () => {
+  return await getAPIResponseData<WorkbookTitleListResDto>({
+    method: 'get',
+    url: API.WORKBOOK_TITLE,
+  });
+};
+
+export const getWorkbookById = async (workbookId: number) => {
+  return await getAPIResponseData<WorkbookResDto>({
+    method: 'get',
+    url: API.WORKBOOK_ID(workbookId),
+  });
+};
+
+export const patchWorkbookById = async (
+  workbookId: number,
+  body: WorkbookPatchReqDto
+) => {
+  return await getAPIResponseData<null, WorkbookPatchReqDto>({
+    method: 'patch',
+    url: API.WORKBOOK_ID(workbookId),
+    data: body,
+  });
+};
+
+export const deleteWorkbookById = async (workbookId: number) => {
+  return await getAPIResponseData({
+    method: 'delete',
+    url: API.WORKBOOK_ID(workbookId),
+  });
+};

--- a/FE/src/constants/api.ts
+++ b/FE/src/constants/api.ts
@@ -20,5 +20,10 @@ export const API = {
   ANSWER_DEFAULT: '/answer/default',
   ANSWER_ID: (id?: Id) => `/answer/${id ?? ':id'}`,
   CATEGORY: '/category',
+  CATEGORY_V2: '/category/v2',
   CATEGORY_ID: (id?: Id) => `/category/${id ?? ':id'}`,
+  WORKBOOK: '/workbook',
+  WORKBOOK_ID: (id?: Id) => `/workbook/${id ?? ':id'}`,
+  WORKBOOK_CATEGORY_ID: (id?: Id) => `/workbook?category=${id ?? ':id'}`,
+  WORKBOOK_MY: '/workbook/my',
 } as const;

--- a/FE/src/constants/api.ts
+++ b/FE/src/constants/api.ts
@@ -21,7 +21,6 @@ export const API = {
   ANSWER_DEFAULT: '/answer/default',
   ANSWER_ID: (id?: Id) => `/answer/${id ?? ':id'}`,
   CATEGORY: '/category',
-  CATEGORY_V2: '/category/v2',
   CATEGORY_ID: (id?: Id) => `/category/${id ?? ':id'}`,
   WORKBOOK: '/workbook',
   WORKBOOK_TITLE: '/workbook/title',

--- a/FE/src/constants/api.ts
+++ b/FE/src/constants/api.ts
@@ -16,6 +16,7 @@ export const API = {
   VIDEO_HASH: (hash?: Hash) => `/video/hash/${hash ?? ':hash'}`,
   QUESTION: '/question',
   QUESTION_ID: (id?: Id) => `/question/${id ?? ':id'}`,
+  QUESTION_COPY: `/question/copy`,
   ANSWER: '/answer',
   ANSWER_DEFAULT: '/answer/default',
   ANSWER_ID: (id?: Id) => `/answer/${id ?? ':id'}`,

--- a/FE/src/constants/api.ts
+++ b/FE/src/constants/api.ts
@@ -24,7 +24,7 @@ export const API = {
   CATEGORY_V2: '/category/v2',
   CATEGORY_ID: (id?: Id) => `/category/${id ?? ':id'}`,
   WORKBOOK: '/workbook',
+  WORKBOOK_TITLE: '/workbook/title',
   WORKBOOK_ID: (id?: Id) => `/workbook/${id ?? ':id'}`,
   WORKBOOK_CATEGORY_ID: (id?: Id) => `/workbook?category=${id ?? ':id'}`,
-  WORKBOOK_MY: '/workbook/my',
 } as const;

--- a/FE/src/constants/queryKey.ts
+++ b/FE/src/constants/queryKey.ts
@@ -7,4 +7,6 @@ export const QUERY_KEY = {
   VIDEO: ['video'],
   VIDEO_ID: (videoId: number) => ['video', videoId],
   VIDEO_HASH: (videoHash: string) => ['video', videoHash],
+  WORKBOOK: ['workbook'],
+  WORKBOOK_ID: (workbookId: number) => ['workbook', workbookId],
 };

--- a/FE/src/hooks/apis/mutations/useQuestionCopyMutation.ts
+++ b/FE/src/hooks/apis/mutations/useQuestionCopyMutation.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { postQuestionCopy } from '@/apis/question';
+
+const useQuestionCopyMutation = () => {
+  return useMutation({
+    mutationFn: postQuestionCopy,
+  });
+};
+
+export default useQuestionCopyMutation;

--- a/FE/src/hooks/apis/mutations/useWorkbookDeleteMutation.ts
+++ b/FE/src/hooks/apis/mutations/useWorkbookDeleteMutation.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { deleteWorkbookById } from '@/apis/workbook';
+
+const useWorkbookDeleteMutation = () => {
+  return useMutation({
+    mutationFn: deleteWorkbookById,
+  });
+};
+
+export default useWorkbookDeleteMutation;

--- a/FE/src/hooks/apis/mutations/useWorkbookPatchMutation.ts
+++ b/FE/src/hooks/apis/mutations/useWorkbookPatchMutation.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { patchWorkbookById } from '@/apis/workbook';
+
+const useWorkbookPatchMutation = () => {
+  return useMutation({
+    mutationFn: patchWorkbookById,
+  });
+};
+
+export default useWorkbookPatchMutation;

--- a/FE/src/hooks/apis/mutations/useWorkbookPostMutation.ts
+++ b/FE/src/hooks/apis/mutations/useWorkbookPostMutation.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { postWorkbook } from '@/apis/workbook';
+
+const useWorkbookPostMutation = () => {
+  return useMutation({
+    mutationFn: postWorkbook,
+  });
+};
+
+export default useWorkbookPostMutation;

--- a/FE/src/hooks/apis/queries/useWorkbookListQuery.ts
+++ b/FE/src/hooks/apis/queries/useWorkbookListQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '@constants/queryKey';
+import { getWorkbookByCategory } from '@/apis/workbook';
+
+const useWorkbookListQuery = (categoryId: number) => {
+  return useQuery({
+    queryKey: QUERY_KEY.WORKBOOK,
+    queryFn: () => getWorkbookByCategory(categoryId),
+  });
+};
+
+export default useWorkbookListQuery;

--- a/FE/src/hooks/apis/queries/useWorkbookQuery.ts
+++ b/FE/src/hooks/apis/queries/useWorkbookQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '@constants/queryKey';
+import { getWorkbookById } from '@/apis/workbook';
+
+const useWorkbookQuery = (workbookId: number) => {
+  return useQuery({
+    queryKey: QUERY_KEY.WORKBOOK_ID(workbookId),
+    queryFn: () => getWorkbookById(workbookId),
+  });
+};
+
+export default useWorkbookQuery;

--- a/FE/src/hooks/apis/queries/useWorkbookTitleListQuery.ts
+++ b/FE/src/hooks/apis/queries/useWorkbookTitleListQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEY } from '@constants/queryKey';
+import { getWorkbookTitle } from '@/apis/workbook';
+
+const useWorkbookTitleListQuery = () => {
+  return useQuery({
+    queryKey: QUERY_KEY.WORKBOOK,
+    queryFn: () => getWorkbookTitle(),
+  });
+};
+
+export default useWorkbookTitleListQuery;

--- a/FE/src/mocks/handlers/category.ts
+++ b/FE/src/mocks/handlers/category.ts
@@ -28,6 +28,33 @@ const categoryHandlers = [
       { status: 200 }
     );
   }),
+  http.get(API.CATEGORY_V2, () => {
+    return HttpResponse.json(
+      [
+        {
+          id: 1,
+          name: 'FE',
+        },
+        {
+          id: 2,
+          name: 'BE',
+        },
+        {
+          id: 3,
+          name: 'CS',
+        },
+        {
+          id: 4,
+          name: 'Android',
+        },
+        {
+          id: 5,
+          name: 'iOS',
+        },
+      ],
+      { status: 200 }
+    );
+  }),
 ];
 
 export default categoryHandlers;

--- a/FE/src/mocks/handlers/category.ts
+++ b/FE/src/mocks/handlers/category.ts
@@ -4,32 +4,6 @@ import { HttpResponse, http } from 'msw';
 const categoryHandlers = [
   http.get(API.CATEGORY, () => {
     return HttpResponse.json(
-      {
-        customCategory: {
-          id: 4,
-          name: '나만의 질문',
-        },
-        categories: [
-          {
-            id: 1,
-            name: 'FE',
-          },
-          {
-            id: 2,
-            name: 'BE',
-          },
-          {
-            id: 3,
-            name: 'CS',
-          },
-        ],
-      },
-
-      { status: 200 }
-    );
-  }),
-  http.get(API.CATEGORY_V2, () => {
-    return HttpResponse.json(
       [
         {
           id: 1,

--- a/FE/src/mocks/handlers/question.ts
+++ b/FE/src/mocks/handlers/question.ts
@@ -73,6 +73,14 @@ const questionHandlers = [
   http.delete(API.QUESTION_ID(), () => {
     return HttpResponse.json({}, { status: 200 });
   }),
+  http.post(API.QUESTION_COPY, ({ request }) => {
+    return HttpResponse.json(
+      {
+        workbookId: 1,
+      },
+      { status: 201 }
+    );
+  }),
 ];
 
 export default questionHandlers;

--- a/FE/src/mocks/handlers/workbook.ts
+++ b/FE/src/mocks/handlers/workbook.ts
@@ -37,7 +37,7 @@ const workbookHandlers = [
       { status: 200 }
     );
   }),
-  http.get(API.WORKBOOK_MY, () => {
+  http.get(API.WORKBOOK_TITLE, () => {
     return HttpResponse.json(
       [
         {

--- a/FE/src/mocks/handlers/workbook.ts
+++ b/FE/src/mocks/handlers/workbook.ts
@@ -26,7 +26,7 @@ const workbookHandlers = [
           content: '당근마켓 가려면 이정도는 껌이라구~~',
         },
         {
-          workbookId: 2,
+          workbookId: 3,
           nickname: 'toss',
           profileImg: 'https://avatars.githubusercontent.com/u/66554167?v=6',
           copyCount: 9999,

--- a/FE/src/mocks/handlers/workbook.ts
+++ b/FE/src/mocks/handlers/workbook.ts
@@ -61,7 +61,7 @@ const workbookHandlers = [
         content:
           '취업하고싶어요! 돈벌고싶어요! 클라이밍, 피아노, 플라잉요가.... 하고싶은게 너무 많아요\n에버랜드, 스키장, 온천 가고싶어요.\n어디 놀러간 적이 100만년 전...',
       },
-      { status: 201 }
+      { status: 200 }
     );
   }),
   http.patch(API.WORKBOOK_ID(), ({ request }) => {

--- a/FE/src/mocks/handlers/workbook.ts
+++ b/FE/src/mocks/handlers/workbook.ts
@@ -1,0 +1,75 @@
+import { API } from '@/constants/api';
+import { HttpResponse, http } from 'msw';
+
+const workbookHandlers = [
+  http.post(API.WORKBOOK, ({ request }) => {
+    return HttpResponse.json({ workbookId: 1 }, { status: 201 });
+  }),
+  http.get(API.WORKBOOK_CATEGORY_ID(), () => {
+    return HttpResponse.json(
+      [
+        {
+          workbookId: 1,
+          nickname: 'milk717',
+          profileImg: 'https://avatars.githubusercontent.com/u/66554167?v=4',
+          copyCount: 717,
+          title: '100% 취업 보장! 토스 FE 개발자의 특별 가이드',
+          content:
+            '취업하고싶어요! 돈벌고싶어요! 클라이밍, 피아노, 플라잉요가.... 하고싶은게 너무 많아요\n에버랜드, 스키장, 온천 가고싶어요.\n어디 놀러간 적이 100만년 전...',
+        },
+        {
+          workbookId: 2,
+          nickname: 'ndd',
+          profileImg: 'https://avatars.githubusercontent.com/u/66554167?v=5',
+          copyCount: 123,
+          title: '당근마켓 합격자 면접',
+          content: '당근마켓 가려면 이정도는 껌이라구~~',
+        },
+        {
+          workbookId: 2,
+          nickname: 'toss',
+          profileImg: 'https://avatars.githubusercontent.com/u/66554167?v=6',
+          copyCount: 9999,
+          title: '토스 개발자의 영혼을 갈아넣은 면접',
+          content: '토스 toss 토~~스',
+        },
+      ],
+      { status: 200 }
+    );
+  }),
+  http.get(API.WORKBOOK_MY, () => {
+    return HttpResponse.json(
+      [
+        {
+          workbookId: 1,
+          title: '100% 취업 보장! 토스 FE 개발자의 특별 가이드',
+        },
+        { workbookId: 2, title: '당근마켓 합격자 면접' },
+        { workbookId: 3, title: '토스 개발자의 영혼을 갈아넣은 면접' },
+      ],
+      { status: 200 }
+    );
+  }),
+  http.get(API.WORKBOOK_ID(), ({ request }) => {
+    return HttpResponse.json(
+      {
+        workbookId: 1,
+        nickname: 'milk717',
+        profileImg: 'https://avatars.githubusercontent.com/u/66554167?v=4',
+        copyCount: 717,
+        title: '100% 취업 보장! 토스 FE 개발자의 특별 가이드',
+        content:
+          '취업하고싶어요! 돈벌고싶어요! 클라이밍, 피아노, 플라잉요가.... 하고싶은게 너무 많아요\n에버랜드, 스키장, 온천 가고싶어요.\n어디 놀러간 적이 100만년 전...',
+      },
+      { status: 201 }
+    );
+  }),
+  http.patch(API.WORKBOOK_ID(), ({ request }) => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+  http.delete(API.WORKBOOK_ID(), () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+];
+
+export default workbookHandlers;

--- a/FE/src/types/category.ts
+++ b/FE/src/types/category.ts
@@ -1,9 +1,6 @@
-export type Category = {
+export type CategoryEntity = {
   id: number;
   name: string;
 };
 
-export type CategoryResDto = {
-  customCategory: Category;
-  categories: Category[];
-};
+export type CategoryResDto = CategoryEntity[];

--- a/FE/src/types/question.ts
+++ b/FE/src/types/question.ts
@@ -4,3 +4,20 @@ export type Question = {
   answerId: number;
   answerContent: string;
 };
+
+/**
+ * POST question/copy
+ * 문제집에서 질문을 새로운 문제집으로 복사할 때 요청 객체 타입입니다.
+ */
+export type QuestionCopyReqDto = {
+  workbookId: number;
+  questionIds: number[];
+};
+
+/**
+ * POST question/copy
+ * 문제집에서 질문을 새로운 문제집으로 복사할 때 응답 객체 타입입니다.
+ */
+export type QuestionCopyResDto = {
+  workbookId: number;
+};

--- a/FE/src/types/workbook.ts
+++ b/FE/src/types/workbook.ts
@@ -1,0 +1,51 @@
+type WorkbookEntity = {
+  workbookId: number;
+  categoryId: number;
+  nickname: string;
+  profileImg: string;
+  copyCount: number;
+  title: string;
+  content: string;
+};
+
+/**
+ * POST workbook
+ * 문제집을 새로 추가할 때 요청 객체 타입
+ */
+export type WorkbookAddReqDto = Pick<
+  WorkbookEntity,
+  'title' | 'content' | 'categoryId'
+>;
+
+/**
+ * POST workbook
+ * 문제집을 새로 추가할 때 응답 객체 타입
+ */
+export type WorkbookAddResDto = Pick<WorkbookEntity, 'workbookId'>;
+
+/**
+ * GET workbook?category=${categoryId}
+ * 카테고리별 문제집을 조회했을 때 응답 객체 타입
+ */
+export type WorkbookListResDto = Omit<WorkbookEntity, 'categoryId'>;
+
+/**
+ * GET workbook/my
+ * 나의 문제집을 조회했을 때 응답 객체 타입
+ */
+export type WorkbookMyResDto = Pick<WorkbookEntity, 'workbookId' | 'title'>[];
+
+/**
+ * GET workbook/${workbookId}
+ * 문제집 아이디로 문제집을 단건 조회 했을 때 응답 객체 타입
+ */
+export type WorkbookResDto = Omit<WorkbookEntity, 'categoryId'>;
+
+/**
+ * PATCH workbook/${workbookId}
+ * 문제집을 수정할 때 요청 객체 타입
+ */
+export type WorkbookPatchReqDto = Pick<
+  WorkbookEntity,
+  'workbookId' | 'title' | 'content' | 'categoryId'
+>;

--- a/FE/src/types/workbook.ts
+++ b/FE/src/types/workbook.ts
@@ -30,10 +30,13 @@ export type WorkbookAddResDto = Pick<WorkbookEntity, 'workbookId'>;
 export type WorkbookListResDto = Omit<WorkbookEntity, 'categoryId'>;
 
 /**
- * GET workbook/my
- * 나의 문제집을 조회했을 때 응답 객체 타입
+ * GET workbook/title
+ * 문제집 제목 리스트를 조회했을 때 응답 객체 타입
  */
-export type WorkbookMyResDto = Pick<WorkbookEntity, 'workbookId' | 'title'>[];
+export type WorkbookTitleListResDto = Pick<
+  WorkbookEntity,
+  'workbookId' | 'title'
+>[];
 
 /**
  * GET workbook/${workbookId}


### PR DESCRIPTION
[![NDD-288](https://badgen.net/badge/JIRA/NDD-288/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-288) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

문제집 단건 조회 (/api/workbook/${workbookId}), 전체 카테고리 조회(/api/category) 같이 여러 페이지에서 사용되는 api 가 있어서 각자 MSW 작업을 하면 PR을 머지할 때 충돌이 날 것이라고 예상했습니다. 그래서 한번에 작업했습니다.

# How

## 나의 문제집 조회 api 추가 (/api/workbook/my)
<img width="848" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/d87684ca-41e8-40cd-b42a-881e1fcb7392">
위에 표시한 부분에서 사용하기 위한 회원별 문제집 조회 api가 없어서 장희님과 상의 후 추가했습니다.

## ~~카테고리 api v2로 임시 추가~~
~~기존에 사용하던 카테고리 api가 문제집의 카테고리로 새롭게 변경되었습니다. 그래서 이에 맞게 MSW도 수정해야하지만, 바로 수정하면 아래 컴포넌트에서 에러가 발생할 것이라고 생각했습니다.
<img width="766" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/96772f79-e4a6-47e3-99dd-03f638fcfce9">
그래서 /category/v2 라는 임시 엔드포인트를 만들어 api를 모킹했습니다.
추후에 해민님이 QuestionSelectionBox 수정하면 그 때 기존 category api를 삭제하고  /category/v2를 category로 마이그레이션 하는 작업이 필요합니다.~~

## 카테고리 api도 변경
api 관련 작업은 한번에 진행하는 것이 좋다는 판단을 내려 react query 작업까지 이 pr에서 하기로 결정했습니다. 제가 이 작업을 하는동안 해민님이 새로 바뀐 category api 대응을 하기로 결정했습니다.
따라서 /category/v2 는 제거하고 기존 category api를 수정했습니다.

[NDD-288]: https://milk717.atlassian.net/browse/NDD-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ