### PR TITLE
[NDD-292] react-query 훅에 JSDocs 설명 추가 (0.5h / 1h)

### DIFF
--- a/FE/src/hooks/apis/mutations/useAddVideoMutation.ts
+++ b/FE/src/hooks/apis/mutations/useAddVideoMutation.ts
@@ -2,6 +2,11 @@ import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postVideo } from '@/apis/video';
 
+/**
+ * POST /video
+ *
+ * 새로운 비디오를 등록할 때 사용하는 api입니다.
+ */
 const useAddVideoMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({

--- a/FE/src/hooks/apis/mutations/useAnswerDefaultMutation.ts
+++ b/FE/src/hooks/apis/mutations/useAnswerDefaultMutation.ts
@@ -2,6 +2,11 @@ import { postDefaultAnswer } from '@/apis/answer';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+/**
+ * POST /answer/default
+ *
+ * 디폴트 답안 스크립트 등록을 위한 api입니다.
+ */
 const useAnswerDefaultMutation = (categoryId: number) => {
   const queryClient = useQueryClient();
 

--- a/FE/src/hooks/apis/mutations/useDeleteVideoMutation.ts
+++ b/FE/src/hooks/apis/mutations/useDeleteVideoMutation.ts
@@ -2,6 +2,11 @@ import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteVideoById } from '@/apis/video';
 
+/**
+ * DELETE /video/${videoId}
+ *
+ * videoId에 해당하는 비디오 정보를 서버에서 지우기 위한 api입니다.
+ */
 const useDeleteVideoMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({

--- a/FE/src/hooks/apis/mutations/useGetPreSignedUrlMutation.ts
+++ b/FE/src/hooks/apis/mutations/useGetPreSignedUrlMutation.ts
@@ -2,6 +2,11 @@ import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postPreSignedUrl } from '@/apis/video';
 
+/**
+ * POST /video/pre-signed
+ *
+ * 면접 비디오 등록용 pre-signed URL을 발급받기 위한 api입니다.
+ */
 const useGetPreSignedUrlMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({

--- a/FE/src/hooks/apis/mutations/useQuestionAnswerMutation.ts
+++ b/FE/src/hooks/apis/mutations/useQuestionAnswerMutation.ts
@@ -2,6 +2,11 @@ import { postAnswer } from '@/apis/answer';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+/**
+ * POST /answer
+ *
+ * 질문에 대한 답안 스크립트 등록을 위한 api입니다.
+ */
 const useQuestionAnswerMutation = (questionId: number) => {
   const queryClient = useQueryClient();
 

--- a/FE/src/hooks/apis/mutations/useQuestionCopyMutation.ts
+++ b/FE/src/hooks/apis/mutations/useQuestionCopyMutation.ts
@@ -1,6 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 import { postQuestionCopy } from '@/apis/question';
 
+/**
+ * POST question/copy
+ *
+ * 다른사람의 문제집에서 질문을 가져올 때 질문을 복제하기 위한 api입니다.
+ */
 const useQuestionCopyMutation = () => {
   return useMutation({
     mutationFn: postQuestionCopy,

--- a/FE/src/hooks/apis/mutations/useQuestionMutation.ts
+++ b/FE/src/hooks/apis/mutations/useQuestionMutation.ts
@@ -2,6 +2,11 @@ import { postQuestion } from '@/apis/question';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+/**
+ * POST /question
+ *
+ * 문제집에 새로운 질문을 등록하기 위한 api입니다.
+ */
 const useQuestionMutation = (categoryId: number) => {
   const queryClient = useQueryClient();
 

--- a/FE/src/hooks/apis/mutations/useToggleVideoPublicMutation.ts
+++ b/FE/src/hooks/apis/mutations/useToggleVideoPublicMutation.ts
@@ -2,6 +2,11 @@ import { QUERY_KEY } from '@/constants/queryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { patchVideoPublic } from '@/apis/video';
 
+/**
+ * PATCH /video/${videoId}
+ *
+ * 비디오 공개, 비공개를 토글하기 위한 api입니다.
+ */
 const useToggleVideoPublicMutation = (videoId: number) => {
   const queryClient = useQueryClient();
   return useMutation({

--- a/FE/src/hooks/apis/mutations/useWorkbookDeleteMutation.ts
+++ b/FE/src/hooks/apis/mutations/useWorkbookDeleteMutation.ts
@@ -1,6 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 import { deleteWorkbookById } from '@/apis/workbook';
 
+/**
+ * DELETE /workbook/${workbookId}
+ *
+ * workbookId에 해당하는 문제집을 삭제하기 위한 api입니다.
+ */
 const useWorkbookDeleteMutation = () => {
   return useMutation({
     mutationFn: deleteWorkbookById,

--- a/FE/src/hooks/apis/mutations/useWorkbookPatchMutation.ts
+++ b/FE/src/hooks/apis/mutations/useWorkbookPatchMutation.ts
@@ -2,6 +2,11 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { patchWorkbookById } from '@/apis/workbook';
 import { WorkbookPatchReqDto } from '@/types/workbook';
 
+/**
+ * PATCH /workbook/${workbookId}
+ *
+ * workbookId에 해당하는 문제집의 메타정보(title, category, content)를 수정하기 위한 api입니다.
+ */
 const useWorkbookPatchMutation = (
   options?: UseMutationOptions<
     null,

--- a/FE/src/hooks/apis/mutations/useWorkbookPostMutation.ts
+++ b/FE/src/hooks/apis/mutations/useWorkbookPostMutation.ts
@@ -1,6 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 import { postWorkbook } from '@/apis/workbook';
 
+/**
+ * POST /workbook
+ *
+ * 새로운 문제집을 추가하기 위한 api입니다.
+ */
 const useWorkbookPostMutation = () => {
   return useMutation({
     mutationFn: postWorkbook,

--- a/FE/src/hooks/apis/queries/useCategoryQuery.ts
+++ b/FE/src/hooks/apis/queries/useCategoryQuery.ts
@@ -2,6 +2,13 @@ import { getCategory } from '@/apis/category';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useQuery } from '@tanstack/react-query';
 
+/**
+ * GET /category
+ *
+ * 문제집의 모든 카테고리 리스트를 조회하는 api입니다.
+ *
+ * ex) FE, BE, CS, Android
+ */
 const useCategoryQuery = () => {
   return useQuery({
     queryKey: QUERY_KEY.CATEGORY,

--- a/FE/src/hooks/apis/queries/useMemberNameQuery.ts
+++ b/FE/src/hooks/apis/queries/useMemberNameQuery.ts
@@ -2,6 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '@constants/queryKey';
 import { getMemberName } from '@/apis/member';
 
+/**
+ * GET /member/name
+ *
+ * 유저의 면접용 이름을 조회하는 api 입니다.
+ *
+ * ex) 토스에게 인수당한 NDD
+ */
 const useMemberNameQuery = () => {
   return useQuery({
     queryKey: QUERY_KEY.MEMBER_NICKNAME,

--- a/FE/src/hooks/apis/queries/useQuestionAnswerQuery.ts
+++ b/FE/src/hooks/apis/queries/useQuestionAnswerQuery.ts
@@ -2,6 +2,13 @@ import { getQuestionAnswer } from '@/apis/answer';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useQuery } from '@tanstack/react-query';
 
+/**
+ * GET /answer/${questionId}
+ *
+ * questionId로 해당 질문의 모든 답안 스크립트를 조회하는 api입니다.
+ *
+ * 답변을 수정하는 모달에서 사용됩니다.
+ */
 const useQuestionAnswerQuery = (questionId: number) => {
   return useQuery({
     queryKey: QUERY_KEY.QUESTION_ANSWER(questionId),

--- a/FE/src/hooks/apis/queries/useQuestionCategoryQuery.ts
+++ b/FE/src/hooks/apis/queries/useQuestionCategoryQuery.ts
@@ -2,6 +2,13 @@ import { getQuestion } from '@/apis/question';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useQuery } from '@tanstack/react-query';
 
+/**
+ * GET /question/${workbookId}
+ *
+ * workbookId로 해당 문제집의 질문과 디폴트 답안을 조회허는 api입니다.
+ *
+ * QuestionSelectionBox, 문제집 상세보기 페이지 등에서 사용됩니다.
+ */
 const useQuestionCategoryQuery = ({
   categoryId,
   enabled,

--- a/FE/src/hooks/apis/queries/useVideoHashQuery.ts
+++ b/FE/src/hooks/apis/queries/useVideoHashQuery.ts
@@ -2,6 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '@constants/queryKey';
 import { getVideoByHash } from '@/apis/video';
 
+/**
+ * GET /video/hash/${hash}
+ *
+ * 비디오 해시값으로 비디오 정보를 조회하는 api입니다.
+ *
+ * 공개된 비디오를 조회할 때 사용합니다.
+ */
 const useVideoHashQuery = (hash: string) => {
   return useQuery({
     queryKey: QUERY_KEY.VIDEO_HASH(hash),

--- a/FE/src/hooks/apis/queries/useVideoItemQuery.ts
+++ b/FE/src/hooks/apis/queries/useVideoItemQuery.ts
@@ -2,6 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '@constants/queryKey';
 import { getVideoById } from '@/apis/video';
 
+/**
+ * GET /video/${videoId}
+ *
+ * videoId로 비디오 정보를 조회하는 api 입니다.
+ *
+ * 비공개된 비디오를 조회할 때 사용합니다.
+ */
 const useVideoItemQuery = (videoId: number) => {
   return useQuery({
     queryKey: QUERY_KEY.VIDEO_ID(videoId),

--- a/FE/src/hooks/apis/queries/useVideoListQuery.ts
+++ b/FE/src/hooks/apis/queries/useVideoListQuery.ts
@@ -2,6 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '@constants/queryKey';
 import { getVideoList } from '@/apis/video';
 
+/**
+ * GET /video/all
+ *
+ * 자신이 촬영한 모든 비디오 목록을 조회하는 api입니다.
+ *
+ * 마이페이지에서 사용됩니다.
+ */
 const useVideoListQuery = () => {
   return useQuery({
     queryKey: QUERY_KEY.VIDEO,

--- a/FE/src/hooks/apis/queries/useWorkbookListQuery.ts
+++ b/FE/src/hooks/apis/queries/useWorkbookListQuery.ts
@@ -2,6 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '@constants/queryKey';
 import { getWorkbookByCategory } from '@/apis/workbook';
 
+/**
+ * GET /workbook?category=${categoryId}
+ *
+ * categoryId로 해당 카테고리의 모든 문제집을 조회하는 api입니다.
+ *
+ * 문제집 리스트 페이지에서 사용됩니다.
+ */
 const useWorkbookListQuery = (categoryId: number) => {
   return useQuery({
     queryKey: QUERY_KEY.WORKBOOK,

--- a/FE/src/hooks/apis/queries/useWorkbookQuery.ts
+++ b/FE/src/hooks/apis/queries/useWorkbookQuery.ts
@@ -2,6 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '@constants/queryKey';
 import { getWorkbookById } from '@/apis/workbook';
 
+/**
+ * GET /workbook/${workbookId}
+ *
+ * workbookId로 문제집을 단건 조회하는 api입니다.
+ *
+ * 문제집 상세보기, 문제집 수정 페이지 등에서 사용됩니다.
+ */
 const useWorkbookQuery = (workbookId: number) => {
   return useQuery({
     queryKey: QUERY_KEY.WORKBOOK_ID(workbookId),

--- a/FE/src/hooks/apis/queries/useWorkbookTitleListQuery.ts
+++ b/FE/src/hooks/apis/queries/useWorkbookTitleListQuery.ts
@@ -2,6 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import { QUERY_KEY } from '@constants/queryKey';
 import { getWorkbookTitle } from '@/apis/workbook';
 
+/**
+ * GET /workbook/title
+ *
+ * 나의 문제집 제목을 조회하는 api입니다.
+ *
+ * 비회원은 탑5 문제집이 조회되고, 회원은 나의 문제집이 조회됩니다.
+ */
 const useWorkbookTitleListQuery = () => {
   return useQuery({
     queryKey: QUERY_KEY.WORKBOOK,


### PR DESCRIPTION
[![NDD-292](https://badgen.net/badge/JIRA/NDD-292/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-292) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
api가 늘어나고 수정됨에 따라서 react-query의 훅 개수가 늘어남에 따라 api명세와 비교하며 개발하기가 어려워졌습니다.
따라서 생산성을 증가시키기 위해 각 훅에 JsDocs로 설명을 추가했습니다.

# How

- api 명세를 보고 JsDocs를 작성했습니다.

# Result

<img width="531" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/bdb196bb-f70b-4ac2-8bc6-ad6a77097489">

편-안

[NDD-292]: https://milk717.atlassian.net/browse/NDD-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ