### PR TITLE
[NDD-270] 문제집 세부 정보페이지 개발하기 (4h/5h)

### DIFF
--- a/FE/src/AppRouter.tsx
+++ b/FE/src/AppRouter.tsx
@@ -12,6 +12,8 @@ import invalidPathLoader from '@routes/invalidPathLoader';
 import InterviewVideoPublicPage from '@page/interviewVideoPublicPage';
 import InterviewVideoPublicLoader from '@routes/interviewVideoPublicLoader';
 import rootLoader from '@routes/rootLoader';
+import InterviewWorkbookDetailPage from '@page/interviewWorkbookDetailPage';
+import interviewWorkbookDetailLoader from '@routes/interviewWorkbookDetailLoader';
 
 const AppRouter = ({ queryClient }: { queryClient: QueryClient }) => {
   const routes = createBrowserRouter([
@@ -49,6 +51,11 @@ const AppRouter = ({ queryClient }: { queryClient: QueryClient }) => {
               params: params,
               queryClient: queryClient,
             }),
+        },
+        {
+          path: PATH.INTERVIEW_WORKBOOK_DETAIL(),
+          element: <InterviewWorkbookDetailPage />,
+          loader: ({ params }) => interviewWorkbookDetailLoader(params),
         },
         {
           path: '*',

--- a/FE/src/apis/question.ts
+++ b/FE/src/apis/question.ts
@@ -13,6 +13,13 @@ export const getQuestion = async (workbookId: number) => {
   });
 };
 
+export const getQuestionById = async (id: number) => {
+  return await getAPIResponseData<Question[]>({
+    method: 'get',
+    url: API.QUESTION_ID(id),
+  });
+};
+
 export const postQuestion = async ({
   workbookId,
   content,

--- a/FE/src/apis/question.ts
+++ b/FE/src/apis/question.ts
@@ -13,13 +13,6 @@ export const getQuestion = async (workbookId: number) => {
   });
 };
 
-export const getQuestionById = async (id: number) => {
-  return await getAPIResponseData<Question[]>({
-    method: 'get',
-    url: API.QUESTION_ID(id),
-  });
-};
-
 export const postQuestion = async ({
   workbookId,
   content,

--- a/FE/src/components/common/QuestionAccordion/QuestionAccordion.tsx
+++ b/FE/src/components/common/QuestionAccordion/QuestionAccordion.tsx
@@ -19,6 +19,7 @@ type QuestionAccordionProps = {
   question: Question;
   workbookId: number;
   isSelected: boolean;
+  isEditable?: boolean;
   toggleSelected?: () => void;
 };
 
@@ -31,6 +32,7 @@ const QuestionAccordion: React.FC<QuestionAccordionProps> = ({
   question,
   workbookId,
   isSelected,
+  isEditable,
   toggleSelected,
 }) => {
   const queryClient = useQueryClient();
@@ -88,15 +90,17 @@ const QuestionAccordion: React.FC<QuestionAccordionProps> = ({
             {question.answerContent}
           </Typography>
         </LeadingDot>
-        <Icon
-          id="edit"
-          css={css`
-            flex-shrink: 0;
-          `}
-          width="2rem"
-          height="2rem"
-          onClick={userInfo ? handleEditModal : handleEditGuestUser}
-        />
+        {isEditable && (
+          <Icon
+            id="edit"
+            css={css`
+              flex-shrink: 0;
+            `}
+            width="2rem"
+            height="2rem"
+            onClick={userInfo ? handleEditModal : handleEditGuestUser}
+          />
+        )}
       </AccordionDetails>
     </Accordion>
   );

--- a/FE/src/components/interviewWorkbookDetailPage/AddWorkbookListModal.tsx
+++ b/FE/src/components/interviewWorkbookDetailPage/AddWorkbookListModal.tsx
@@ -73,9 +73,7 @@ const AddWorkbookListModal = ({
           <div
             css={css`
               width: 100%;
-              > * {
-                margin-bottom: 1rem;
-              }
+              gap: 1rem;
             `}
           >
             {workbookTitleData?.map((item) => (

--- a/FE/src/components/interviewWorkbookDetailPage/AddWorkbookListModal.tsx
+++ b/FE/src/components/interviewWorkbookDetailPage/AddWorkbookListModal.tsx
@@ -27,12 +27,14 @@ const AddWorkbookListModal = ({
 
   const handleCheckBox = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { checked, id } = e.target;
-    if (checked) {
-      setSelectedWorkbook((pre) => [...pre, id]);
-    } else {
-      setSelectedWorkbook((pre) => pre.filter((item) => item !== id));
-    }
+    checked ? selectWorkBook(id) : unSelectWorkBook(id);
   };
+
+  const selectWorkBook = (id: string) =>
+    setSelectedWorkbook((pre) => [...pre, id]);
+
+  const unSelectWorkBook = (id: string) =>
+    setSelectedWorkbook((pre) => pre.filter((item) => item !== id));
 
   const mutateAllQuestionCopy = async () => {
     await Promise.all(

--- a/FE/src/components/interviewWorkbookDetailPage/AddWorkbookListModal.tsx
+++ b/FE/src/components/interviewWorkbookDetailPage/AddWorkbookListModal.tsx
@@ -1,19 +1,25 @@
+import { WorkbookEntity } from '@/types/workbook';
 import { css } from '@emotion/react';
 import Modal from '@foundation/Modal';
-import { Button, CheckBox, Icon, Typography } from '@foundation/index';
+import { Button, CheckBox, Typography } from '@foundation/index';
 import useQuestionCopyMutation from '@hooks/apis/mutations/useQuestionCopyMutation';
 import useWorkbookTitleListQuery from '@hooks/apis/queries/useWorkbookTitleListQuery';
 import { useState } from 'react';
+import NewWorkbookListButton from './NewWorkbookListButton';
+import { useNavigate } from 'react-router-dom';
 
 const AddWorkbookListModal = ({
   isOpen,
   closeModal,
   selectedQuestionIds,
+  workbookData,
 }: {
   isOpen: boolean;
   closeModal: () => void;
   selectedQuestionIds: number[];
+  workbookData: WorkbookEntity;
 }) => {
+  const navigate = useNavigate();
   const { data: workbookTitleData } = useWorkbookTitleListQuery();
   const { mutateAsync } = useQuestionCopyMutation();
 
@@ -29,20 +35,15 @@ const AddWorkbookListModal = ({
   };
 
   const mutateAllQuestionCopy = async () => {
-    try {
-      await Promise.all(
-        selectedWorkbook.map((item) => {
-          const workbookId = parseInt(item);
-          return mutateAsync({
-            workbookId: workbookId,
-            questionIds: selectedQuestionIds,
-          });
-        })
-      );
-    } catch (error) {
-      console.error('문제집 복사 중 오류 발생', error);
-      throw error;
-    }
+    await Promise.all(
+      selectedWorkbook.map((item) => {
+        const workbookId = parseInt(item);
+        return mutateAsync({
+          workbookId: workbookId,
+          questionIds: selectedQuestionIds,
+        });
+      })
+    );
   };
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -51,7 +52,15 @@ const AddWorkbookListModal = ({
       alert('문제집을 선택해주세요.');
       return;
     }
-    void mutateAllQuestionCopy();
+
+    try {
+      void mutateAllQuestionCopy();
+      closeModal();
+      // TODO: 문제집 리스트가 있는 페이지로 이동해야함
+    } catch (error) {
+      console.error('문제집 복사 중 오류 발생', error);
+      throw error;
+    }
   };
 
   return (
@@ -82,7 +91,10 @@ const AddWorkbookListModal = ({
                 </Typography>
               </CheckBox>
             ))}
-            <NewWorkbookList />
+            <NewWorkbookListButton
+              selectedQuestionIds={selectedQuestionIds}
+              workbookData={workbookData}
+            />
           </div>
         </Modal.content>
         <Modal.footer>
@@ -111,32 +123,5 @@ const ModalHeader = () => {
     >
       <Typography variant="title4">문제집 추가</Typography>
     </div>
-  );
-};
-
-const NewWorkbookList = () => {
-  return (
-    <button
-      css={css`
-        display: flex;
-        align-items: center;
-        width: 100%;
-
-        outline: none;
-        border: none;
-        background-color: transparent;
-        cursor: pointer;
-      `}
-      type="button"
-    >
-      <Icon id="plus" width="1.5rem" height="1.5rem" />
-      <Typography
-        css={css`
-          margin-left: 1rem;
-        `}
-      >
-        새로운 재생 목록 만들기
-      </Typography>
-    </button>
   );
 };

--- a/FE/src/components/interviewWorkbookDetailPage/AddWorkbookListModal.tsx
+++ b/FE/src/components/interviewWorkbookDetailPage/AddWorkbookListModal.tsx
@@ -12,7 +12,6 @@ const AddWorkbookListModal = ({
 }: {
   isOpen: boolean;
   closeModal: () => void;
-  workbookId: number;
   selectedQuestionIds: number[];
 }) => {
   const { data: workbookTitleData } = useWorkbookTitleListQuery();

--- a/FE/src/components/interviewWorkbookDetailPage/InterviewWorkbookDetailPageLayout.tsx
+++ b/FE/src/components/interviewWorkbookDetailPage/InterviewWorkbookDetailPageLayout.tsx
@@ -1,0 +1,23 @@
+import { Header, Layout } from '@components/layout';
+import { css } from '@emotion/react';
+import React, { PropsWithChildren } from 'react';
+
+const InterviewWorkbookDetailPageLayout: React.FC<PropsWithChildren> = ({
+  children,
+}) => {
+  return (
+    <div>
+      <Header />
+      <Layout
+        direction="column"
+        css={css`
+          padding: 8rem 1rem 1rem 1rem;
+        `}
+      >
+        {children}
+      </Layout>
+    </div>
+  );
+};
+
+export default InterviewWorkbookDetailPageLayout;

--- a/FE/src/components/interviewWorkbookDetailPage/NewWorkbookListButton.tsx
+++ b/FE/src/components/interviewWorkbookDetailPage/NewWorkbookListButton.tsx
@@ -11,26 +11,32 @@ const NewWorkbookListButton = ({
   selectedQuestionIds: number[];
   workbookData: WorkbookEntity;
 }) => {
-  const { mutate: newWorkbookMutate } = useWorkbookPostMutation();
-  const { mutate: newQuestionCopyMutate } = useQuestionCopyMutation();
+  const { mutateAsync: newWorkbookMutate } = useWorkbookPostMutation();
+  const { mutateAsync: newQuestionCopyMutate } = useQuestionCopyMutation();
 
   const handleNewWorkbook = () => {
-    newWorkbookMutate(
-      {
-        title: `${workbookData.title} 복사본`,
-        content: workbookData.content,
-        categoryId: workbookData.categoryId,
-      },
-      {
-        onSuccess: (data) => {
-          newQuestionCopyMutate({
-            workbookId: data.workbookId,
-            questionIds: selectedQuestionIds,
-          });
-        },
-      }
-    );
+    try {
+      void createNewWorkbook();
+      //TODO: 이 다음에는 어떻게 해줄까...?
+    } catch (err) {
+      console.log(err);
+      throw err;
+    }
   };
+
+  const createNewWorkbook = async () => {
+    const result = await newWorkbookMutate({
+      title: `${workbookData.title} 복사본`,
+      content: workbookData.content,
+      categoryId: workbookData.categoryId,
+    });
+
+    await newQuestionCopyMutate({
+      workbookId: result.workbookId,
+      questionIds: selectedQuestionIds,
+    });
+  };
+
   return (
     <button
       onClick={handleNewWorkbook}

--- a/FE/src/components/interviewWorkbookDetailPage/NewWorkbookListButton.tsx
+++ b/FE/src/components/interviewWorkbookDetailPage/NewWorkbookListButton.tsx
@@ -1,0 +1,61 @@
+import { WorkbookEntity } from '@/types/workbook';
+import { css } from '@emotion/react';
+import { Icon, Typography } from '@foundation/index';
+import useQuestionCopyMutation from '@hooks/apis/mutations/useQuestionCopyMutation';
+import useWorkbookPostMutation from '@hooks/apis/mutations/useWorkbookPostMutation';
+
+const NewWorkbookListButton = ({
+  selectedQuestionIds,
+  workbookData,
+}: {
+  selectedQuestionIds: number[];
+  workbookData: WorkbookEntity;
+}) => {
+  const { mutate: newWorkbookMutate } = useWorkbookPostMutation();
+  const { mutate: newQuestionCopyMutate } = useQuestionCopyMutation();
+
+  const handleNewWorkbook = () => {
+    newWorkbookMutate(
+      {
+        title: `${workbookData.title} 복사본`,
+        content: workbookData.content,
+        categoryId: workbookData.categoryId,
+      },
+      {
+        onSuccess: (data) => {
+          newQuestionCopyMutate({
+            workbookId: data.workbookId,
+            questionIds: selectedQuestionIds,
+          });
+        },
+      }
+    );
+  };
+  return (
+    <button
+      onClick={handleNewWorkbook}
+      css={css`
+        display: flex;
+        align-items: center;
+        width: 100%;
+
+        outline: none;
+        border: none;
+        background-color: transparent;
+        cursor: pointer;
+      `}
+      type="button"
+    >
+      <Icon id="plus" width="1.5rem" height="1.5rem" />
+      <Typography
+        css={css`
+          margin-left: 1rem;
+        `}
+      >
+        새로운 재생 목록 만들기
+      </Typography>
+    </button>
+  );
+};
+
+export default NewWorkbookListButton;

--- a/FE/src/components/interviewWorkbookDetailPage/index.ts
+++ b/FE/src/components/interviewWorkbookDetailPage/index.ts
@@ -1,0 +1,2 @@
+export { default as AddWorkbookListModal } from './AddWorkbookListModal';
+export { default as InterviewWorkbookDetailPageLayout } from './InterviewWorkbookDetailPageLayout';

--- a/FE/src/constants/path.ts
+++ b/FE/src/constants/path.ts
@@ -4,6 +4,7 @@ const CONNECTION = 'connection';
 const RECORD = 'record';
 const MYPAGE = 'mypage';
 const QUESTION = 'question';
+const WORKBOOK = 'workbook';
 
 export const PATH = {
   ROOT: '/',
@@ -16,6 +17,8 @@ export const PATH = {
     `/${INTERVIEW}/${videoId ?? ':videoId'}`,
   INTERVIEW_VIDEO_PUBLIC: (videoHash?: string) =>
     `/${INTERVIEW}/public/${videoHash ?? ':videoHash'}`,
+  INTERVIEW_WORKBOOK_DETAIL: (workbookId?: number) =>
+    `/${INTERVIEW}/${WORKBOOK}/${workbookId ?? ':workbookId'}`,
   NOT_FOUND: `/404`,
 };
 

--- a/FE/src/constants/queryKey.ts
+++ b/FE/src/constants/queryKey.ts
@@ -9,4 +9,9 @@ export const QUERY_KEY = {
   VIDEO_HASH: (videoHash: string) => ['video', videoHash],
   WORKBOOK: ['workbook'],
   WORKBOOK_ID: (workbookId: number) => ['workbook', workbookId],
+  QUESTION_WORKBOOK_ID: (workbookId: number) => [
+    'question',
+    'workbook',
+    workbookId,
+  ],
 };

--- a/FE/src/hooks/apis/queries/useQuestionWorkbookQuery.ts
+++ b/FE/src/hooks/apis/queries/useQuestionWorkbookQuery.ts
@@ -14,7 +14,7 @@ const useQuestionWorkbookQuery = ({
   enabled,
 }: {
   workbookId: number;
-  enabled: boolean;
+  enabled?: boolean;
 }) => {
   return useQuery({
     queryKey: QUERY_KEY.QUESTION_CATEGORY(workbookId),

--- a/FE/src/page/interviewWorkbookDetailPage/index.tsx
+++ b/FE/src/page/interviewWorkbookDetailPage/index.tsx
@@ -18,7 +18,9 @@ const InterviewWorkbookDetailPage = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const { workbookId } = useLoaderData() as { workbookId: number };
-  const { data: questionWorkbookData } = useQuestionWorkbookQuery(workbookId);
+  const { data: questionWorkbookData } = useQuestionWorkbookQuery({
+    workbookId,
+  });
   const { data: workbookData } = useWorkbookQuery(workbookId);
 
   const selectQuestion = (questionId: number) =>

--- a/FE/src/page/interviewWorkbookDetailPage/index.tsx
+++ b/FE/src/page/interviewWorkbookDetailPage/index.tsx
@@ -75,6 +75,7 @@ const InterviewWorkbookDetailPage = () => {
           css={css`
             display: flex;
             justify-content: space-between;
+            align-items: center;
             padding: 1rem;
           `}
         >

--- a/FE/src/page/interviewWorkbookDetailPage/index.tsx
+++ b/FE/src/page/interviewWorkbookDetailPage/index.tsx
@@ -57,6 +57,7 @@ const InterviewWorkbookDetailPage = () => {
         isOpen={isModalOpen}
         closeModal={closeModal}
         selectedQuestionIds={selectedQuestionId}
+        workbookData={workbookData}
       />
       <InterviewWorkbookDetailPageLayout>
         <WorkbookCard

--- a/FE/src/page/interviewWorkbookDetailPage/index.tsx
+++ b/FE/src/page/interviewWorkbookDetailPage/index.tsx
@@ -105,6 +105,7 @@ const InterviewWorkbookDetailPage = () => {
                 question={question}
                 workbookId={workbookId}
                 isSelected={isSelected}
+                isEditable={false}
                 toggleSelected={() =>
                   isSelected
                     ? selectQuestion(question.questionId)

--- a/FE/src/page/interviewWorkbookDetailPage/index.tsx
+++ b/FE/src/page/interviewWorkbookDetailPage/index.tsx
@@ -1,0 +1,92 @@
+import QuestionAccordion from '@common/QuestionAccordion/QuestionAccordion';
+import { WorkbookCard } from '@common/index';
+import { InterviewWorkbookDetailPageLayout } from '@components/interviewWorkbookDetailPage';
+import { css } from '@emotion/react';
+import { Box, Button, CheckBox } from '@foundation/index';
+import useQuestionWorkbookQuery from '@hooks/apis/queries/useQuestionWorkbookQuery';
+import useWorkbookQuery from '@hooks/apis/queries/useWorkbookQuery';
+import { theme } from '@styles/theme';
+import { useState } from 'react';
+import { useLoaderData } from 'react-router-dom';
+
+const InterviewWorkbookDetailPage = () => {
+  const [selectedQuestionId, setSelectedQuestionId] = useState<number[]>([]);
+  const [allSelected, setAllSelected] = useState<boolean>(false);
+
+  const { workbookId } = useLoaderData() as { workbookId: number };
+  const { data: questionWorkbookData } = useQuestionWorkbookQuery(workbookId);
+  const { data: workbookData } = useWorkbookQuery(workbookId);
+
+  const toggleSelectedQuestionId = (questionId: number) => {
+    if (selectedQuestionId.includes(questionId)) {
+      setSelectedQuestionId((prev) => prev.filter((id) => id !== questionId));
+    } else {
+      setSelectedQuestionId((prev) => [...prev, questionId]);
+    }
+  };
+
+  const handleAllSelected = () => {
+    if (allSelected) {
+      setSelectedQuestionId([]);
+    } else {
+      setSelectedQuestionId(
+        questionWorkbookData?.map((question) => question.questionId) || []
+      );
+    }
+    setAllSelected((prev) => !prev);
+  };
+
+  if (!workbookData) return;
+
+  return (
+    <InterviewWorkbookDetailPageLayout>
+      <WorkbookCard
+        css={css`
+          height: auto;
+        `}
+        nickname={workbookData.nickname}
+        profileImg={workbookData.profileImg}
+        copyCount={workbookData.copyCount}
+        title={workbookData.title}
+        content={workbookData.content}
+      />
+
+      <div
+        css={css`
+          display: flex;
+          justify-content: space-between;
+          padding: 1rem;
+        `}
+      >
+        <CheckBox
+          id="allSelect"
+          checked={allSelected}
+          onInputChange={handleAllSelected}
+        >
+          전체 선택하기
+        </CheckBox>
+        <Button>질문 가져오기</Button>
+      </div>
+
+      <Box
+        css={css`
+          padding: 1rem;
+          background-color: ${theme.colors.border.weak};
+          height: auto;
+        `}
+      >
+        {questionWorkbookData?.map((question) => (
+          <QuestionAccordion
+            question={question}
+            workbookId={workbookId}
+            isSelected={selectedQuestionId.includes(question.questionId)}
+            toggleSelected={() => toggleSelectedQuestionId(question.questionId)}
+            key={question.questionId}
+          />
+        ))}
+      </Box>
+    </InterviewWorkbookDetailPageLayout>
+  );
+};
+
+export default InterviewWorkbookDetailPage;

--- a/FE/src/page/interviewWorkbookDetailPage/index.tsx
+++ b/FE/src/page/interviewWorkbookDetailPage/index.tsx
@@ -1,6 +1,9 @@
 import QuestionAccordion from '@common/QuestionAccordion/QuestionAccordion';
 import { WorkbookCard } from '@common/index';
-import { InterviewWorkbookDetailPageLayout } from '@components/interviewWorkbookDetailPage';
+import {
+  AddWorkbookListModal,
+  InterviewWorkbookDetailPageLayout,
+} from '@components/interviewWorkbookDetailPage';
 import { css } from '@emotion/react';
 import { Box, Button, CheckBox } from '@foundation/index';
 import useQuestionWorkbookQuery from '@hooks/apis/queries/useQuestionWorkbookQuery';
@@ -12,80 +15,104 @@ import { useLoaderData } from 'react-router-dom';
 const InterviewWorkbookDetailPage = () => {
   const [selectedQuestionId, setSelectedQuestionId] = useState<number[]>([]);
   const [allSelected, setAllSelected] = useState<boolean>(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const { workbookId } = useLoaderData() as { workbookId: number };
   const { data: questionWorkbookData } = useQuestionWorkbookQuery(workbookId);
   const { data: workbookData } = useWorkbookQuery(workbookId);
 
-  const toggleSelectedQuestionId = (questionId: number) => {
-    if (selectedQuestionId.includes(questionId)) {
-      setSelectedQuestionId((prev) => prev.filter((id) => id !== questionId));
-    } else {
-      setSelectedQuestionId((prev) => [...prev, questionId]);
-    }
-  };
+  const selectQuestion = (questionId: number) =>
+    setSelectedQuestionId((prev) => prev.filter((id) => id !== questionId));
+
+  const unSelectQuestion = (questionId: number) =>
+    setSelectedQuestionId((prev) => [...prev, questionId]);
+
+  const allSelectQuestion = () =>
+    setSelectedQuestionId(
+      questionWorkbookData?.map((question) => question.questionId) || []
+    );
+
+  const allUnSelectQuestion = () => setSelectedQuestionId([]);
 
   const handleAllSelected = () => {
-    if (allSelected) {
-      setSelectedQuestionId([]);
-    } else {
-      setSelectedQuestionId(
-        questionWorkbookData?.map((question) => question.questionId) || []
-      );
-    }
+    allSelected ? allUnSelectQuestion() : allSelectQuestion();
     setAllSelected((prev) => !prev);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const openModal = () => {
+    selectedQuestionId.length < 1
+      ? alert('질문을 선택해주세요')
+      : setIsModalOpen(true);
   };
 
   if (!workbookData) return;
 
   return (
-    <InterviewWorkbookDetailPageLayout>
-      <WorkbookCard
-        css={css`
-          height: auto;
-        `}
-        nickname={workbookData.nickname}
-        profileImg={workbookData.profileImg}
-        copyCount={workbookData.copyCount}
-        title={workbookData.title}
-        content={workbookData.content}
+    <>
+      <AddWorkbookListModal
+        isOpen={isModalOpen}
+        closeModal={closeModal}
+        selectedQuestionIds={selectedQuestionId}
       />
+      <InterviewWorkbookDetailPageLayout>
+        <WorkbookCard
+          css={css`
+            height: auto;
+          `}
+          nickname={workbookData.nickname}
+          profileImg={workbookData.profileImg}
+          copyCount={workbookData.copyCount}
+          title={workbookData.title}
+          content={workbookData.content}
+        />
 
-      <div
-        css={css`
-          display: flex;
-          justify-content: space-between;
-          padding: 1rem;
-        `}
-      >
-        <CheckBox
-          id="allSelect"
-          checked={allSelected}
-          onInputChange={handleAllSelected}
+        <div
+          css={css`
+            display: flex;
+            justify-content: space-between;
+            padding: 1rem;
+          `}
         >
-          전체 선택하기
-        </CheckBox>
-        <Button>질문 가져오기</Button>
-      </div>
+          <CheckBox
+            id="allSelect"
+            checked={allSelected}
+            onInputChange={handleAllSelected}
+          >
+            전체 선택하기
+          </CheckBox>
+          <Button onClick={openModal}>질문 가져오기</Button>
+        </div>
 
-      <Box
-        css={css`
-          padding: 1rem;
-          background-color: ${theme.colors.border.weak};
-          height: auto;
-        `}
-      >
-        {questionWorkbookData?.map((question) => (
-          <QuestionAccordion
-            question={question}
-            workbookId={workbookId}
-            isSelected={selectedQuestionId.includes(question.questionId)}
-            toggleSelected={() => toggleSelectedQuestionId(question.questionId)}
-            key={question.questionId}
-          />
-        ))}
-      </Box>
-    </InterviewWorkbookDetailPageLayout>
+        <Box
+          css={css`
+            padding: 1rem;
+            background-color: ${theme.colors.border.weak};
+            height: auto;
+          `}
+        >
+          {questionWorkbookData?.map((question) => {
+            const isSelected = selectedQuestionId.includes(question.questionId);
+            return (
+              <QuestionAccordion
+                question={question}
+                workbookId={workbookId}
+                isSelected={isSelected}
+                toggleSelected={() =>
+                  isSelected
+                    ? selectQuestion(question.questionId)
+                    : unSelectQuestion(question.questionId)
+                }
+                key={question.questionId}
+              />
+            );
+          })}
+        </Box>
+      </InterviewWorkbookDetailPageLayout>
+    </>
   );
 };
 

--- a/FE/src/routes/interviewWorkbookDetailLoader.ts
+++ b/FE/src/routes/interviewWorkbookDetailLoader.ts
@@ -1,0 +1,13 @@
+import { PATH } from '@constants/path';
+import { Params, json, redirect } from 'react-router-dom';
+
+const interviewWorkbookDetailLoader = (params: Params<string>) => {
+  const workbookId = params.workbookId;
+  if (!workbookId || isNaN(Number(workbookId))) {
+    return redirect(PATH.ROOT);
+  } else {
+    return json({ workbookId: params.workbookId });
+  }
+};
+
+export default interviewWorkbookDetailLoader;


### PR DESCRIPTION
[![NDD-270](https://badgen.net/badge/JIRA/NDD-270/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-270) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

api가 많아지다보니 슬슬 햇갈리기 시작하네요 ㅠㅠ querykey중복 이슈떄문에 30분동안 헤매고 있었습니다. 생각보다 얽힌게 많은것 같아요 주말에 풀어보도록 하죠

# How

문제집 세부정보 페이지를 완성하였습니다. 아직 연결하지 못한 부분 => 문제집에 추가가 되고 난 이후에 유저를 어디로 보내줘야할지에 대한 내용은  성인님 페이지가 완성되고 연결하는것이 좋을것 같아요 아직 PATH가 없어서 못하더라고요

## 포인트1

`  const { workbookId } = useLoaderData() as { workbookId: number };`
코드 중에 다음과 같은 코드가 있는데 이는 path의 workbookId를 추출해 내는 코드입니다. 제가 지금 사용하는 페이지의 경로는 다음과 같은데
`interview/workbook/:workbookId` 이중에서 loader단에서 workbookId를 검증하고 맞는 타입이라면 위의 코드처럼 사용해 페이지 내부에서 workbookId를 사용할 수 있습니다.


## 포인트2

```
  const createNewWorkbook = async () => {
    const result = await newWorkbookMutate({
      title: `${workbookData.title} 복사본`,
      content: workbookData.content,
      categoryId: workbookData.categoryId,
    });

    await newQuestionCopyMutate({
      workbookId: result.workbookId,
      questionIds: selectedQuestionIds,
    });
  };
```

기존의 mutate 방법으로 사용하니 onSuccess 옵션을 계속 사용해야 하고 그러다 보니 callback hell과 같은 상황이 펼쳐 졌습니다. 그래서 이전 PR에서 사용했던 mutateAsync 방법을 사용해서 직접 async/awiat으로 변경하였습니다

# Result

![image](https://github.com/boostcampwm2023/web14-gomterview/assets/49224104/c8ad4428-2e60-4488-9bc5-29af0778ed26)



[NDD-270]: https://milk717.atlassian.net/browse/NDD-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ