### PR TITLE
[NDD-282]: 문제집에 대한 조회 기능 구현 (3h / 1h)

### DIFF
--- a/BE/src/member/fixture/member.fixture.ts
+++ b/BE/src/member/fixture/member.fixture.ts
@@ -10,6 +10,14 @@ export const memberFixture = new Member(
   new Date(),
 );
 
+export const differentMemberFixture = new Member(
+  2,
+  'jang@jang.com',
+  'jang',
+  'https://jangsarchive.tistory.com',
+  new Date(),
+);
+
 export const memberFixturesOAuthRequest = {
   email: 'test@example.com',
   name: 'TestUser',

--- a/BE/src/token/guard/token.soft.guard.ts
+++ b/BE/src/token/guard/token.soft.guard.ts
@@ -1,0 +1,30 @@
+// auth.guard.ts
+
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { TokenService } from '../service/token.service';
+
+@Injectable()
+export class TokenSoftGuard extends AuthGuard('jwt') {
+  constructor(private tokenService: TokenService) {
+    super();
+  }
+
+  async canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+    const token = request.cookies['accessToken'];
+
+    // validate 메소드 내에서 토큰을 사용
+    request.user = await this.validateToken(token);
+
+    return true;
+  }
+
+  private async validateToken(token: string) {
+    try {
+      return this.tokenService.findMemberByToken(token.replace('Bearer ', ''));
+    } catch (error) {
+      return null;
+    }
+  }
+}

--- a/BE/src/token/token.module.ts
+++ b/BE/src/token/token.module.ts
@@ -11,6 +11,7 @@ import { JwtModule } from '@nestjs/jwt';
 import 'dotenv/config';
 import { AccessTokenStrategy } from './strategy/access.token.strategy';
 import { TokenController } from './token.controller';
+import { TokenSoftGuard } from './guard/token.soft.guard';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { TokenController } from './token.controller';
     TokenRepository,
     MemberRepository,
     AccessTokenStrategy,
+    TokenSoftGuard,
   ],
   exports: [TokenService],
   controllers: [TokenController],

--- a/BE/src/util/decorator.util.ts
+++ b/BE/src/util/decorator.util.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const OPTIONAL_GUARD = 'OptionalGuard';
+export const OptionalGuard = () => {
+  return SetMetadata(OPTIONAL_GUARD, true);
+};

--- a/BE/src/workbook/controller/workbook.controller.spec.ts
+++ b/BE/src/workbook/controller/workbook.controller.spec.ts
@@ -26,14 +26,25 @@ import * as cookieParser from 'cookie-parser';
 import { TokenModule } from '../../token/token.module';
 import { Token } from '../../token/entity/token';
 import { AuthService } from '../../auth/service/auth.service';
-import { categoryFixtureWithId } from '../../category/fixture/category.fixture';
+import {
+  categoryFixtureWithId,
+  categoryListFixture,
+} from '../../category/fixture/category.fixture';
 import * as request from 'supertest';
 import { CreateWorkbookRequest } from '../dto/createWorkbookRequest';
+import { WorkbookNotFoundException } from '../exception/workbook.exception';
+import { WorkbookResponse } from '../dto/workbookResponse';
+import { WorkbookTitleResponse } from '../dto/workbookTitleResponse';
+import { CategoryNotFoundException } from '../../category/exception/category.exception';
+import { WorkbookRepository } from '../repository/workbook.repository';
 
 describe('WorkbookController 단위테스트', () => {
   let controller: WorkbookController;
   const mockWorkbookService = {
     createWorkbook: jest.fn(),
+    findWorkbooks: jest.fn(),
+    findWorkbookTitles: jest.fn(),
+    findSingleWorkbook: jest.fn(),
   };
   const mockTokenService = {};
 
@@ -71,6 +82,107 @@ describe('WorkbookController 단위테스트', () => {
       expect(response.workbookId).toBe(workbookFixture.id);
     });
   });
+
+  describe('카테고리별 문제집 조회', () => {
+    it('조회를 성공한다', async () => {
+      //given
+
+      //when
+      mockWorkbookService.findWorkbooks.mockResolvedValue(
+        [workbookFixture, workbookFixture, workbookFixture].map(
+          WorkbookResponse.of,
+        ),
+      );
+
+      //then
+      const result = await controller.findWorkbooks(null);
+      expect(result.length).toBe(3);
+      expect(result[0]).toBeInstanceOf(WorkbookResponse);
+      expect(result[0].title).toBeInstanceOf(workbookFixture.title);
+      expect(result[0].content).toBeInstanceOf(workbookFixture.content);
+    });
+
+    it('카테고리가 존재하지 않으면 CategoryNotFoundException을 반환한다', async () => {
+      //given
+
+      //when
+      mockWorkbookService.findWorkbooks.mockRejectedValue(
+        new CategoryNotFoundException(),
+      );
+
+      //then
+      await expect(controller.findWorkbooks(12412)).rejects.toThrow(
+        new CategoryNotFoundException(),
+      );
+    });
+  });
+
+  describe('회원/비회원의 문제집 조회', () => {
+    it('회원을 입력해주면 해당 회원의 문제집을 보여준다.', async () => {
+      //given
+
+      //when
+      mockWorkbookService.findWorkbookTitles.mockResolvedValue([
+        WorkbookTitleResponse.of(workbookFixture),
+      ]);
+      const response = await controller.findMembersWorkbook(
+        mockReqWithMemberFixture,
+      );
+
+      //then
+      expect(response).toBeInstanceOf(Array);
+      expect(response[0]).toBeInstanceOf(WorkbookTitleResponse);
+      expect(response[0].workbookId).toBeInstanceOf(workbookFixture.id);
+      expect(response[0].title).toBeInstanceOf(workbookFixture.title);
+    });
+
+    it('비회원은 복사횟수 Top5의 문제집들을 보여준다.', async () => {
+      //given
+
+      //when
+      mockWorkbookService.findWorkbookTitles.mockResolvedValue([
+        WorkbookTitleResponse.of(workbookFixture),
+      ]);
+      const response = await controller.findMembersWorkbook(null);
+
+      //then
+      expect(response).toBeInstanceOf(Array);
+      expect(response[0]).toBeInstanceOf(WorkbookTitleResponse);
+      expect(response[0].workbookId).toBeInstanceOf(workbookFixture.id);
+      expect(response[0].title).toBeInstanceOf(workbookFixture.title);
+    });
+  });
+
+  describe('문제집 단건 조회', () => {
+    it('id로 문제집이 있다면 조회한다.', async () => {
+      //given
+
+      //when
+      mockWorkbookService.findSingleWorkbook.mockResolvedValue(
+        WorkbookResponse.of(workbookFixture),
+      );
+
+      //then
+      const result = await controller.findSingleWorkbook(1);
+      expect(result).toBeInstanceOf(WorkbookResponse);
+      expect(result.title).toBeInstanceOf(workbookFixture.title);
+      expect(result.content).toBeInstanceOf(workbookFixture.content);
+    });
+
+    it('문제집이 없다면 WorkbookNotFoundException을 반환한다.', async () => {
+      //given
+
+      //when
+      mockWorkbookService.findSingleWorkbook.mockRejectedValue(
+        new WorkbookNotFoundException(),
+      );
+
+      //then
+      await expect(controller.findSingleWorkbook(1234)).rejects.toThrow(
+        new WorkbookNotFoundException(),
+      );
+    });
+  });
 });
 
 describe('WorkbookController 통합테스트', () => {
@@ -78,6 +190,7 @@ describe('WorkbookController 통합테스트', () => {
   let authService: AuthService;
   let memberRepository: MemberRepository;
   let categoryRepository: CategoryRepository;
+  let workbookRepository: WorkbookRepository;
 
   beforeAll(async () => {
     const modules = [AuthModule, WorkbookModule, CategoryModule, TokenModule];
@@ -97,99 +210,214 @@ describe('WorkbookController 통합테스트', () => {
     memberRepository = moduleFixture.get<MemberRepository>(MemberRepository);
     categoryRepository =
       moduleFixture.get<CategoryRepository>(CategoryRepository);
+    workbookRepository =
+      moduleFixture.get<WorkbookRepository>(WorkbookRepository);
   });
 
-  it('토큰과 dto를 정상적으로 넣으면 201코드와 WorkbookIdResponse를 반환한다.', async () => {
-    //given
-    await memberRepository.save(memberFixture);
-    await categoryRepository.save(categoryFixtureWithId);
-    const token = await authService.login(memberFixturesOAuthRequest);
+  describe('문제집을 추가한다', () => {
+    it('토큰과 dto를 정상적으로 넣으면 201코드와 WorkbookIdResponse를 반환한다.', async () => {
+      //given
+      await memberRepository.save(memberFixture);
+      await categoryRepository.save(categoryFixtureWithId);
+      const token = await authService.login(memberFixturesOAuthRequest);
 
-    //when & then
-    const agent = request.agent(app.getHttpServer());
-    await agent
-      .post('/api/workbook')
-      .set('Cookie', [`accessToken=${token}`])
-      .send(createWorkbookRequestFixture)
-      .expect(201);
-  });
-
-  it('토큰이 없으면 401에러를 반환한다.', async () => {
-    //given
-    await memberRepository.save(memberFixture);
-    await categoryRepository.save(categoryFixtureWithId);
-
-    //when & then
-    const agent = request.agent(app.getHttpServer());
-    await agent
-      .post('/api/workbook')
-      .send(createWorkbookRequestFixture)
-      .expect(401);
-  });
-
-  it('요청 dto의 title이 빈 문자열/null이면 400에러를 반환한다.', async () => {
-    //given
-    await memberRepository.save(memberFixture);
-    await categoryRepository.save(categoryFixtureWithId);
-    const token = await authService.login(memberFixturesOAuthRequest);
-
-    //when & then
-    const cases = ['', null];
-    const agent = request.agent(app.getHttpServer());
-    for (const title of cases) {
-      const createWorkbookRequest = new CreateWorkbookRequest(
-        title,
-        'test content',
-        categoryFixtureWithId.id,
-      );
+      //when & then
+      const agent = request.agent(app.getHttpServer());
       await agent
         .post('/api/workbook')
         .set('Cookie', [`accessToken=${token}`])
-        .send(createWorkbookRequest)
-        .expect(400);
-    }
-  });
+        .send(createWorkbookRequestFixture)
+        .expect(201);
+    });
 
-  it('요청 dto의 content가 빈 문자열/null이면 400에러를 반환한다.', async () => {
-    //given
-    await memberRepository.save(memberFixture);
-    await categoryRepository.save(categoryFixtureWithId);
-    const token = await authService.login(memberFixturesOAuthRequest);
+    it('토큰이 없으면 401에러를 반환한다.', async () => {
+      //given
+      await memberRepository.save(memberFixture);
+      await categoryRepository.save(categoryFixtureWithId);
 
-    //when & then
-    const cases = ['', null];
-    const agent = request.agent(app.getHttpServer());
-    for (const content of cases) {
+      //when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .post('/api/workbook')
+        .send(createWorkbookRequestFixture)
+        .expect(401);
+    });
+
+    it('요청 dto의 title이 빈 문자열/null이면 400에러를 반환한다.', async () => {
+      //given
+      await memberRepository.save(memberFixture);
+      await categoryRepository.save(categoryFixtureWithId);
+      const token = await authService.login(memberFixturesOAuthRequest);
+
+      //when & then
+      const cases = ['', null];
+      const agent = request.agent(app.getHttpServer());
+      for (const title of cases) {
+        const createWorkbookRequest = new CreateWorkbookRequest(
+          title,
+          'test content',
+          categoryFixtureWithId.id,
+        );
+        await agent
+          .post('/api/workbook')
+          .set('Cookie', [`accessToken=${token}`])
+          .send(createWorkbookRequest)
+          .expect(400);
+      }
+    });
+
+    it('요청 dto의 content가 빈 문자열/null이면 400에러를 반환한다.', async () => {
+      //given
+      await memberRepository.save(memberFixture);
+      await categoryRepository.save(categoryFixtureWithId);
+      const token = await authService.login(memberFixturesOAuthRequest);
+
+      //when & then
+      const cases = ['', null];
+      const agent = request.agent(app.getHttpServer());
+      for (const content of cases) {
+        const createWorkbookRequest = new CreateWorkbookRequest(
+          'test title',
+          content,
+          categoryFixtureWithId.id,
+        );
+        await agent
+          .post('/api/workbook')
+          .set('Cookie', [`accessToken=${token}`])
+          .send(createWorkbookRequest)
+          .expect(400);
+      }
+    });
+
+    it('category가 존재하지 않으면 404에러를 반환한다.', async () => {
+      //given
+      await memberRepository.save(memberFixture);
+      await categoryRepository.save(categoryFixtureWithId);
+      const token = await authService.login(memberFixturesOAuthRequest);
+
+      //when & then
+      const agent = request.agent(app.getHttpServer());
       const createWorkbookRequest = new CreateWorkbookRequest(
         'test title',
-        content,
-        categoryFixtureWithId.id,
+        'test content',
+        12345,
       );
       await agent
         .post('/api/workbook')
         .set('Cookie', [`accessToken=${token}`])
         .send(createWorkbookRequest)
-        .expect(400);
-    }
+        .expect(404);
+    });
   });
 
-  it('category가 존재하지 않으면 404에러를 반환한다.', async () => {
-    //given
-    await memberRepository.save(memberFixture);
-    await categoryRepository.save(categoryFixtureWithId);
-    const token = await authService.login(memberFixturesOAuthRequest);
+  describe('카테고리별 문제집을 조회한다', () => {
+    it('카테고리id를 입력해주지 않으면 전체를 조회한다.', async () => {
+      //given
+      const member = await memberRepository.save(memberFixture);
+      for (const eachCategory of categoryListFixture) {
+        const category = await categoryRepository.save(eachCategory);
+        await workbookRepository.save(
+          Workbook.of(
+            `title_${category.name}`,
+            `content_${category.name}`,
+            category,
+            member,
+          ),
+        );
+      }
 
-    //when & then
-    const agent = request.agent(app.getHttpServer());
-    const createWorkbookRequest = new CreateWorkbookRequest(
-      'test title',
-      'test content',
-      12345,
-    );
-    await agent
-      .post('/api/workbook')
-      .set('Cookie', [`accessToken=${token}`])
-      .send(createWorkbookRequest)
-      .expect(404);
+      //when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .get('/api/workbook')
+        .expect(200)
+        .then((response) => {
+          expect(response.body.length).toBe(categoryListFixture.length);
+          expect(response.body[0].title).toBe('title_BE');
+          expect(response.body[1].title).toBe('title_CS');
+          expect(response.body[2].title).toBe('title_FE');
+          expect(response.body[3].title).toBe('title_나만의 질문');
+        });
+    });
+
+    it('특정 카테고리를 입력해주면 해당 카테고리의 문제집들을 조회한다.', async () => {
+      //given
+      const member = await memberRepository.save(memberFixture);
+      for (const eachCategory of categoryListFixture) {
+        const category = await categoryRepository.save(eachCategory);
+        await workbookRepository.save(
+          Workbook.of(
+            `title_${category.name}`,
+            `content_${category.name}`,
+            category,
+            member,
+          ),
+        );
+      }
+
+      //when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .get('/api/workbook?categoryId=1')
+        .expect(200)
+        .then((response) => {
+          expect(response.body.length).toBe(1);
+          expect(response.body[0].title).toBe('title_BE');
+        });
+    });
+
+    it('카테고리id가 존재하지 않는 값이라면 404에러를 반환한다.', async () => {
+      //given
+      const member = await memberRepository.save(memberFixture);
+      for (const eachCategory of categoryListFixture) {
+        const category = await categoryRepository.save(eachCategory);
+        await workbookRepository.save(
+          Workbook.of(
+            `title_${category.name}`,
+            `content_${category.name}`,
+            category,
+            member,
+          ),
+        );
+      }
+
+      //when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent.get('/api/workbook?categoryId=15314').expect(404);
+    });
+  });
+
+  describe('회원의 문제집을 조회한다', () => {
+    it('쿠키가 있을 경우 회원의 문제집을 조회한다.', async () => {
+      //given
+      //when
+      //then
+    });
+
+    it('쿠키가 없을 경우 복사횟수 Top5의 문제집을 조회한다.', async () => {
+      //given
+      //when
+      //then
+    });
+  });
+
+  describe('단건의 문제집을 조회한다', () => {
+    it('존재하는 경우 단건을 반환한다.', async () => {
+      //given
+      //when
+      //then
+    });
+
+    it('존재하지 않는 문제집의 id일 경우 404에러를 반환한다.', async () => {
+      //given
+      //when
+      //then
+    });
+  });
+
+  afterEach(async () => {
+    await workbookRepository.query('delete from Workbook');
+    await workbookRepository.query('delete from Member');
+    await workbookRepository.query('delete from Category');
   });
 });

--- a/BE/src/workbook/controller/workbook.controller.spec.ts
+++ b/BE/src/workbook/controller/workbook.controller.spec.ts
@@ -99,8 +99,8 @@ describe('WorkbookController 단위테스트', () => {
       const result = await controller.findWorkbooks(null);
       expect(result.length).toBe(3);
       expect(result[0]).toBeInstanceOf(WorkbookResponse);
-      expect(result[0].title).toBeInstanceOf(workbookFixture.title);
-      expect(result[0].content).toBeInstanceOf(workbookFixture.content);
+      expect(result[0].title).toBe(workbookFixture.title);
+      expect(result[0].content).toBe(workbookFixture.content);
     });
 
     it('카테고리가 존재하지 않으면 CategoryNotFoundException을 반환한다', async () => {
@@ -133,8 +133,8 @@ describe('WorkbookController 단위테스트', () => {
       //then
       expect(response).toBeInstanceOf(Array);
       expect(response[0]).toBeInstanceOf(WorkbookTitleResponse);
-      expect(response[0].workbookId).toBeInstanceOf(workbookFixture.id);
-      expect(response[0].title).toBeInstanceOf(workbookFixture.title);
+      expect(response[0].workbookId).toBe(workbookFixture.id);
+      expect(response[0].title).toBe(workbookFixture.title);
     });
 
     it('비회원은 복사횟수 Top5의 문제집들을 보여준다.', async () => {
@@ -149,8 +149,8 @@ describe('WorkbookController 단위테스트', () => {
       //then
       expect(response).toBeInstanceOf(Array);
       expect(response[0]).toBeInstanceOf(WorkbookTitleResponse);
-      expect(response[0].workbookId).toBeInstanceOf(workbookFixture.id);
-      expect(response[0].title).toBeInstanceOf(workbookFixture.title);
+      expect(response[0].workbookId).toBe(workbookFixture.id);
+      expect(response[0].title).toBe(workbookFixture.title);
     });
   });
 
@@ -166,8 +166,8 @@ describe('WorkbookController 단위테스트', () => {
       //then
       const result = await controller.findSingleWorkbook(1);
       expect(result).toBeInstanceOf(WorkbookResponse);
-      expect(result.title).toBeInstanceOf(workbookFixture.title);
-      expect(result.content).toBeInstanceOf(workbookFixture.content);
+      expect(result.title).toBe(workbookFixture.title);
+      expect(result.content).toBe(workbookFixture.content);
     });
 
     it('문제집이 없다면 WorkbookNotFoundException을 반환한다.', async () => {
@@ -472,7 +472,6 @@ describe('WorkbookController 통합테스트', () => {
         .get('/api/workbook/title')
         .expect(200)
         .then((response) => {
-          console.log(response.body);
           expect(response.body.length).toBe(categoryListFixture.length + 1);
           expect(response.body[4].title).toBe('title_BE');
           expect(response.body[3].title).toBe('title_CS');

--- a/BE/src/workbook/controller/workbook.controller.spec.ts
+++ b/BE/src/workbook/controller/workbook.controller.spec.ts
@@ -486,14 +486,33 @@ describe('WorkbookController 통합테스트', () => {
   describe('단건의 문제집을 조회한다', () => {
     it('존재하는 경우 단건을 반환한다.', async () => {
       //given
-      //when
-      //then
+      const other = await memberRepository.save(differentMemberFixture);
+      const category = await categoryRepository.save(categoryFixtureWithId);
+      const workbook = Workbook.of(
+        `other${category.name}`,
+        `other${category.name}`,
+        category,
+        other,
+      );
+      await workbookRepository.save(workbook);
+
+      //when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .get(`/api/workbook/${workbook.id}`)
+        .expect(200)
+        .then((response) => {
+          expect(response.body.title).toBe(workbook.title);
+          expect(response.body.content).toBe(workbook.content);
+        });
     });
 
     it('존재하지 않는 문제집의 id일 경우 404에러를 반환한다.', async () => {
       //given
-      //when
-      //then
+
+      //when & then
+      const agent = request.agent(app.getHttpServer());
+      await agent.get(`/api/workbook/1252143`).expect(404);
     });
   });
 

--- a/BE/src/workbook/dto/workbookResponse.ts
+++ b/BE/src/workbook/dto/workbookResponse.ts
@@ -1,0 +1,65 @@
+import { Workbook } from '../entity/workbook';
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from '../../util/swagger.util';
+
+export class WorkbookResponse {
+  @ApiProperty(createPropertyOption(1, '문제집 ID', Number))
+  workbookId: number;
+
+  @ApiProperty(createPropertyOption(1, '카테고리 ID', Number))
+  categoryId: number;
+
+  @ApiProperty(createPropertyOption('이장희', '회원 닉네임', String))
+  nickname: string;
+
+  @ApiProperty(
+    createPropertyOption(
+      'https://jangsarchive.tistory.com',
+      '회원 프로필 사진 주소',
+      String,
+    ),
+  )
+  profileImg: string;
+
+  @ApiProperty(createPropertyOption(1, '문제집 복사 횟수', Number))
+  copyCount: number;
+
+  @ApiProperty(
+    createPropertyOption('이장희의 면접 문제집', '문제집 제목', String),
+  )
+  title: string;
+
+  @ApiProperty(createPropertyOption('내꺼 건들 ㄴㄴ해', '문제집 설명', String))
+  content: string;
+
+  constructor(
+    workbookId: number,
+    categoryId: number,
+    nickname: string,
+    profileImg: string,
+    copyCount: number,
+    title: string,
+    content: string,
+  ) {
+    this.workbookId = workbookId;
+    this.categoryId = categoryId;
+    this.nickname = nickname;
+    this.profileImg = profileImg;
+    this.copyCount = copyCount;
+    this.title = title;
+    this.content = content;
+  }
+
+  static of(workbook: Workbook) {
+    const member = workbook.member;
+    return new WorkbookResponse(
+      workbook.id,
+      workbook.category.id,
+      member.nickname,
+      member.profileImg,
+      workbook.copyCount,
+      workbook.title,
+      workbook.content,
+    );
+  }
+}

--- a/BE/src/workbook/dto/workbookTitleResponse.ts
+++ b/BE/src/workbook/dto/workbookTitleResponse.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from '../../util/swagger.util';
+import { Workbook } from '../entity/workbook';
+
+export class WorkbookTitleResponse {
+  @ApiProperty(createPropertyOption(1, '문제집 ID', Number))
+  workbookId: number;
+  @ApiProperty(
+    createPropertyOption('이장희의 면접 문제집', '문제집 제목', String),
+  )
+  title: string;
+
+  constructor(workbookId: number, title: string) {
+    this.workbookId = workbookId;
+    this.title = title;
+  }
+
+  static of(workbook: Workbook) {
+    return new WorkbookTitleResponse(workbook.id, workbook.title);
+  }
+}

--- a/BE/src/workbook/entity/workbook.ts
+++ b/BE/src/workbook/entity/workbook.ts
@@ -51,4 +51,8 @@ export class Workbook extends DefaultEntity {
   isOwnedBy(member: Member) {
     return this.member.id === member.id;
   }
+
+  increaseCopyCount() {
+    this.copyCount++;
+  }
 }

--- a/BE/src/workbook/repository/workbook.repository.ts
+++ b/BE/src/workbook/repository/workbook.repository.ts
@@ -58,7 +58,7 @@ export class WorkbookRepository {
     return await this.repository
       .createQueryBuilder('Workbook')
       .leftJoinAndSelect('Workbook.member', 'member')
-      .where('member.id = :id', { memberId })
+      .where('member.id = :memberId', { memberId })
       .getMany();
   }
 }

--- a/BE/src/workbook/repository/workbook.repository.ts
+++ b/BE/src/workbook/repository/workbook.repository.ts
@@ -27,4 +27,38 @@ export class WorkbookRepository {
       member: { id: memberId },
     });
   }
+
+  async findAll() {
+    return await this.repository
+      .createQueryBuilder('Workbook')
+      .leftJoinAndSelect('Workbook.category', 'category')
+      .leftJoinAndSelect('Workbook.member', 'member')
+      .getMany();
+  }
+
+  async findAllByCategoryId(categoryId: number) {
+    return await this.repository
+      .createQueryBuilder('Workbook')
+      .leftJoinAndSelect('Workbook.category', 'category')
+      .leftJoinAndSelect('Workbook.member', 'member')
+      .where('category.id = :id', { categoryId })
+      .getMany();
+  }
+
+  async findTop5Workbooks() {
+    return await this.repository
+      .createQueryBuilder('Workbook')
+      .select()
+      .orderBy('Workbook.copyCount', 'DESC')
+      .limit(5)
+      .getMany();
+  }
+
+  async findMembersWorkbooks(memberId: number) {
+    return await this.repository
+      .createQueryBuilder('Workbook')
+      .leftJoinAndSelect('Workbook.member', 'member')
+      .where('member.id = :id', { memberId })
+      .getMany();
+  }
 }

--- a/BE/src/workbook/repository/workbook.repository.ts
+++ b/BE/src/workbook/repository/workbook.repository.ts
@@ -39,9 +39,9 @@ export class WorkbookRepository {
   async findAllByCategoryId(categoryId: number) {
     return await this.repository
       .createQueryBuilder('Workbook')
-      .leftJoinAndSelect('Workbook.category', 'category')
       .leftJoinAndSelect('Workbook.member', 'member')
-      .where('category.id = :id', { categoryId })
+      .leftJoinAndSelect('Workbook.category', 'category')
+      .where('category.id = :categoryId', { categoryId })
       .getMany();
   }
 

--- a/BE/src/workbook/repository/workbook.repository.ts
+++ b/BE/src/workbook/repository/workbook.repository.ts
@@ -10,7 +10,12 @@ export class WorkbookRepository {
   ) {}
 
   async findById(id: number) {
-    return await this.repository.findOneBy({ id: id });
+    return await this.repository
+      .createQueryBuilder('Workbook')
+      .leftJoinAndSelect('Workbook.member', 'member')
+      .leftJoinAndSelect('Workbook.category', 'category')
+      .where('Workbook.id = :id', { id })
+      .getOne();
   }
 
   async query(query: string) {

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -146,6 +146,42 @@ describe('WorkbookService 단위테스트', () => {
       );
     });
   });
+
+  describe('회원을 통한 문제집 조회', () => {
+    it('회원 정보가 null인 상태로 제목리스트를 조회하면 copyCount가 많은 순으로 5개의 문제집만이 조회된다.', async () => {
+      //given
+
+      //when
+      mockWorkbookRepository.findTop5Workbooks.mockResolvedValue([
+        workbookFixture,
+        workbookFixture,
+      ]);
+      mockWorkbookRepository.findMembersWorkbooks.mockResolvedValue([
+        workbookFixture,
+      ]);
+
+      //then
+      const workbooks = await service.findWorkbookTitles(null);
+      expect(workbooks.length).toBe(2);
+    });
+
+    it('member가 null이 아니라면 회원의 문제집만이 조회된다.', async () => {
+      //given
+
+      //when
+      mockWorkbookRepository.findTop5Workbooks.mockResolvedValue([
+        workbookFixture,
+        workbookFixture,
+      ]);
+      mockWorkbookRepository.findMembersWorkbooks.mockResolvedValue([
+        workbookFixture,
+      ]);
+
+      //then
+      const workbooks = await service.findWorkbookTitles(memberFixture);
+      expect(workbooks.length).toBe(1);
+    });
+  });
 });
 
 describe('WorkbookService 통합테스트', () => {

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -295,8 +295,10 @@ describe('WorkbookService 통합테스트', () => {
   it('카테고리를 입력받으면 해당 카테고리의 문제집을 조회한다.', async () => {
     ///given
     const member = await memberRepository.save(memberFixture);
+    let categoryId = 0;
     for (const each of categoryListFixture) {
       const category = await categoryRepository.save(each);
+      categoryId = category.id;
       for (let index = 1; index <= 3; index++) {
         await workbookRepository.save(
           Workbook.of(
@@ -310,10 +312,10 @@ describe('WorkbookService 통합테스트', () => {
     }
 
     //when
-    const result = await workbookService.findWorkbooks(1);
+    const result = await workbookService.findWorkbooks(categoryId);
 
     //then
-    expect(result.length).toBe(categoryListFixture.length);
+    expect(result.length).toBe(3);
     expect(result[0]).toBeInstanceOf(WorkbookResponse);
   });
 
@@ -428,5 +430,11 @@ describe('WorkbookService 통합테스트', () => {
     expect(workbook.title).toEqual('test title');
     expect(workbook.content).toEqual('test content');
     expect(workbook.member.id).toEqual(member.id);
+  });
+
+  afterEach(async () => {
+    await workbookRepository.query('delete from Workbook');
+    await workbookRepository.query('delete from Member');
+    await workbookRepository.query('delete from Category');
   });
 });

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -23,6 +23,7 @@ import * as cookieParser from 'cookie-parser';
 import { Category } from '../../category/entity/category';
 import { CreateWorkbookRequest } from '../dto/createWorkbookRequest';
 import { WorkbookResponse } from '../dto/workbookResponse';
+import { WorkbookNotFoundException } from '../exception/workbook.exception';
 
 describe('WorkbookService 단위테스트', () => {
   let service: WorkbookService;
@@ -31,6 +32,7 @@ describe('WorkbookService 단위테스트', () => {
   };
   const mockWorkbookRepository = {
     save: jest.fn(),
+    findById: jest.fn(),
     findAll: jest.fn(),
     findAllByCategoryId: jest.fn(),
     findTop5Workbooks: jest.fn(),
@@ -109,7 +111,7 @@ describe('WorkbookService 단위테스트', () => {
       const workbooks = await service.findWorkbooks(null);
       //then
       expect(workbooks.length).toBe(1);
-      expect(workbooks).toBeInstanceOf([WorkbookResponse]);
+      expect(workbooks).toBeInstanceOf(Array);
       expect(workbooks[0].title).toEqual(workbookFixture.title);
       expect(workbooks[0].content).toEqual(workbookFixture.content);
     });
@@ -127,7 +129,7 @@ describe('WorkbookService 단위테스트', () => {
       const workbooks = await service.findWorkbooks(1);
       //then
       expect(workbooks.length).toBe(1);
-      expect(workbooks).toBeInstanceOf([WorkbookResponse]);
+      expect(workbooks).toBeInstanceOf(Array);
       expect(workbooks[0].title).toEqual(workbookFixture.title);
       expect(workbooks[0].content).toEqual(workbookFixture.content);
     });
@@ -180,6 +182,33 @@ describe('WorkbookService 단위테스트', () => {
       //then
       const workbooks = await service.findWorkbookTitles(memberFixture);
       expect(workbooks.length).toBe(1);
+    });
+  });
+
+  describe('문제집 id로 문제집 조회', () => {
+    it('문제집 id로 조회를 성공하면 WorkbookResponse로 반환된다.', async () => {
+      //given
+
+      //when
+      mockWorkbookRepository.findById.mockResolvedValue(workbookFixtureWithId);
+
+      //then
+      const result = await service.findSingleWorkbook(workbookFixtureWithId.id);
+      expect(result).toBeInstanceOf(WorkbookResponse);
+      expect(result.title).toBe(workbookFixtureWithId.title);
+      expect(result.content).toBe(workbookFixtureWithId.content);
+    });
+
+    it('존재하지 않는 id라면 WorkbookNotFoundExceoption을 반환한다.', async () => {
+      //given
+
+      //when
+      mockWorkbookRepository.findById.mockResolvedValue(null);
+
+      //then
+      await expect(service.findSingleWorkbook(135)).rejects.toThrow(
+        new WorkbookNotFoundException(),
+      );
     });
   });
 });

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -417,31 +417,22 @@ describe('WorkbookService 통합테스트', () => {
     );
 
     //then
-    expect(workbook.title).toEqual('test title');
-    expect(workbook.content).toEqual('test content');
-    expect(workbook.member.id).toEqual(member.id);
+    const result = await workbookService.findSingleWorkbook(workbook.id);
+    expect(result).toBeInstanceOf(WorkbookResponse);
+    expect(result.title).toBe(workbook.title);
+    expect(result.content).toBe(workbook.content);
+    expect(result.workbookId).toBe(workbook.id);
   });
 
   it('문제집 id가 존재하지 않으면 WorkbookNotFound예외처리한다.', async () => {
     //given
-    const member = await memberRepository.save(memberFixture);
-    const category = await categoryRepository.save(categoryFixtureWithId);
 
     //when
-    const createWorkbookRequest = new CreateWorkbookRequest(
-      'test title',
-      'test content',
-      category.id,
-    );
-    const workbook = await workbookService.createWorkbook(
-      createWorkbookRequest,
-      member,
-    );
 
     //then
-    expect(workbook.title).toEqual('test title');
-    expect(workbook.content).toEqual('test content');
-    expect(workbook.member.id).toEqual(member.id);
+    await expect(workbookService.findSingleWorkbook(12345)).rejects.toThrow(
+      new WorkbookNotFoundException(),
+    );
   });
 
   afterEach(async () => {

--- a/BE/src/workbook/service/workbook.service.ts
+++ b/BE/src/workbook/service/workbook.service.ts
@@ -6,6 +6,9 @@ import { validateCategory } from '../../category/util/category.util';
 import { Workbook } from '../entity/workbook';
 import { Member } from '../../member/entity/member';
 import { validateManipulatedToken } from '../../util/token.util';
+import { WorkbookResponse } from '../dto/workbookResponse';
+import { isEmpty } from 'class-validator';
+import { validateWorkbook } from '../util/workbook.util';
 
 @Injectable()
 export class WorkbookService {
@@ -32,5 +35,46 @@ export class WorkbookService {
         member,
       ),
     );
+  }
+
+  async findWorkbooks(categoryId: number) {
+    if (isEmpty(categoryId)) {
+      return await this.findAllWorkbook();
+    }
+
+    return this.findAllByCategory(categoryId);
+  }
+
+  private async findAllWorkbook() {
+    const workbooks = await this.workbookRepository.findAll();
+    return workbooks.map(WorkbookResponse.of);
+  }
+
+  private async findAllByCategory(categoryId: number) {
+    const category = await this.categoryRepository.findByCategoryId(categoryId);
+    validateCategory(category);
+
+    const workbooks =
+      await this.workbookRepository.findAllByCategoryId(categoryId);
+    return workbooks.map(WorkbookResponse.of);
+  }
+
+  async findWorkbookTitles(member: Member) {
+    if (isEmpty(member)) {
+      return (await this.workbookRepository.findTop5Workbooks()).map(
+        WorkbookResponse.of,
+      );
+    }
+
+    return (await this.workbookRepository.findMembersWorkbooks(member.id)).map(
+      WorkbookResponse.of,
+    );
+  }
+
+  async findSingleWorkbook(workbookId: number) {
+    const workbook = await this.workbookRepository.findById(workbookId);
+    validateWorkbook(workbook);
+
+    return WorkbookResponse.of(workbook);
   }
 }

--- a/BE/src/workbook/service/workbook.service.ts
+++ b/BE/src/workbook/service/workbook.service.ts
@@ -9,6 +9,7 @@ import { validateManipulatedToken } from '../../util/token.util';
 import { WorkbookResponse } from '../dto/workbookResponse';
 import { isEmpty } from 'class-validator';
 import { validateWorkbook } from '../util/workbook.util';
+import { WorkbookTitleResponse } from '../dto/workbookTitleResponse';
 
 @Injectable()
 export class WorkbookService {
@@ -60,15 +61,16 @@ export class WorkbookService {
   }
 
   async findWorkbookTitles(member: Member) {
+    const workbooks = await this.findWorkbookByMember(member);
+    return workbooks.map(WorkbookTitleResponse.of);
+  }
+
+  private async findWorkbookByMember(member: Member) {
     if (isEmpty(member)) {
-      return (await this.workbookRepository.findTop5Workbooks()).map(
-        WorkbookResponse.of,
-      );
+      return await this.workbookRepository.findTop5Workbooks();
     }
 
-    return (await this.workbookRepository.findMembersWorkbooks(member.id)).map(
-      WorkbookResponse.of,
-    );
+    return await this.workbookRepository.findMembersWorkbooks(member.id);
   }
 
   async findSingleWorkbook(workbookId: number) {

--- a/BE/src/workbook/workbook.module.ts
+++ b/BE/src/workbook/workbook.module.ts
@@ -7,10 +7,21 @@ import { WorkbookController } from './controller/workbook.controller';
 import { Category } from '../category/entity/category';
 import { CategoryRepository } from '../category/repository/category.repository';
 import { CategoryModule } from '../category/category.module';
+import { TokenSoftGuard } from '../token/guard/token.soft.guard';
+import { TokenModule } from '../token/token.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Workbook, Category]), CategoryModule],
-  providers: [WorkbookRepository, WorkbookService, CategoryRepository],
+  imports: [
+    TypeOrmModule.forFeature([Workbook, Category]),
+    CategoryModule,
+    TokenModule,
+  ],
+  providers: [
+    WorkbookRepository,
+    WorkbookService,
+    CategoryRepository,
+    TokenSoftGuard,
+  ],
   controllers: [WorkbookController],
 })
 export class WorkbookModule {}


### PR DESCRIPTION
[![NDD-282](https://badgen.net/badge/JIRA/NDD-282/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-282) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

Category의 로직들이 삭제되며, 비회원/회원을 동적으로 처리해줄 로직이 필요했다. 
- 쿠키를 가지고 오지만, AuthGuard는 없을 경우 401에러를 바로 반환한다.
- 하지만, 회원과 비회원이 상황에 따라 다르게 동작해야 하는 경우 이를 예외처리하면 안된다. 
- 이를 위한 미들웨어 등록 및 테스트 케이스 다양화로 인해 시간이 지체되었다.

# How

조회는 크게 3가지 api가 존재한다. 
- /api/workbook?categoryId=${categoryId}
    - categoryId === null일 경우 전체를 반환한다.
    - 있을 경우 해당 카테고리만을 반환한다.
    - 카테고리 자체가 없는데 있는 요청이면 예외처리한다.
- /api/workbook/title
    - 회원은 자신이 가지고 있는 문제집을 조회한다
    - 비회원은 복사된 횟수가 가장 많은 문제집 5개를 조회한다.
- /api/workbook/${workbookId}
    - 단건을 조회한다
    - 없으면 예외처리한다.

# Result

<img width="291" alt="스크린샷 2023-11-28 18 46 36" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/69583e15-0dcf-4ade-8107-32fa1530b63b">
<img width="900" alt="스크린샷 2023-11-28 18 47 09" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/225d4871-ae86-4d73-b758-384b31136f64">
<img width="606" alt="스크린샷 2023-11-28 18 47 30" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/ed876d76-dc4c-4973-8327-acc1da5944a9">
<img width="681" alt="스크린샷 2023-11-28 18 47 39" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/908e5ec3-0446-4e08-9e57-b0e111959a00">


# Prize

- TokenSoftGuard를 따로 만들었다. 
```
@Get('/title')
  @OptionalGuard()
  @UseGuards(TokenSoftGuard)
  @ApiOperation({
    summary: '회원의(null이면 Top5) 문제집 조회',
  })
  @ApiResponse(
    createApiResponseOption(200, '회원의(null이면 Top5) 문제집 조회', [
      WorkbookTitleResponse,
    ]),
  )
  async findMembersWorkbook(@Req() req: Request) {
    const member = isEmpty(req) ? null : (req.user as Member);
    return await this.workbookService.findWorkbookTitles(member);
  }
```

- 해당 미들웨어를 통해 쿠키가 없는 상황에서 미들웨어의 필터링을 거치지 않고, null로 가져온다.

# Reference

https://www.notion.so/OptionalGuard-97a30bf104274c37ad84baded61a46f8?pvs=4

- 미들웨어를 통해 Authorization헤더에서 쿠키를 401에러가 아닌 null로 처리해 가져오는 방식이다. 
- 해당 방식을 조금 수정했다. 
    - 쿠키에서 토큰을 빼낸다. 
    - 토큰을 통해 Member객체를 가져온다. 
        - 예외처리시 null로 가져온다.
    - req.user에 담는다(쿠키가 없다면 req자체가 null이 된다.)

[NDD-282]: https://milk717.atlassian.net/browse/NDD-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ