### PR TITLE
 [NDD-290]: Video Service 통합 테스트 (3h / 3h)

### DIFF
--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -592,7 +592,7 @@ describe('VideoController 단위 테스트', () => {
   });
 });
 
-describe('VideoController 통합테스트', () => {
+describe('VideoController 통합 테스트', () => {
   let app: INestApplication;
   let authService: AuthService;
   let categoryRepository: CategoryRepository;
@@ -1003,6 +1003,9 @@ describe('VideoController 통합테스트', () => {
   afterEach(async () => {
     await questionRepository.query('delete from token');
     await questionRepository.query('delete from Member');
+    await questionRepository.query('delete from Category');
+    await questionRepository.query('delete from Workbook');
+    await questionRepository.query('delete from Question');
     await questionRepository.query('delete from Video');
     await questionRepository.query('DELETE FROM sqlite_sequence'); // Auto Increment 초기화
   });

--- a/BE/src/video/service/video.service.spec.ts
+++ b/BE/src/video/service/video.service.spec.ts
@@ -963,10 +963,58 @@ describe('VideoService 통합 테스트', () => {
   });
 
   describe('deleteVideo', () => {
-    // 성공 시 undefined
-    // manipulated
-    // 비디오 없음
-    // 소유권 없음
+    it('비디오 삭제에 성공하면 undefined를 반환한다.', async () => {
+      // given
+      const member = memberFixture;
+      const video = await videoRepository.save(videoFixture);
+
+      // when
+
+      // then
+      await expect(
+        videoService.deleteVideo(video.id, member),
+      ).resolves.toBeUndefined();
+    });
+
+    it('비디오 삭제 시 member가 없으면 ManipulatedTokenNotFiltered를 반환한다.', async () => {
+      // given
+      const member = null;
+      const video = await videoRepository.save(videoFixture);
+
+      // when
+
+      // then
+      expect(videoService.deleteVideo(video.id, member)).rejects.toThrow(
+        ManipulatedTokenNotFiltered,
+      );
+    });
+
+    it('비디오 삭제 시 존재하지 않는 비디오를 삭제하려 하면 VideoNotFoundException을 반환한다.', async () => {
+      // given
+      const member = memberFixture;
+      const video = await videoRepository.save(videoFixture);
+
+      // when
+
+      // then
+      expect(videoService.deleteVideo(video.id + 1000, member)).rejects.toThrow(
+        VideoNotFoundException,
+      );
+    });
+
+    it('비디오 삭제 시 다른 사람의 비디오를 삭제하려 하면 VideoAccessForbiddenException을 반환한다.', async () => {
+      // given
+      const member = memberFixture;
+      await memberRepository.save(otherMemberFixture);
+      const video = await videoRepository.save(videoOfOtherFixture);
+
+      // when
+
+      // then
+      expect(videoService.deleteVideo(video.id, member)).rejects.toThrow(
+        VideoAccessForbiddenException,
+      );
+    });
   });
 
   afterEach(async () => {

--- a/BE/src/video/service/video.service.spec.ts
+++ b/BE/src/video/service/video.service.spec.ts
@@ -146,6 +146,7 @@ describe('VideoService 단위 테스트', () => {
       expect(response.key.includes(content)).toBeTruthy(); // 파일명엔 반드시 문제의 제목이 포함되어 있어야 함
       expect(response.key.endsWith('.webm')).toBeTruthy(); // 파일 확장자는 반드시 webm이어야 함
       expect(response.preSignedUrl.startsWith('https://videos')).toBeTruthy(); // 실제 Pre-Signed Url 구조를 따라가는지 확인하기 위함
+      (videoService as any).getQuestionContent.mockRestore();
     });
 
     it('prSigned URL 얻기 성공 시 member가 없으면 ManipulatedTokenNotFiltered을 반환한다.', () => {
@@ -657,13 +658,42 @@ describe('VideoService 통합 테스트', () => {
   describe('createVideo', () => {
     it('새로운 비디오 저장에 성공하면 undefined를 반환한다.', async () => {
       //given
+      const member = memberFixture;
 
       //when
 
       //then
       await expect(
-        videoService.createVideo(memberFixture, createVideoRequestFixture),
+        videoService.createVideo(member, createVideoRequestFixture),
       ).resolves.toBeUndefined();
+    });
+
+    it('새로운 비디오 저장 시 member가 없으면 ManipulatedTokenNotFiltered를 반환한다.', async () => {
+      //given
+      const member = null;
+
+      //when
+
+      //then
+      expect(
+        videoService.createVideo(member, createVideoRequestFixture),
+      ).rejects.toThrow(ManipulatedTokenNotFiltered);
+    });
+  });
+
+  describe('getPreSignedUrl', () => {
+    it('preSigned URL 얻기 성공 시 PreSignedUrlResponse 형식으로 반환된다.', async () => {
+      //given
+      const member = memberFixture;
+
+      //when
+      const result = await videoService.getPreSignedUrl(
+        member,
+        createPreSignedUrlRequestFixture,
+      );
+
+      //then
+      expect(result).toBeInstanceOf(PreSignedUrlResponse);
     });
 
     it('새로운 비디오 저장 시 member가 없으면 ManipulatedTokenNotFiltered를 반환한다.', async () => {
@@ -674,7 +704,10 @@ describe('VideoService 통합 테스트', () => {
 
       //then
       expect(
-        videoService.createVideo(memberFixture, createVideoRequestFixture),
+        videoService.getPreSignedUrl(
+          memberFixture,
+          createPreSignedUrlRequestFixture,
+        ),
       ).rejects.toThrow(ManipulatedTokenNotFiltered);
     });
   });

--- a/BE/src/video/service/video.service.spec.ts
+++ b/BE/src/video/service/video.service.spec.ts
@@ -849,6 +849,53 @@ describe('VideoService 통합 테스트', () => {
     });
   });
 
+  describe('getAllVideosByMemberId', () => {
+    it('비디오 세부 정보 조회 성공 시 SingleVideoResponse의 배열 형식으로 반환된다.', async () => {
+      //given
+      const member = memberFixture;
+      const video = await videoRepository.save(videoFixture);
+
+      //when
+      const result = await videoService.getAllVideosByMemberId(member);
+
+      //then
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(SingleVideoResponse);
+      expect(result[0].thumbnail).toBe(video.thumbnail);
+      expect(result[0].videoName).toBe(video.name);
+      expect(result[0].videoLength).toBe(video.videoLength);
+      expect(result[0].isPublic).toBe(video.isPublic);
+    });
+
+    it('비디오 세부 정보 조회 성공 시 비디오가 없다면 빈 배열을 반환한다.', async () => {
+      //given
+      const member = memberFixture;
+
+      //when
+      const result = await videoService.getAllVideosByMemberId(member);
+
+      //then
+      expect(result).toEqual([]);
+    });
+
+    it('비디오 전체 조회 시 member가 없으면 ManipulatedTokenNotFiltered를 반환한다.', async () => {
+      //given
+      const member = null;
+      await videoRepository.save(videoFixture);
+
+      //when
+
+      //then
+      expect(videoService.getAllVideosByMemberId(member)).rejects.toThrow(
+        ManipulatedTokenNotFiltered,
+      );
+    });
+  });
+
+  describe('toggleVideoStatus', () => {});
+
+  describe('deleteVideo', () => {});
+
   afterEach(async () => {
     await questionRepository.query('delete from Member');
     await questionRepository.query('delete from Category');


### PR DESCRIPTION
[![NDD-290](https://badgen.net/badge/JIRA/NDD-290/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-290) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
Video Service 계층에 대한 통합 테스트를 진행하기 위함

최근 3일 간 테스트 코드만 작성했기에 빠른 속도로 작성할 수 있을 줄 알았으나, 사소한 에러를 놓쳐 예상했던 시간과 동일하게 마치고 말았다.
```javascript
it('preSigned URL 얻기 시 IDrive Client가 Pre-Signed URL 발급에 실패하면 IDriveException을 반환한다.', async () => {
  // given
  const member = memberFixture;

  // when
  const getSignedUrlMock = jest.fn();
  (S3.prototype.getSignedUrlPromise as jest.Mock) = getSignedUrlMock;
  getSignedUrlMock.mockRejectedValue(new IDriveException());

  // then
  await expect(
    videoService.getPreSignedUrl(member, request),
  ).rejects.toThrow(IDriveException);

  getSignedUrlMock.mockRestore(); // 이것이 없어서 다른 테스트에서 에러가 발생
});
```
위 코드는 이전 Service 단위 테스트를 진행할 때 모킹을 진행한 IDrive 관련 메서드이다. 모킹을 하고 사용을 마치면 모킹한 내역을 mockRestore()로 초기화를 했었어야 하는데, 이를 놓치고 있다가 Service 통합 테스트를 진행할 때 지속적으로 IDriveException이 발생해서 이를 해결하기 위해 문제가 없는 다른 코드들을 확인하는 바람에 시간을 오래 사용하였다.  

# How
각 API 별로 Video Service의 메서드를 호출할 때 발생할 수 있는 상황에 대한 모든 경우들을 테스트

POST - 비디오를 저장하는 API, 비디오를 저장하기 위한 Pre-Signed URL을 발급받는 API
GET - 비디오 전체 조회, 비디오 상세 정보 조회, 비디오 해시값으로 조회
PATCH - 비디오 상태를 토글하는 API
DELETE - 비디오를 삭제하는 API

우선 위의 4가지 메서드의 7개의 API에 대한 Service 계층의 통합 테스트를 진행하였다.
각 Service의 메서드 별로 올바른 응답, 또 다른 응답(비디오 정보 토글 시 hash가 null로 갈 때 등), 오류 상황(권한이 없는 리소스에 대한 요청, 존재하지 않는 리소스에 대한 요청 등) 같은 최대한 다양한 경우를 테스트하고자 노력하였다.

각 API별 세부 사항(에러 처리, 상황 별 응답의 차이)들은 아래 Result의 사진에서 확인할 수 있다.

# Result
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/3b80d23f-5df4-4bb5-8fec-5137a0c42568)

# Prize
테스트를 통해 Video Service가 요청 상태에 맞게 알맞은 응답을 하는지 확인할 수 있다.
또한 Video API의 전체적인 테스트를 완료하여, Video API가 예상되는 모든 상황에서 의도대로 작동함을 확인할 수 있다.

[NDD-290]: https://milk717.atlassian.net/browse/NDD-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ