### PR TITLE
[NDD-185]: Video API Controller 통합 테스트 (5h / 3h)

### DIFF
--- a/BE/src/member/fixture/member.fixture.ts
+++ b/BE/src/member/fixture/member.fixture.ts
@@ -10,6 +10,14 @@ export const memberFixture = new Member(
   new Date(),
 );
 
+export const otherMemberFixture = new Member(
+  999,
+  'other@example.com',
+  'other',
+  'https://other.com',
+  new Date(),
+);
+
 export const memberFixturesOAuthRequest = {
   email: 'test@example.com',
   name: 'TestUser',

--- a/BE/src/question/repository/question.repository.ts
+++ b/BE/src/question/repository/question.repository.ts
@@ -9,6 +9,10 @@ export class QuestionRepository {
     @InjectRepository(Question) private repository: Repository<Question>,
   ) {}
 
+  async query(query: string) {
+    return await this.repository.query(query);
+  }
+
   async save(question: Question) {
     return await this.repository.save(question);
   }

--- a/BE/src/util/redis.util.ts
+++ b/BE/src/util/redis.util.ts
@@ -6,44 +6,36 @@ import {
   RedisSaveException,
 } from 'src/video/exception/video.exception';
 
-let redisInstance: Redis;
-
-function getRedisInstance() {
-  if (redisInstance) return redisInstance;
-
-  const redisUrl: string = process.env.REDIS_URL as string;
-  if (redisUrl) {
-    redisInstance = new Redis(redisUrl);
-    return redisInstance;
-  }
-
-  throw new Error('REDIS_URL 환경 변수가 설정되지 않았습니다.');
-}
-
 export const saveToRedis = async (key: string, value: string) => {
+  const redis = new Redis(process.env.REDIS_URL as string);
   try {
-    const redis = getRedisInstance();
     await redis.set(key, value);
   } catch (error) {
     throw new RedisSaveException();
+  } finally {
+    await redis.quit();
   }
 };
 
 export const deleteFromRedis = async (key: string) => {
+  const redis = new Redis(process.env.REDIS_URL as string);
   try {
-    const redis = getRedisInstance();
     await redis.del(key);
   } catch (error) {
     throw new RedisDeleteException();
+  } finally {
+    await redis.quit();
   }
 };
 
 export const getValueFromRedis = async (key: string) => {
+  const redis = new Redis(process.env.REDIS_URL as string);
   try {
-    const redis = getRedisInstance();
     const value = await redis.get(key);
     return value;
   } catch (error) {
     throw new RedisRetrieveException();
+  } finally {
+    await redis.quit();
   }
 };

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -886,7 +886,7 @@ describe('VideoController 통합테스트', () => {
       const token = await authService.login(oauthRequestFixture);
       await workbookRepository.save(workbookFixtureWithId);
       await questionRepository.save(questionFixture);
-      memberRepository.save(otherMemberFixture);
+      await memberRepository.save(otherMemberFixture);
       const video = await videoRepository.save(videoOfOtherFixture);
 
       // when & then
@@ -913,11 +913,90 @@ describe('VideoController 통합테스트', () => {
     });
   });
 
+  describe('toggleVideoStatus', () => {
+    it('쿠키를 가지고 비디오 상태 토글을 요청하면 200 상태 코드와 해시값 null이 반환된다.', async () => {
+      // give
+      const token = await authService.login(oauthRequestFixture);
+      await workbookRepository.save(workbookFixtureWithId);
+      await questionRepository.save(questionFixture);
+      const video = await videoRepository.save(videoFixture);
+
+      // when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .patch(`/api/video/${video.id}`)
+        .set('Cookie', [`accessToken=${token}`])
+        .expect(200)
+        .expect((res) => expect(res.body.hash).toBeNull());
+    });
+
+    it('쿠키를 가지고 private 비디오의 상태 토글을 요청하면 200 상태 코드와 url 해시값이 반환된다.', async () => {
+      // give
+      const token = await authService.login(oauthRequestFixture);
+      await workbookRepository.save(workbookFixtureWithId);
+      await questionRepository.save(questionFixture);
+      const video = await videoRepository.save(privateVideoFixture);
+      const hash = crypto.createHash('md5').update(video.url).digest('hex');
+
+      // when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .patch(`/api/video/${video.id}`)
+        .set('Cookie', [`accessToken=${token}`])
+        .expect(200)
+        .expect((res) => expect(res.body.hash).toBe(hash));
+    });
+
+    it('쿠키 없이 해시로 비디오 상태 토글을 요청하면 401 상태 코드가 반환된다.', async () => {
+      // given
+      await authService.login(oauthRequestFixture);
+      await workbookRepository.save(workbookFixtureWithId);
+      await questionRepository.save(questionFixture);
+      const video = await videoRepository.save(videoFixture);
+
+      // when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent.patch(`/api/video/${video.id}`).expect(401);
+    });
+
+    it('다른 사람의 비디오 상태 토글을 요청하면 403 상태 코드가 반환된다.', async () => {
+      // give
+      const token = await authService.login(oauthRequestFixture);
+      await workbookRepository.save(workbookFixtureWithId);
+      await questionRepository.save(questionFixture);
+      await memberRepository.save(otherMemberFixture);
+      const video = await videoRepository.save(videoOfOtherFixture);
+
+      // when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .patch(`/api/video/${video.id}`)
+        .set('Cookie', [`accessToken=${token}`])
+        .expect(403);
+    });
+
+    it('존재하지 않는 비디오 상태 토글을 요청하면 404 상태 코드가 반환된다.', async () => {
+      // give
+      const token = await authService.login(oauthRequestFixture);
+      await workbookRepository.save(workbookFixtureWithId);
+      await questionRepository.save(questionFixture);
+      const video = await videoRepository.save(videoFixture);
+
+      // when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .patch(`/api/video/${video.id + 1000}`)
+        .set('Cookie', [`accessToken=${token}`])
+        .expect(404);
+    });
+  });
+
   afterEach(async () => {
     await questionRepository.query('delete from token');
     await questionRepository.query('delete from Question');
     await questionRepository.query('delete from Member');
     await questionRepository.query('delete from Workbook');
+    await questionRepository.query('delete from Video');
     await questionRepository.query('DELETE FROM sqlite_sequence'); // Auto Increment 초기화
   });
 });

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -991,7 +991,7 @@ describe('VideoController 통합테스트', () => {
     });
   });
 
-  describe('toggleVideoStatus', () => {
+  describe('deleteVideo', () => {
     it('쿠키를 가지고 비디오의 삭제를 요청하면 204 상태 코드가 반환된다.', async () => {
       // give
       const token = await authService.login(oauthRequestFixture);

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -642,6 +642,37 @@ describe('VideoController 통합테스트', () => {
     });
   });
 
+  describe('getPreSignedUrl', () => {
+    it('쿠키를 가지고 Pre-Signed URL 생성을 요청하면 201 상태 코드가 반환된다.', async () => {
+      // given
+      const token = await authService.login(oauthRequestFixture);
+      await workbookRepository.save(workbookFixtureWithId);
+      await questionRepository.save(questionFixture);
+
+      // when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .post('/api/video/pre-signed')
+        .set('Cookie', [`accessToken=${token}`])
+        .send(createPreSignedUrlRequestFixture)
+        .expect(201);
+    });
+
+    it('쿠키 없이 Pre-Signed URL 생성을 요청하면 401 상태 코드가 반환된다.', async () => {
+      // given
+      await authService.login(oauthRequestFixture);
+      await workbookRepository.save(workbookFixtureWithId);
+      await questionRepository.save(questionFixture);
+
+      // when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .post('/api/video/pre-signed')
+        .send(createPreSignedUrlRequestFixture)
+        .expect(401);
+    });
+  });
+
   afterEach(async () => {
     await questionRepository.query('delete from token');
     await questionRepository.query('delete from Question');

--- a/BE/src/video/entity/video.ts
+++ b/BE/src/video/entity/video.ts
@@ -8,17 +8,17 @@ import { DEFAULT_THUMBNAIL } from 'src/constant/constant';
 
 @Entity({ name: 'Video' })
 export class Video extends DefaultEntity {
-  @Column()
+  @Column({ nullable: true })
   memberId: number;
 
-  @Column()
+  @Column({ nullable: true })
   questionId: number;
 
-  @ManyToOne(() => Member, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Member, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'memberId' })
   member: Member;
 
-  @ManyToOne(() => Question, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Question, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'questionId' })
   question: Question;
 

--- a/BE/src/video/fixture/video.fixture.ts
+++ b/BE/src/video/fixture/video.fixture.ts
@@ -80,7 +80,7 @@ export const videoOfOtherFixture = new Video(
   false,
 );
 
-export const VideoOfWithdrawnMemberFixture = new Video(
+export const videoOfWithdrawnMemberFixture = new Video(
   null,
   1,
   '루이뷔통통튀기네',

--- a/BE/src/video/fixture/video.fixture.ts
+++ b/BE/src/video/fixture/video.fixture.ts
@@ -64,7 +64,7 @@ export const privateVideoFixture = new Video(
   1,
   1,
   '루이뷔통통튀기네',
-  'https://test.com',
+  'https://priavte-test.com',
   'https://thumbnail-test.com',
   '03:29',
   false,

--- a/BE/src/video/repository/video.repository.ts
+++ b/BE/src/video/repository/video.repository.ts
@@ -11,7 +11,7 @@ export class VideoRepository {
   ) {}
 
   async save(video: Video) {
-    await this.videoRepository.save(video);
+    return await this.videoRepository.save(video);
   }
 
   async findAllVideosByMemberId(memberId: number) {

--- a/BE/src/video/service/video.service.spec.ts
+++ b/BE/src/video/service/video.service.spec.ts
@@ -5,7 +5,7 @@ import { memberFixture } from 'src/member/fixture/member.fixture';
 import { QuestionRepository } from 'src/question/repository/question.repository';
 import { MemberRepository } from 'src/member/repository/member.repository';
 import {
-  VideoOfWithdrawnMemberFixture,
+  videoOfWithdrawnMemberFixture,
   createPreSignedUrlRequestFixture,
   createVideoRequestFixture,
   privateVideoFixture,
@@ -320,7 +320,7 @@ describe('VideoService', () => {
 
     it('해시로 비디오 상세 정보 조회 시 비디오가 삭제된 회원의 비디오라면 VideoOfWithdrawnMemberException을 반환한다.', () => {
       // given
-      const video = VideoOfWithdrawnMemberFixture;
+      const video = videoOfWithdrawnMemberFixture;
 
       // when
       const mockedGetValueFromRedis =

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -83,7 +83,6 @@ export class VideoService {
 
   async getVideoDetailByHash(hash: string) {
     const originUrl = await getValueFromRedis(hash);
-    console.log(originUrl);
     const video = await this.videoRepository.findByUrl(originUrl);
     if (!video.isPublic) throw new VideoAccessForbiddenException();
     if (isEmpty(video.memberId)) throw new VideoOfWithdrawnMemberException();

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -83,6 +83,7 @@ export class VideoService {
 
   async getVideoDetailByHash(hash: string) {
     const originUrl = await getValueFromRedis(hash);
+    console.log(originUrl);
     const video = await this.videoRepository.findByUrl(originUrl);
     if (!video.isPublic) throw new VideoAccessForbiddenException();
     if (isEmpty(video.memberId)) throw new VideoOfWithdrawnMemberException();


### PR DESCRIPTION
[![NDD-185](https://badgen.net/badge/JIRA/NDD-185/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-185) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
Video Controller 계층에 대한 통합 테스트를 진행하기 위함

통합 테스트 관련 경험이 많이 없기에, 이에 익숙하지 않아 시간이 예상보다 더 걸린 것 같다.
save 메서드를 await 처리하지 않아, 외래키 제약 조건에서 에러가 발생하기도 하는 등 실수를 하는 등 전체적으로 미숙하여 시간이 오래 걸렸다.

또한 기획상 기능 명세의 변경으로 Category와 Workbook 간의 매핑 관계가 추가되어 이를 처리하기 위해 또 추가적으로 시간이 들었다.

# How
각 API 별로 Video Controller에 요청이 들어왔을 때 발생할 수 있는 상황에 대한 모든 경우들을 테스트

POST - 비디오를 저장하는 API, 비디오를 저장하기 위한 Pre-Signed URL을 발급받는 API
GET - 비디오 전체 조회, 비디오 상세 정보 조회, 비디오 해시값으로 조회
PATCH - 비디오 상태를 토글하는 API
DELETE - 비디오를 삭제하는 API

우선 위의 4가지 메서드의 7개의 API에 대한 Controller 계층의 통합 테스트를 진행하였다.
각 Controller의 메서드 별로 올바른 응답, 또 다른 응답(비디오 정보 토글 시 hash가 null로 갈 때 등), 오류 상황(권한이 없는 리소스에 대한 요청, 존재하지 않는 리소스에 대한 요청 등) 같은 최대한 다양한 경우를 테스트하고자 노력하였다.

각 API별 세부 사항(에러 처리, 상황 별 응답의 차이)들은 아래 Result의 사진에서 확인할 수 있다.

# Result
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/16576db9-6d03-4ef0-8b12-c9342d6e2a76)

# Prize
지속적인 테스트 관련 코드를 작성함을 통해 테스트에 대해 점점 익숙해짐을 느낄 수 있다.

테스트를 통해 Video Controller가 Repository, IDrive, Redis 등 내부 서비스 로직의 상황에 맞게 알맞은 응답을 전달 받고 이를 클라이언트에게 전송함을 확인할 수 있었다.

# Reference
https://forum.qt.io/topic/121036/how-to-reset-auto-increment-id-of-column-in-data-base-table-of-sqlite-browser/5

[NDD-185]: https://milk717.atlassian.net/browse/NDD-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ