### PR TITLE
[NDD-284]: 문제집 수정 로직 구현 (2h / 1h)

### DIFF
--- a/BE/src/question/controller/question.controller.spec.ts
+++ b/BE/src/question/controller/question.controller.spec.ts
@@ -249,7 +249,7 @@ describe('QuestionController 통합테스트', () => {
       await agent
         .delete(`/api/question?questionId=${question.id}`)
         .set('Cookie', [`accessToken=${token}`])
-        .expect(401);
+        .expect(403);
     });
   });
 

--- a/BE/src/question/service/question.service.spec.ts
+++ b/BE/src/question/service/question.service.spec.ts
@@ -9,7 +9,7 @@ import { QuestionResponse } from '../dto/questionResponse';
 import { createIntegrationTestModule } from '../../util/test.util';
 import { QuestionModule } from '../question.module';
 import { Question } from '../entity/question';
-import { INestApplication, UnauthorizedException } from '@nestjs/common';
+import { INestApplication } from '@nestjs/common';
 import { Member } from '../../member/entity/member';
 import { MemberModule } from '../../member/member.module';
 import { MemberRepository } from '../../member/repository/member.repository';
@@ -25,7 +25,10 @@ import { WorkbookRepository } from '../../workbook/repository/workbook.repositor
 import { workbookFixture } from '../../workbook/fixture/workbook.fixture';
 import { WorkbookModule } from '../../workbook/workbook.module';
 import { Workbook } from '../../workbook/entity/workbook';
-import { WorkbookNotFoundException } from '../../workbook/exception/workbook.exception';
+import {
+  WorkbookForbiddenException,
+  WorkbookNotFoundException,
+} from '../../workbook/exception/workbook.exception';
 import { CategoryRepository } from '../../category/repository/category.repository';
 import { categoryFixtureWithId } from '../../category/fixture/category.fixture';
 import { CategoryModule } from '../../category/category.module';
@@ -189,7 +192,7 @@ describe('QuestionService', () => {
             new Date(),
           ),
         ),
-      ).rejects.toThrow(new UnauthorizedException());
+      ).rejects.toThrow(new WorkbookForbiddenException());
     });
   });
 });

--- a/BE/src/workbook/controller/workbook.controller.ts
+++ b/BE/src/workbook/controller/workbook.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Param,
+  Patch,
   Post,
   Query,
   Req,
@@ -27,6 +28,7 @@ import { WorkbookTitleResponse } from '../dto/workbookTitleResponse';
 import { OptionalGuard } from '../../util/decorator.util';
 import { TokenSoftGuard } from '../../token/guard/token.soft.guard';
 import { isEmpty } from 'class-validator';
+import { UpdateWorkbookRequest } from '../dto/updateWorkbookRequest';
 
 @ApiTags('workbook')
 @Controller('/api/workbook')
@@ -93,5 +95,25 @@ export class WorkbookController {
   )
   async findSingleWorkbook(@Param('workbookId') workbookId: number) {
     return await this.workbookService.findSingleWorkbook(workbookId);
+  }
+
+  @Patch()
+  @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth()
+  @ApiBody({ type: UpdateWorkbookRequest })
+  @ApiOperation({
+    summary: '문제집 수정',
+  })
+  @ApiResponse(
+    createApiResponseOption(200, '문제집 수정 완료', WorkbookResponse),
+  )
+  async updateAnswer(
+    @Body() updateWorkbookRequest: UpdateWorkbookRequest,
+    @Req() req: Request,
+  ) {
+    return await this.workbookService.updateWorkbook(
+      updateWorkbookRequest,
+      req.user as Member,
+    );
   }
 }

--- a/BE/src/workbook/dto/updateWorkbookRequest.ts
+++ b/BE/src/workbook/dto/updateWorkbookRequest.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from '../../util/swagger.util';
+import { IsNotEmpty, IsString } from '@nestjs/class-validator';
+import { IsNumber } from 'class-validator';
+
+export class UpdateWorkbookRequest {
+  @ApiProperty(createPropertyOption(1, '문제집 id', Number))
+  @IsNumber()
+  @IsNotEmpty()
+  workbookId: number;
+
+  @ApiProperty(createPropertyOption('장희문제집', '문제집 이름', String))
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty(
+    createPropertyOption('나만볼꺼다요 메롱', '문제집에 대한 설명', String),
+  )
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+
+  @ApiProperty(createPropertyOption(1, '카테고리 id', Number))
+  @IsNumber()
+  @IsNotEmpty()
+  categoryId: number;
+
+  constructor(
+    workbookId: number,
+    title: string,
+    content: string,
+    categoryId: number,
+  ) {
+    this.workbookId = workbookId;
+    this.title = title;
+    this.content = content;
+    this.categoryId = categoryId;
+  }
+}

--- a/BE/src/workbook/entity/workbook.ts
+++ b/BE/src/workbook/entity/workbook.ts
@@ -2,6 +2,7 @@ import { DefaultEntity } from '../../app.entity';
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { Member } from '../../member/entity/member';
 import { Category } from '../../category/entity/category';
+import { UpdateWorkbookRequest } from '../dto/updateWorkbookRequest';
 
 @Entity({ name: 'Workbook' })
 export class Workbook extends DefaultEntity {
@@ -54,5 +55,11 @@ export class Workbook extends DefaultEntity {
 
   increaseCopyCount() {
     this.copyCount++;
+  }
+
+  updateInfo(updateWorkbookRequest: UpdateWorkbookRequest, category: Category) {
+    this.title = updateWorkbookRequest.title;
+    this.content = updateWorkbookRequest.content;
+    this.category = category;
   }
 }

--- a/BE/src/workbook/fixture/workbook.fixture.ts
+++ b/BE/src/workbook/fixture/workbook.fixture.ts
@@ -2,6 +2,7 @@ import { Workbook } from '../entity/workbook';
 import { memberFixture } from '../../member/fixture/member.fixture';
 import { categoryFixtureWithId } from '../../category/fixture/category.fixture';
 import { CreateWorkbookRequest } from '../dto/createWorkbookRequest';
+import { UpdateWorkbookRequest } from '../dto/updateWorkbookRequest';
 
 export const workbookFixture = Workbook.of(
   '테스트 문제집',
@@ -23,5 +24,12 @@ export const workbookFixtureWithId = new Workbook(
 export const createWorkbookRequestFixture = new CreateWorkbookRequest(
   workbookFixture.title,
   workbookFixture.content,
+  categoryFixtureWithId.id,
+);
+
+export const updateWorkbookRequestFixture = new UpdateWorkbookRequest(
+  workbookFixtureWithId.id,
+  'newT',
+  'newC',
   categoryFixtureWithId.id,
 );

--- a/BE/src/workbook/repository/workbook.repository.ts
+++ b/BE/src/workbook/repository/workbook.repository.ts
@@ -66,4 +66,8 @@ export class WorkbookRepository {
       .where('member.id = :memberId', { memberId })
       .getMany();
   }
+
+  async update(workbook: Workbook) {
+    return await this.repository.update({ id: workbook.id }, workbook);
+  }
 }

--- a/BE/src/workbook/service/workbook.service.ts
+++ b/BE/src/workbook/service/workbook.service.ts
@@ -8,8 +8,9 @@ import { Member } from '../../member/entity/member';
 import { validateManipulatedToken } from '../../util/token.util';
 import { WorkbookResponse } from '../dto/workbookResponse';
 import { isEmpty } from 'class-validator';
-import { validateWorkbook } from '../util/workbook.util';
+import { validateWorkbook, validateWorkbookOwner } from '../util/workbook.util';
 import { WorkbookTitleResponse } from '../dto/workbookTitleResponse';
+import { UpdateWorkbookRequest } from '../dto/updateWorkbookRequest';
 
 @Injectable()
 export class WorkbookService {
@@ -77,6 +78,28 @@ export class WorkbookService {
     const workbook = await this.workbookRepository.findById(workbookId);
     validateWorkbook(workbook);
 
+    return WorkbookResponse.of(workbook);
+  }
+
+  async updateWorkbook(
+    updateWorkbookRequest: UpdateWorkbookRequest,
+    member: Member,
+  ) {
+    const category = await this.categoryRepository.findByCategoryId(
+      updateWorkbookRequest.categoryId,
+    );
+    validateManipulatedToken(member);
+    validateCategory(category);
+
+    const workbook = await this.workbookRepository.findById(
+      updateWorkbookRequest.workbookId,
+    );
+
+    validateWorkbook(workbook);
+    validateWorkbookOwner(workbook, member);
+
+    workbook.updateInfo(updateWorkbookRequest, category);
+    await this.workbookRepository.update(workbook);
     return WorkbookResponse.of(workbook);
   }
 }

--- a/BE/src/workbook/util/workbook.util.ts
+++ b/BE/src/workbook/util/workbook.util.ts
@@ -1,7 +1,9 @@
 import { Workbook } from '../entity/workbook';
 import { isEmpty } from 'class-validator';
-import { WorkbookNotFoundException } from '../exception/workbook.exception';
-import { UnauthorizedException } from '@nestjs/common';
+import {
+  WorkbookForbiddenException,
+  WorkbookNotFoundException,
+} from '../exception/workbook.exception';
 import { Member } from '../../member/entity/member';
 
 export const validateWorkbook = (workbook: Workbook) => {
@@ -10,6 +12,6 @@ export const validateWorkbook = (workbook: Workbook) => {
 
 export const validateWorkbookOwner = (workbook: Workbook, member: Member) => {
   if (!workbook.isOwnedBy(member)) {
-    throw new UnauthorizedException();
+    throw new WorkbookForbiddenException();
   }
 };


### PR DESCRIPTION
[![NDD-284](https://badgen.net/badge/JIRA/NDD-284/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-284) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- 문제집에 대한 권한 확인 및 이에 따른 데이터 수정을 해야했다.

# How

```
updateInfo(updateWorkbookRequest: UpdateWorkbookRequest, category: Category) {
    this.title = updateWorkbookRequest.title;
    this.content = updateWorkbookRequest.content;
    this.category = category;
  }
```

- 도메인 영역에서 데이터를 수정하는 로직을 만들었다. 
   - 생성일자, 사용 회원, 카테고리를 제외한 다른 데이터를 복제시켰다. 

```
async update(workbook: Workbook) {
    return await this.repository.update({ id: workbook.id }, workbook);
  }
```

- 리포지토리 영역에서 수정처리를 진행시켜주었다. 
- update쿼리를 사용하는 이유는 이전에 select를 통한 검증을 하는 데에 있다. 
- 기본적으로 save쿼리는, 이미 존재하는지 확인하고, 데이터가 있다면 수정을, 없다면 추가를 한다.
- 이미 있는지 조회를 했기 때문에, update로 수정시키게 했다.
<img width="467" alt="스크린샷 2023-11-29 10 21 17" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/00180679-ce1e-475c-b61b-0dd8c33bfde4">


# Result

```
async updateWorkbook(
    updateWorkbookRequest: UpdateWorkbookRequest,
    member: Member,
  ) {
    const category = await this.categoryRepository.findByCategoryId(
      updateWorkbookRequest.categoryId,
    );
    validateManipulatedToken(member);
    validateCategory(category);

    const workbook = await this.workbookRepository.findById(
      updateWorkbookRequest.workbookId,
    );

    validateWorkbook(workbook);
    validateWorkbookOwner(workbook, member);

    workbook.updateInfo(updateWorkbookRequest, category);
    await this.workbookRepository.update(workbook);
    return WorkbookResponse.of(workbook);
  }
```

<img width="676" alt="스크린샷 2023-11-29 10 23 09" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/911b366d-993d-448d-981c-6aee60fdd28f">
<img width="799" alt="스크린샷 2023-11-29 10 23 16" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/8d45e9e1-61b8-4d56-93bd-02de029b9cdf">
<img width="810" alt="스크린샷 2023-11-29 10 23 47" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/45f853cb-a820-4bd5-83e3-d8ff0619f0cf">
<img width="545" alt="스크린샷 2023-11-29 10 23 40" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/b0d215ab-67e7-4e0c-9f65-de60b2a3b0a7">


# Prize

- update를 통해 우리가 마구잡이로 사용하는 ORM은 불필요한 쿼리를 발생시킬 수 있다는 점을 배웠다. 
- 이를 최적화 하기 위한 시도를 다시 해봐야겠다는 생각이 들었다.

[NDD-284]: https://milk717.atlassian.net/browse/NDD-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ