### PR TITLE
[NDD-274] 문제집에 새로운 문제를 추가하는 InterviewSetQuestionList 컴포넌트 구현(1.5h/3h)

### DIFF
--- a/FE/src/apis/question.ts
+++ b/FE/src/apis/question.ts
@@ -15,17 +15,17 @@ export const getQuestion = async (id: number) => {
 };
 
 export const postQuestion = async ({
-  categoryId,
+  workbookId,
   content,
 }: {
-  categoryId: number;
+  workbookId: number;
   content: string;
 }) => {
   return await getAPIResponseData({
     method: 'post',
     url: API.QUESTION,
     data: {
-      categoryId: categoryId,
+      workbookId: workbookId,
       content: content,
     },
   });

--- a/FE/src/apis/question.ts
+++ b/FE/src/apis/question.ts
@@ -6,11 +6,10 @@ import {
 } from '@/types/question';
 import getAPIResponseData from '@/utils/getAPIResponseData';
 
-export const getQuestion = async (id: number) => {
+export const getQuestion = async (workbookId: number) => {
   return await getAPIResponseData<Question[]>({
     method: 'get',
-    url: API.QUESTION,
-    params: { category: id },
+    url: API.QUESTION_ID(workbookId),
   });
 };
 

--- a/FE/src/components/InterviewSetEditPage/InterviewSetQuestionList.tsx
+++ b/FE/src/components/InterviewSetEditPage/InterviewSetQuestionList.tsx
@@ -1,0 +1,66 @@
+import { css } from '@emotion/react';
+import { theme } from '@styles/theme';
+import QuestionAccordion from '@common/QuestionAccordion/QuestionAccordion';
+import AnswerSelectionModal from '@common/QuestionSelectionBox/AnswerSelectionModal/AnswerSelectionModal';
+import { QuestionAnswerSelectionModal } from '@atoms/modal';
+import { useRecoilState } from 'recoil';
+import QuestionAddForm from '@common/QuestionSelectionBox/QuestionAddForm';
+import useQuestionWorkbookQuery from '@hooks/apis/queries/useQuestionWorkbookQuery';
+
+type InterviewSetQuestionListProps = {
+  workbookId: number;
+};
+const InterviewSetQuestionList: React.FC<InterviewSetQuestionListProps> = ({
+  workbookId,
+}) => {
+  const { data: workbookQuestionList } = useQuestionWorkbookQuery({
+    workbookId,
+    enabled: true,
+  });
+  const [{ isOpen, question: selectedQuestion }, setModalState] =
+    useRecoilState(QuestionAnswerSelectionModal);
+
+  if (!workbookQuestionList) return null;
+
+  return (
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        row-gap: 1rem;
+        padding: 1rem;
+        background-color: ${theme.colors.surface.inner};
+      `}
+    >
+      <QuestionAddForm workbookId={workbookId} />
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+        `}
+      >
+        <AnswerSelectionModal
+          isOpen={isOpen}
+          workbookId={workbookId}
+          question={selectedQuestion ?? workbookQuestionList[0]}
+          closeModal={() =>
+            setModalState((pre) => ({
+              ...pre,
+              isOpen: false,
+            }))
+          }
+        />
+        {workbookQuestionList?.map((question) => (
+          <QuestionAccordion
+            key={question?.questionId}
+            question={question}
+            workbookId={workbookId}
+            isSelected={true}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default InterviewSetQuestionList;

--- a/FE/src/components/common/QuestionAccordion/QuestionAccordion.tsx
+++ b/FE/src/components/common/QuestionAccordion/QuestionAccordion.tsx
@@ -19,7 +19,7 @@ type QuestionAccordionProps = {
   question: Question;
   workbookId: number;
   isSelected: boolean;
-  toggleSelected: () => void;
+  toggleSelected?: () => void;
 };
 
 const selectedStyle = css`
@@ -54,7 +54,7 @@ const QuestionAccordion: React.FC<QuestionAccordionProps> = ({
 
   return (
     <Accordion
-      onChange={toggleSelected}
+      onChange={() => toggleSelected?.()}
       expanded={isSelected}
       css={css`
         margin-bottom: 1.2rem;

--- a/FE/src/components/common/QuestionSelectionBox/QuestionAddForm.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionAddForm.tsx
@@ -1,7 +1,7 @@
 import useInput from '@hooks/useInput';
 import useQuestionAdd from '@hooks/useQuestionAdd';
 import { css } from '@emotion/react';
-import { Button, InputArea } from '@foundation/index';
+import { Button, Input } from '@foundation/index';
 
 type QuestionAddFormProps = {
   workbookId: number;
@@ -15,7 +15,7 @@ const QuestionAddForm: React.FC<QuestionAddFormProps> = ({ workbookId }) => {
   });
 
   const { value, onChange, clearInput, isEmpty } =
-    useInput<HTMLTextAreaElement>('');
+    useInput<HTMLInputElement>('');
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -30,15 +30,13 @@ const QuestionAddForm: React.FC<QuestionAddFormProps> = ({ workbookId }) => {
   return (
     <form
       css={css`
-        padding: 1rem;
         display: flex;
         align-items: center;
-        gap: 0.3rem;
+        gap: 0.5rem;
       `}
       onSubmit={onSubmit}
     >
-      <InputArea
-        rows={1}
+      <Input
         css={css`
           padding: 0.5rem;
         `}

--- a/FE/src/components/common/QuestionSelectionBox/QuestionAddForm.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionAddForm.tsx
@@ -1,20 +1,14 @@
 import useInput from '@hooks/useInput';
-import useQuestionAddMutation from '@hooks/useQuestionAdd';
+import useQuestionAdd from '@hooks/useQuestionAdd';
 import { css } from '@emotion/react';
 import { Button, InputArea } from '@foundation/index';
 
 type QuestionAddFormProps = {
-  categoryId: number;
+  workbookId: number;
 };
 
-/**
- * @deprecated
- * 현재 사용하지 않는 컴포넌트 입니다.
- * 나만의 질문에서 사용했던 질문을 바로 추가하는 컴포넌트로 사용하고 있습니다.
- *
- */
-const QuestionAddForm: React.FC<QuestionAddFormProps> = ({ categoryId }) => {
-  const { addQuestion } = useQuestionAddMutation(categoryId, {
+const QuestionAddForm: React.FC<QuestionAddFormProps> = ({ workbookId }) => {
+  const { addQuestion } = useQuestionAdd(workbookId, {
     onSuccess: () => {
       clearInput();
     },
@@ -28,7 +22,7 @@ const QuestionAddForm: React.FC<QuestionAddFormProps> = ({ categoryId }) => {
 
     if (isEmpty()) return;
     addQuestion({
-      categoryId,
+      workbookId,
       value,
     });
   };

--- a/FE/src/components/common/QuestionSelectionBox/QuestionTabPanelItem.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionTabPanelItem.tsx
@@ -3,7 +3,7 @@ import { theme } from '@styles/theme';
 import { css } from '@emotion/react';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import useQuestionCategoryQuery from '@/hooks/apis/queries/useQuestionCategoryQuery';
+import useQuestionWorkbookQuery from '@hooks/apis/queries/useQuestionWorkbookQuery';
 import { Typography, Toggle, Tabs } from '@foundation/index';
 import { WorkbookTitleListResDto } from '@/types/workbook';
 import { ExcludeArray } from '@/types/utils';
@@ -31,8 +31,8 @@ const TabPanelItem: React.FC<TabPanelItemProps> = ({
     setOnlySelectedOption((prev) => !prev);
   };
 
-  const { data: questionAPIData } = useQuestionCategoryQuery({
-    categoryId: workbook.workbookId,
+  const { data: questionAPIData } = useQuestionWorkbookQuery({
+    workbookId: workbook.workbookId,
     enabled: selectedTabIndex === tabIndex,
   });
 

--- a/FE/src/hooks/apis/mutations/useQuestionMutation.ts
+++ b/FE/src/hooks/apis/mutations/useQuestionMutation.ts
@@ -7,14 +7,14 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
  *
  * 문제집에 새로운 질문을 등록하기 위한 api입니다.
  */
-const useQuestionMutation = (categoryId: number) => {
+const useQuestionMutation = (workbookId: number) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: postQuestion,
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: QUERY_KEY.QUESTION_CATEGORY(categoryId),
+        queryKey: QUERY_KEY.QUESTION_CATEGORY(workbookId),
       });
     },
   });

--- a/FE/src/hooks/apis/queries/useQuestionWorkbookQuery.ts
+++ b/FE/src/hooks/apis/queries/useQuestionWorkbookQuery.ts
@@ -9,18 +9,18 @@ import { useQuery } from '@tanstack/react-query';
  *
  * QuestionSelectionBox, 문제집 상세보기 페이지 등에서 사용됩니다.
  */
-const useQuestionCategoryQuery = ({
-  categoryId,
+const useQuestionWorkbookQuery = ({
+  workbookId,
   enabled,
 }: {
-  categoryId: number;
+  workbookId: number;
   enabled: boolean;
 }) => {
   return useQuery({
-    queryKey: QUERY_KEY.QUESTION_CATEGORY(categoryId),
-    queryFn: () => getQuestion(categoryId),
+    queryKey: QUERY_KEY.QUESTION_CATEGORY(workbookId),
+    queryFn: () => getQuestion(workbookId),
     enabled,
   });
 };
 
-export default useQuestionCategoryQuery;
+export default useQuestionWorkbookQuery;

--- a/FE/src/hooks/useQuestionAdd.ts
+++ b/FE/src/hooks/useQuestionAdd.ts
@@ -4,14 +4,14 @@ import useUserInfo from './useUserInfo';
 import { Question } from '@/types/question';
 import { QUERY_KEY } from '@/constants/queryKey';
 
-const useQuestionAddMutation = (
-  categoryId: number,
+const useQuestionAdd = (
+  workbookId: number,
   { onSuccess }: { onSuccess?: () => void }
 ) => {
   const userInfo = useUserInfo();
   const queryClient = useQueryClient();
 
-  const { mutate } = useQuestionMutation(categoryId);
+  const { mutate } = useQuestionMutation(workbookId);
 
   const createNewQuestion = (content: string, lastId: number = 1) => {
     return {
@@ -24,21 +24,21 @@ const useQuestionAddMutation = (
 
   const addQuestion = ({
     value,
-    categoryId,
+    workbookId,
   }: {
     value: string;
-    categoryId: number;
+    workbookId: number;
   }) => {
     if (userInfo) {
       mutate(
-        { content: value, categoryId: categoryId },
+        { content: value, workbookId: workbookId },
         {
           onSuccess: () => onSuccess && onSuccess(),
         }
       );
     } else {
       queryClient.setQueryData<Question[] | []>(
-        QUERY_KEY.QUESTION_CATEGORY(categoryId),
+        QUERY_KEY.QUESTION_CATEGORY(workbookId),
         (prev) => {
           if (prev?.length === 0 || !prev) return [createNewQuestion(value)];
           return [createNewQuestion(value, prev[0].questionId), ...prev];
@@ -50,4 +50,4 @@ const useQuestionAddMutation = (
   return { addQuestion };
 };
 
-export default useQuestionAddMutation;
+export default useQuestionAdd;

--- a/FE/src/mocks/handlers/question.ts
+++ b/FE/src/mocks/handlers/question.ts
@@ -5,11 +5,7 @@ const questionHandlers = [
   http.post(API.QUESTION, () => {
     return HttpResponse.json({}, { status: 201 });
   }),
-  http.get(API.QUESTION, ({ request }) => {
-    const url = new URL(request.url);
-    const category = url.searchParams.get('category');
-
-    console.log(category);
+  http.get(API.QUESTION_ID(), ({ request }) => {
     return HttpResponse.json([
       {
         questionId: 1,


### PR DESCRIPTION
[![NDD-274](https://badgen.net/badge/JIRA/NDD-274/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-274) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

div태그 두개를 제외하고는 모두 해민님이 만들어두신 컴포넌트를 사용할 수 있어서 생각보다 빠르게 끝났습니다.

# How
## category -> workbook으로 모두 변경
QuestionAddForm 컴포넌트는 기획이 변경되면서 더이상 사용되지 않을 컴포넌트라 이전 api 명세를 따르고 있었습니다.
이 컴포넌트를 제 작업 부분에서 사용하게 되면서 category라는 단어를 모두 workbook으로 변경했습니다.
추가로 현재 사용되고 있는 부분에서도 아직 이름이 변경되지 않은 곳이 있어서 변경했습니다.

## QuestionAccordion props 타입 변경
QuestionAccordion의 toggleSelected props의 타입을 옵셔널로 변경했습니다.
왜냐하면 문제집을 수정하는 모달에서는 아코디언이 항상 펼쳐진 상태로 유지되어야 하기 때문입니다.

## InterviewSetQuestionList 에서 문제집에 질문 추가 구현 완료
MSW를 사용해서 해당 기능을 구현하고 테스트했습니다.
구현하면서 들었던 생각인데 질문을 추가하는 부분은 QuestionAddForm를 사용하고, 이 컴포넌트의 내부 동작을 보면 로그인 여부에 따라 state혹은 서버에 새로운 질문을 추가해주고 있습니다. 따라서 InterviewSetQuestionList 컴포넌트의 질문 리스트 부분만 잘 수정한다면 이전 비회원 유저에게 제공하던 나만의 질문 기능을 재생목록으로써 제공할 수 있을 것 같습니다.
아직 기획이 정해지지 않은 부분이라 일단 회원 유저만 고려해서 만들었습니다.


# Result

https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/54f2e53d-4a14-4dfd-b8ac-cb6a0cf77dbe

[NDD-274]: https://milk717.atlassian.net/browse/NDD-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ