### PR TITLE
[NDD-272] InterviewSetForm 컴포넌트 생성 (3h/3h)

### DIFF
--- a/FE/src/components/InterviewSetEditPage/InterviewSetCategory.tsx
+++ b/FE/src/components/InterviewSetEditPage/InterviewSetCategory.tsx
@@ -1,19 +1,38 @@
 import { css } from '@emotion/react';
 import { Typography } from '@foundation/index';
+import useCategoryQuery from '@hooks/apis/queries/useCategoryQuery';
+import { theme } from '@styles/theme';
 
-const InterviewSetCategory: React.FC = () => {
-  const categoryList = ['FE', 'BE', 'CS', 'Android', 'iOS', 'Android'];
+type InterviewSetCategoryProps = {
+  selectedId: number;
+  onClick: (id: number) => void;
+};
+const InterviewSetCategory: React.FC<InterviewSetCategoryProps> = ({
+  selectedId,
+  onClick,
+}) => {
+  const { data } = useCategoryQuery();
   return (
     <div
       css={css`
         display: flex;
         column-gap: 1rem;
         padding-left: 0.25rem;
+        cursor: pointer;
       `}
     >
-      {categoryList.map((category, index) => (
-        <Typography key={index} variant="title4">
-          {category}
+      {data?.map(({ id, name }) => (
+        <Typography
+          key={id}
+          variant="title4"
+          color={
+            selectedId === id
+              ? theme.colors.text.default
+              : theme.colors.text.subStrong
+          }
+          onClick={() => onClick(id)}
+        >
+          {name}
         </Typography>
       ))}
     </div>

--- a/FE/src/components/InterviewSetEditPage/InterviewSetCategory.tsx
+++ b/FE/src/components/InterviewSetEditPage/InterviewSetCategory.tsx
@@ -1,0 +1,23 @@
+import { css } from '@emotion/react';
+import { Typography } from '@foundation/index';
+
+const InterviewSetCategory: React.FC = () => {
+  const categoryList = ['FE', 'BE', 'CS', 'Android', 'iOS', 'Android'];
+  return (
+    <div
+      css={css`
+        display: flex;
+        column-gap: 1rem;
+        padding-left: 0.25rem;
+      `}
+    >
+      {categoryList.map((category, index) => (
+        <Typography key={index} variant="title4">
+          {category}
+        </Typography>
+      ))}
+    </div>
+  );
+};
+
+export default InterviewSetCategory;

--- a/FE/src/components/InterviewSetEditPage/InterviewSetCategory.tsx
+++ b/FE/src/components/InterviewSetEditPage/InterviewSetCategory.tsx
@@ -11,7 +11,7 @@ const InterviewSetCategory: React.FC<InterviewSetCategoryProps> = ({
   selectedId,
   onClick,
 }) => {
-  const { data } = useCategoryQuery();
+  const { data: categories } = useCategoryQuery();
   return (
     <div
       css={css`
@@ -21,7 +21,7 @@ const InterviewSetCategory: React.FC<InterviewSetCategoryProps> = ({
         cursor: pointer;
       `}
     >
-      {data?.map(({ id, name }) => (
+      {categories?.map(({ id, name }) => (
         <Typography
           key={id}
           variant="title4"

--- a/FE/src/components/InterviewSetEditPage/InterviewSetForm.tsx
+++ b/FE/src/components/InterviewSetEditPage/InterviewSetForm.tsx
@@ -1,0 +1,42 @@
+import { Avatar, Box, Input, InputArea, Typography } from '@foundation/index';
+import { css } from '@emotion/react';
+import React from 'react';
+import LabelBox from '@components/InterviewSetEditPage/LabelBox';
+import InterviewSetCategory from '@components/InterviewSetEditPage/InterviewSetCategory';
+
+const InterviewSetForm: React.FC = () => {
+  const avatarImage = 'https://avatars.githubusercontent.com/u/66554167?v=4';
+  const userName = 'milk717';
+  return (
+    <Box
+      css={css`
+        display: flex;
+        flex-direction: column;
+        row-gap: 1rem;
+        padding: 1rem;
+      `}
+    >
+      <div
+        css={css`
+          display: flex;
+          align-items: center;
+          column-gap: 0.5rem;
+        `}
+      >
+        <Avatar width="1.5rem" height="1.5rem" src={avatarImage} />
+        <Typography variant="body3">{userName}</Typography>
+      </div>
+      <LabelBox labelName="제목">
+        <Input />
+      </LabelBox>
+      <LabelBox labelName="카테고리">
+        <InterviewSetCategory />
+      </LabelBox>
+      <LabelBox labelName="설명">
+        <InputArea />
+      </LabelBox>
+    </Box>
+  );
+};
+
+export default InterviewSetForm;

--- a/FE/src/components/InterviewSetEditPage/InterviewSetForm.tsx
+++ b/FE/src/components/InterviewSetEditPage/InterviewSetForm.tsx
@@ -1,6 +1,6 @@
 import { Avatar, Box, Input, InputArea, Typography } from '@foundation/index';
 import { css } from '@emotion/react';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import LabelBox from '@components/InterviewSetEditPage/LabelBox';
 import InterviewSetCategory from '@components/InterviewSetEditPage/InterviewSetCategory';
 import useUserInfo from '@hooks/useUserInfo';
@@ -35,7 +35,7 @@ const InterviewSetForm: React.FC<InterviewSetFormProps> = ({ workbookId }) => {
   });
   const debouncedMutate = useDebounce(mutate, 1000);
 
-  useEffect(() => {
+  const runDebouncedMutation = useCallback(() => {
     debouncedMutate({
       workbookId,
       body: {
@@ -45,7 +45,20 @@ const InterviewSetForm: React.FC<InterviewSetFormProps> = ({ workbookId }) => {
         categoryId: selectedCategory,
       },
     });
-  }, [workbookTitle, workbookContent, selectedCategory]);
+  }, [
+    debouncedMutate,
+    selectedCategory,
+    workbookContent,
+    workbookId,
+    workbookTitle,
+  ]);
+
+  useEffect(() => {
+    runDebouncedMutation();
+    return () => {
+      runDebouncedMutation();
+    };
+  }, [runDebouncedMutation]);
 
   //TODO 추후 Suspense와 스켈레톤 UI 도입 예정
   if (!workbookInfo) return '로딩중';

--- a/FE/src/components/InterviewSetEditPage/InterviewSetForm.tsx
+++ b/FE/src/components/InterviewSetEditPage/InterviewSetForm.tsx
@@ -1,6 +1,6 @@
 import { Avatar, Box, Input, InputArea, Typography } from '@foundation/index';
 import { css } from '@emotion/react';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import LabelBox from '@components/InterviewSetEditPage/LabelBox';
 import InterviewSetCategory from '@components/InterviewSetEditPage/InterviewSetCategory';
 import useUserInfo from '@hooks/useUserInfo';

--- a/FE/src/components/InterviewSetEditPage/LabelBox.tsx
+++ b/FE/src/components/InterviewSetEditPage/LabelBox.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { Typography } from '@foundation/index';
+import { theme } from '@styles/theme';
+
+type LabelBoxProps = {
+  children: React.ReactNode;
+  labelName: string;
+};
+
+const LabelBox: React.FC<LabelBoxProps> = ({ children, labelName }) => {
+  return (
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        row-gap: 0.25rem;
+      `}
+    >
+      <Typography
+        component="label"
+        variant="captionWeak"
+        color={theme.colors.text.subStrong}
+        css={css`
+          padding-left: 0.25rem;
+        `}
+      >
+        {labelName}
+      </Typography>
+      {children}
+    </div>
+  );
+};
+
+export default LabelBox;

--- a/FE/src/components/foundation/Input/Input.tsx
+++ b/FE/src/components/foundation/Input/Input.tsx
@@ -1,0 +1,24 @@
+import { css } from '@emotion/react';
+import { theme } from '@styles/theme';
+import { HTMLElementTypes } from '@/types/utils';
+import React from 'react';
+
+type InputProps = HTMLElementTypes<HTMLInputElement> &
+  React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input: React.FC<InputProps> = ({ ...args }) => {
+  return (
+    <input
+      type="text"
+      css={css`
+        padding: 1rem;
+        border: 0.0625rem solid ${theme.colors.border.default};
+        border-radius: 1rem;
+        width: 100%;
+      `}
+      {...args}
+    />
+  );
+};
+
+export default Input;

--- a/FE/src/components/foundation/index.ts
+++ b/FE/src/components/foundation/index.ts
@@ -13,3 +13,4 @@ export { default as Tabs } from './Tabs';
 export { default as Typography } from './Typography/Typography';
 export { default as Toggle } from './Toggle/Toggle';
 export { default as CheckBox } from './CheckBox/CheckBox';
+export { default as Input } from './Input/Input';

--- a/FE/src/hooks/apis/mutations/useWorkbookPatchMutation.ts
+++ b/FE/src/hooks/apis/mutations/useWorkbookPatchMutation.ts
@@ -1,9 +1,17 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { patchWorkbookById } from '@/apis/workbook';
+import { WorkbookPatchReqDto } from '@/types/workbook';
 
-const useWorkbookPatchMutation = () => {
+const useWorkbookPatchMutation = (
+  options?: UseMutationOptions<
+    null,
+    Error,
+    { body: WorkbookPatchReqDto; workbookId: number }
+  >
+) => {
   return useMutation({
     mutationFn: patchWorkbookById,
+    ...options,
   });
 };
 

--- a/FE/src/hooks/useDebounce.ts
+++ b/FE/src/hooks/useDebounce.ts
@@ -1,0 +1,30 @@
+import { FunctionParamsType } from '@/types/utils';
+import { useCallback, useEffect, useRef } from 'react';
+
+const useDebounce = <T extends (...args: FunctionParamsType<T>) => void>(
+  func: T,
+  wait: number
+) => {
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const cleanup = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    return () => cleanup();
+  }, []);
+
+  return useCallback(
+    (...args: FunctionParamsType<T>) => {
+      cleanup();
+      timeoutRef.current = setTimeout(() => func(...args), wait);
+    },
+    [func, wait]
+  );
+};
+
+export default useDebounce;

--- a/FE/src/mocks/handlers.ts
+++ b/FE/src/mocks/handlers.ts
@@ -3,6 +3,7 @@ import questionHandlers from './handlers/question';
 import answerHandlers from './handlers/answer';
 import videoHandlers from '@/mocks/handlers/video';
 import categoryHandlers from './handlers/category';
+import workbookHandlers from '@/mocks/handlers/workbook';
 
 export const handlers = [
   ...memberHandlers,
@@ -10,4 +11,5 @@ export const handlers = [
   ...answerHandlers,
   ...videoHandlers,
   ...categoryHandlers,
+  ...workbookHandlers,
 ];

--- a/FE/src/mocks/handlers/workbook.ts
+++ b/FE/src/mocks/handlers/workbook.ts
@@ -54,6 +54,7 @@ const workbookHandlers = [
     return HttpResponse.json(
       {
         workbookId: 1,
+        categoryId: 1,
         nickname: 'milk717',
         profileImg: 'https://avatars.githubusercontent.com/u/66554167?v=4',
         copyCount: 717,

--- a/FE/src/types/utils.ts
+++ b/FE/src/types/utils.ts
@@ -4,3 +4,7 @@ export type HTMLElementTypes<T> = React.ClassAttributes<T> &
   React.HTMLAttributes<T> & {
     css?: Interpolation<Theme>;
   };
+
+export type FunctionParamsType<T> = T extends (...args: infer P) => unknown
+  ? P
+  : never;

--- a/FE/src/types/workbook.ts
+++ b/FE/src/types/workbook.ts
@@ -42,7 +42,7 @@ export type WorkbookTitleListResDto = Pick<
  * GET workbook/${workbookId}
  * 문제집 아이디로 문제집을 단건 조회 했을 때 응답 객체 타입
  */
-export type WorkbookResDto = Omit<WorkbookEntity, 'categoryId'>;
+export type WorkbookResDto = WorkbookEntity;
 
 /**
  * PATCH workbook/${workbookId}


### PR DESCRIPTION
[![NDD-272](https://badgen.net/badge/JIRA/NDD-272/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-272) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->


# Why

중간에 밥도 먹고 나갈준비도 하고 ppt도 만들어서 시간을 제대로 측정하지 못했지만 WakaTime을 보니 3시간 약간 넘게 걸린 것 같습니다.

# How
> 면접 세트 추가에 대한 상황은 아직 염두하지 않고 구현했습니다.

## useDebounce 훅 추가
이벤트 지연을 처리할 수 있는 useDebounce 훅을 추가했습니다.
InterviewSetForm은 별도의 저장 버튼 없이 각 필드 항목이 변경될 때 마다 자동저장 되도록 구현했습니다. 하지만 onChange 액션마다 api를 호출하게 되면 불필요한 요청이 발생할 수 있으므로 debounce를 설정해서 요청 수를 조절했습니다.

## FunctionParamsType 유틸 타입 추가
useDebounce훅에서 첫 번째 인자로 넘어온 함수의 파라미터 타입을 추론하기 위해 FunctionParamsType 유틸 타입을 생성했습니다.

## mutate 옵션에 로그 찍어둔 이유
InterviewSetForm은 자동 저장 로직으로 구현되어 있기 때문에 유저에게 현재 입력된 상태가 계속 저장되고 있다는 UI를 표시해 주는 것이 좋다고 생각했습니다. 따라서 각 mutation 요청의 단계별로 '저장중....', '저장 완료', '저장 오류' 등의 정보를 나타낼 수 있는 UI를 보여주고 싶었습니다.
이 부분은 메인 기능을 모두 구현한 후 다른 태스크로 분리해서 작업하기 위해 일단 로그만 찍어놨습니다.

# Result

https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/ff2665bf-63a6-4f09-bd83-8b89af142509

[NDD-272]: https://milk717.atlassian.net/browse/NDD-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ