### PR TITLE
[NDD-285]: 문제집 삭제 로직 구현 (1h / 1h)

### DIFF
--- a/BE/src/workbook/controller/workbook.controller.spec.ts
+++ b/BE/src/workbook/controller/workbook.controller.spec.ts
@@ -271,7 +271,7 @@ describe('WorkbookController 단위테스트', () => {
       ).rejects.toThrow(new WorkbookForbiddenException());
     });
 
-    it('없는 문제집을 삭제요청하ㅑ면 WorkbookNotFoundException처리한다', async () => {
+    it('없는 문제집을 삭제요청하면 WorkbookNotFoundException처리한다', async () => {
       //given
 
       //when
@@ -317,10 +317,13 @@ describe('WorkbookController 통합테스트', () => {
   });
 
   describe('문제집을 추가한다', () => {
-    it('토큰과 dto를 정상적으로 넣으면 201코드와 WorkbookIdResponse를 반환한다.', async () => {
-      //given
+    beforeEach(async () => {
       await memberRepository.save(memberFixture);
       await categoryRepository.save(categoryFixtureWithId);
+    });
+
+    it('토큰과 dto를 정상적으로 넣으면 201코드와 WorkbookIdResponse를 반환한다.', async () => {
+      //given
       const token = await authService.login(memberFixturesOAuthRequest);
 
       //when & then
@@ -334,8 +337,6 @@ describe('WorkbookController 통합테스트', () => {
 
     it('토큰이 없으면 401에러를 반환한다.', async () => {
       //given
-      await memberRepository.save(memberFixture);
-      await categoryRepository.save(categoryFixtureWithId);
 
       //when & then
       const agent = request.agent(app.getHttpServer());
@@ -347,8 +348,6 @@ describe('WorkbookController 통합테스트', () => {
 
     it('요청 dto의 title이 빈 문자열/null이면 400에러를 반환한다.', async () => {
       //given
-      await memberRepository.save(memberFixture);
-      await categoryRepository.save(categoryFixtureWithId);
       const token = await authService.login(memberFixturesOAuthRequest);
 
       //when & then
@@ -370,8 +369,6 @@ describe('WorkbookController 통합테스트', () => {
 
     it('요청 dto의 content가 빈 문자열/null이면 400에러를 반환한다.', async () => {
       //given
-      await memberRepository.save(memberFixture);
-      await categoryRepository.save(categoryFixtureWithId);
       const token = await authService.login(memberFixturesOAuthRequest);
 
       //when & then
@@ -413,8 +410,7 @@ describe('WorkbookController 통합테스트', () => {
   });
 
   describe('카테고리별 문제집을 조회한다', () => {
-    it('카테고리id를 입력해주지 않으면 전체를 조회한다.', async () => {
-      //given
+    beforeEach(async () => {
       const member = await memberRepository.save(memberFixture);
       for (const eachCategory of categoryListFixture) {
         const category = await categoryRepository.save(eachCategory);
@@ -427,6 +423,10 @@ describe('WorkbookController 통합테스트', () => {
           ),
         );
       }
+    });
+
+    it('카테고리id를 입력해주지 않으면 전체를 조회한다.', async () => {
+      //given
 
       //when & then
       const agent = request.agent(app.getHttpServer());
@@ -444,19 +444,6 @@ describe('WorkbookController 통합테스트', () => {
 
     it('특정 카테고리를 입력해주면 해당 카테고리의 문제집들을 조회한다.', async () => {
       //given
-      const member = await memberRepository.save(memberFixture);
-      for (const eachCategory of categoryListFixture) {
-        const category = await categoryRepository.save(eachCategory);
-        await workbookRepository.save(
-          Workbook.of(
-            `title_${category.name}`,
-            `content_${category.name}`,
-            category,
-            member,
-          ),
-        );
-      }
-
       //when & then
       const agent = request.agent(app.getHttpServer());
       await agent
@@ -470,18 +457,6 @@ describe('WorkbookController 통합테스트', () => {
 
     it('카테고리id가 존재하지 않는 값이라면 404에러를 반환한다.', async () => {
       //given
-      const member = await memberRepository.save(memberFixture);
-      for (const eachCategory of categoryListFixture) {
-        const category = await categoryRepository.save(eachCategory);
-        await workbookRepository.save(
-          Workbook.of(
-            `title_${category.name}`,
-            `content_${category.name}`,
-            category,
-            member,
-          ),
-        );
-      }
 
       //when & then
       const agent = request.agent(app.getHttpServer());
@@ -490,8 +465,7 @@ describe('WorkbookController 통합테스트', () => {
   });
 
   describe('회원의 문제집을 조회한다', () => {
-    it('쿠키가 있을 경우 회원의 문제집을 조회한다.', async () => {
-      //given
+    beforeEach(async () => {
       const member = await memberRepository.save(memberFixture);
       for (const eachCategory of categoryListFixture) {
         const category = await categoryRepository.save(eachCategory);
@@ -504,7 +478,6 @@ describe('WorkbookController 통합테스트', () => {
           ),
         );
       }
-
       const other = await memberRepository.save(differentMemberFixture);
       const category = await categoryRepository.findByCategoryId(1);
       await workbookRepository.save(
@@ -515,6 +488,10 @@ describe('WorkbookController 통합테스트', () => {
           other,
         ),
       );
+    });
+
+    it('쿠키가 있을 경우 회원의 문제집을 조회한다.', async () => {
+      //given
 
       //when & then
       const token = await authService.login(memberFixturesOAuthRequest);
@@ -584,6 +561,8 @@ describe('WorkbookController 통합테스트', () => {
   });
 
   describe('단건의 문제집을 조회한다', () => {
+    beforeEach(() => {});
+
     it('존재하는 경우 단건을 반환한다.', async () => {
       //given
       const other = await memberRepository.save(differentMemberFixture);
@@ -773,10 +752,13 @@ describe('WorkbookController 통합테스트', () => {
   });
 
   describe('문제집을 삭제한다', () => {
-    it('문제집을 성공적으로 삭제한다', async () => {
-      //given
+    beforeEach(async () => {
       await memberRepository.save(memberFixture);
       await categoryRepository.save(categoryFixtureWithId);
+    });
+
+    it('문제집을 성공적으로 삭제한다', async () => {
+      //given
       const workbook = await workbookRepository.save(workbookFixtureWithId);
 
       //when & then
@@ -790,8 +772,6 @@ describe('WorkbookController 통합테스트', () => {
 
     it('쿠키가 없으면 401에러를 반환한다', async () => {
       //given
-      await memberRepository.save(memberFixture);
-      await categoryRepository.save(categoryFixtureWithId);
       const workbook = await workbookRepository.save(workbookFixtureWithId);
 
       //when & then
@@ -801,8 +781,6 @@ describe('WorkbookController 통합테스트', () => {
 
     it('다른 사람의 문제집 삭제 요청을 하면 403에러를 반환한다', async () => {
       //given
-      await memberRepository.save(memberFixture);
-      await categoryRepository.save(categoryFixtureWithId);
       const workbook = await workbookRepository.save(workbookFixtureWithId);
 
       //when & then
@@ -816,8 +794,6 @@ describe('WorkbookController 통합테스트', () => {
 
     it('존재하지 않는 문제집을 삭제하려하면 404에러를 반환한다', async () => {
       //given
-      await memberRepository.save(memberFixture);
-      await categoryRepository.save(categoryFixtureWithId);
 
       //when & then
       const token = await authService.login(memberFixturesOAuthRequest);

--- a/BE/src/workbook/controller/workbook.controller.ts
+++ b/BE/src/workbook/controller/workbook.controller.ts
@@ -1,12 +1,14 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Patch,
   Post,
   Query,
   Req,
+  Res,
   UseGuards,
 } from '@nestjs/common';
 import { WorkbookService } from '../service/workbook.service';
@@ -19,7 +21,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { createApiResponseOption } from '../../util/swagger.util';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import { CreateWorkbookRequest } from '../dto/createWorkbookRequest';
 import { Member } from '../../member/entity/member';
 import { WorkbookIdResponse } from '../dto/workbookIdResponse';
@@ -115,5 +117,24 @@ export class WorkbookController {
       updateWorkbookRequest,
       req.user as Member,
     );
+  }
+
+  @Delete('/:workbookId')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth()
+  @ApiOperation({
+    summary: '문제집 수정',
+  })
+  @ApiResponse(createApiResponseOption(204, '문제집 수정 완료', null))
+  async deleteAnswer(
+    @Req() req: Request,
+    @Param('workbookId') workbookId: number,
+    @Res() res: Response,
+  ) {
+    await this.workbookService.deleteWorkbookById(
+      workbookId,
+      req.user as Member,
+    );
+    res.status(204).send();
   }
 }

--- a/BE/src/workbook/repository/workbook.repository.ts
+++ b/BE/src/workbook/repository/workbook.repository.ts
@@ -70,4 +70,8 @@ export class WorkbookRepository {
   async update(workbook: Workbook) {
     return await this.repository.update({ id: workbook.id }, workbook);
   }
+
+  async remove(workbook: Workbook) {
+    await this.repository.remove(workbook);
+  }
 }

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -628,6 +628,70 @@ describe('WorkbookService 통합테스트', () => {
     });
   });
 
+  describe('문제집 삭제', () => {
+    it('문제집 삭제를 성공한다.', async () => {
+      //given
+      await memberRepository.save(memberFixture);
+      await categoryRepository.save(categoryFixtureWithId);
+      await workbookRepository.save(workbookFixtureWithId);
+
+      //when
+
+      //then
+      await expect(
+        workbookService.deleteWorkbookById(
+          workbookFixtureWithId.id,
+          memberFixture,
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it('문제집 삭제시 회원이 없으면 Manipulated예외처리한다..', async () => {
+      //given
+      await memberRepository.save(memberFixture);
+      await categoryRepository.save(categoryFixtureWithId);
+      await workbookRepository.save(workbookFixtureWithId);
+
+      //when
+
+      //then
+      await expect(
+        workbookService.deleteWorkbookById(workbookFixtureWithId.id, null),
+      ).rejects.toThrow(new ManipulatedTokenNotFiltered());
+    });
+
+    it('다른 회원이 문제집 수정을 요청하면 WorkbookForbidden예외처리한다.', async () => {
+      //given
+      await memberRepository.save(memberFixture);
+      await categoryRepository.save(categoryFixtureWithId);
+      await workbookRepository.save(workbookFixtureWithId);
+
+      //when
+
+      //then
+      await expect(
+        workbookService.deleteWorkbookById(
+          workbookFixtureWithId.id,
+          otherMemberFixture,
+        ),
+      ).rejects.toThrow(new WorkbookForbiddenException());
+    });
+
+    it('존재하지 않는 문제집 삭제를 요청하면 WorkbookNotFoundExeption예외처리한다.', async () => {
+      //given
+      await memberRepository.save(memberFixture);
+      await categoryRepository.save(categoryFixtureWithId);
+      await workbookRepository.save(workbookFixtureWithId);
+
+      //when
+
+      //then
+      await expect(
+        workbookService.deleteWorkbookById(1244232, memberFixture),
+      ).rejects.toThrow(new WorkbookNotFoundException());
+    });
+  });
+
   afterEach(async () => {
     await workbookRepository.query('delete from Workbook');
     await workbookRepository.query('delete from Member');

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -52,6 +52,7 @@ describe('WorkbookService 단위테스트', () => {
     findMembersWorkbooks: jest.fn(),
     findSingleWorkbook: jest.fn(),
     update: jest.fn(),
+    remove: jest.fn(),
   };
 
   beforeAll(async () => {
@@ -272,6 +273,63 @@ describe('WorkbookService 단위테스트', () => {
           service.updateWorkbook(workbookUpdateRequest, cases[index]),
         ).rejects.toThrow(result[index]);
       }
+    });
+  });
+
+  describe('문제집 삭제', () => {
+    it('문제집을 성공적으로 삭제한다.', async () => {
+      //given
+
+      //when
+      mockWorkbookRepository.findById.mockResolvedValue(workbookFixtureWithId);
+      mockWorkbookRepository.remove.mockResolvedValue(undefined);
+
+      //then
+      await expect(
+        service.deleteWorkbookById(workbookFixtureWithId.id, memberFixture),
+      ).resolves.toBeUndefined();
+    });
+
+    it('회원이 null이면 ManipulatedToken예외처리한다.', async () => {
+      //given
+
+      //when
+      mockWorkbookRepository.findById.mockResolvedValue(workbookFixtureWithId);
+      mockWorkbookRepository.remove.mockResolvedValue(undefined);
+
+      //then
+      await expect(
+        service.deleteWorkbookById(workbookFixtureWithId.id, null),
+      ).rejects.toThrow(new ManipulatedTokenNotFiltered());
+    });
+
+    it('회원이 다른 사람이라면  WorkbookForbidden예외처리한다.', async () => {
+      //given
+
+      //when
+      mockWorkbookRepository.findById.mockResolvedValue(workbookFixtureWithId);
+      mockWorkbookRepository.remove.mockResolvedValue(undefined);
+
+      //then
+      await expect(
+        service.deleteWorkbookById(
+          workbookFixtureWithId.id,
+          otherMemberFixture,
+        ),
+      ).rejects.toThrow(new WorkbookForbiddenException());
+    });
+
+    it('문제집이 존재하지 않는다면 WorkbookNotFoundException예외처리한다.', async () => {
+      //given
+
+      //when
+      mockWorkbookRepository.findById.mockResolvedValue(null);
+      mockWorkbookRepository.remove.mockResolvedValue(undefined);
+
+      //then
+      await expect(
+        service.deleteWorkbookById(workbookFixtureWithId.id, memberFixture),
+      ).rejects.toThrow(new WorkbookNotFoundException());
     });
   });
 });

--- a/BE/src/workbook/service/workbook.service.ts
+++ b/BE/src/workbook/service/workbook.service.ts
@@ -102,4 +102,12 @@ export class WorkbookService {
     await this.workbookRepository.update(workbook);
     return WorkbookResponse.of(workbook);
   }
+
+  async deleteWorkbookById(workbookId: number, member: Member) {
+    validateManipulatedToken(member);
+    const workbook = await this.workbookRepository.findById(workbookId);
+    validateWorkbook(workbook);
+    validateWorkbookOwner(workbook, member);
+    await this.workbookRepository.remove(workbook);
+  }
 }


### PR DESCRIPTION
[![NDD-285](https://badgen.net/badge/JIRA/NDD-285/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-285) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- 문제집 삭제 로직을 구현한다. 
- 삭제시에 권한을 확인해야 한다
- 문제집 존재 여부를 검증해야 한다
- 내부의 문제는 onDelete: CASCADE로 자동삭제시킨다.

# How

```
async deleteWorkbookById(workbookId: number, member: Member) {
    validateManipulatedToken(member);
    const workbook = await this.workbookRepository.findById(workbookId);
    validateWorkbook(workbook);
    validateWorkbookOwner(workbook, member);
    await this.workbookRepository.remove(workbook);
  }
```
- 회원을 받아 조작된 토큰인지 검증하고, 문제집을 가져온다(이 때 문제집의 Member와 카테고리를 fetch해서 가져온다)
- 문제집의 소유자와 현재 회원이 같은지 검증한다.
- DB에서 문제집을 삭제한다

# Result
![스크린샷 2023-11-30 16 36 39](https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/7d0bd12b-2b3f-4e1f-8c5f-978bde7c9fc4)

- 비즈니스 로직 단위 테스트

![스크린샷 2023-11-30 16 36 58](https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/9bbe0c6d-f03f-408d-9900-d238bf9a0312)

- 비즈니스 로직 통합 테스트

![스크린샷 2023-11-30 16 37 26](https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/72c814c0-2964-4bd3-a47c-720db55f6983)

- 컨트롤러 로직 단위 테스트

![스크린샷 2023-11-30 16 37 43](https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/c7885975-8a13-407c-957a-a37d48887f58)

- 컨트롤러 로직 통합 테스트

[NDD-285]: https://milk717.atlassian.net/browse/NDD-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ