### PR TITLE
[NDD-287]: 질문 복제 로직 구현 (1h / 1h)

### DIFF
--- a/BE/src/member/fixture/member.fixture.ts
+++ b/BE/src/member/fixture/member.fixture.ts
@@ -15,7 +15,7 @@ export const differentMemberFixture = new Member(
   'jang@jang.com',
   'jang',
   'https://jangsarchive.tistory.com',
-  new Date()
+  new Date(),
 );
 
 export const otherMemberFixture = new Member(

--- a/BE/src/question/controller/question.controller.ts
+++ b/BE/src/question/controller/question.controller.ts
@@ -23,6 +23,8 @@ import {
 import { createApiResponseOption } from '../../util/swagger.util';
 import { QuestionResponse } from '../dto/questionResponse';
 import { Member } from '../../member/entity/member';
+import { CopyQuestionRequest } from '../dto/copyQuestionRequest';
+import { WorkbookIdResponse } from '../../workbook/dto/workbookIdResponse';
 
 @ApiTags('question')
 @Controller('/api/question')
@@ -45,6 +47,24 @@ export class QuestionController {
   ) {
     return await this.questionService.createQuestion(
       createQuestionRequest,
+      req.user as Member,
+    );
+  }
+
+  @Post('/copy')
+  @UseGuards(AuthGuard('jwt'))
+  @ApiCookieAuth()
+  @ApiBody({ type: CopyQuestionRequest })
+  @ApiOperation({
+    summary: '질문 복제',
+  })
+  @ApiResponse(createApiResponseOption(201, '질문 복제', WorkbookIdResponse))
+  async copyQuestions(
+    @Body() copyQuestionRequest: CopyQuestionRequest,
+    @Req() req: Request,
+  ) {
+    return await this.questionService.copyQuestions(
+      copyQuestionRequest,
       req.user as Member,
     );
   }

--- a/BE/src/question/dto/copyQuestionRequest.ts
+++ b/BE/src/question/dto/copyQuestionRequest.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { createPropertyOption } from '../../util/swagger.util';
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class CopyQuestionRequest {
+  @ApiProperty(createPropertyOption('1', '문제집 id', Number))
+  @IsNotEmpty()
+  @IsNumber()
+  workbookId: number;
+
+  @ApiProperty(
+    createPropertyOption([1, 2, 3, 4, 5], '복사할 질문들의 id', Number),
+  )
+  @IsNotEmpty()
+  @IsNumber()
+  questionIds: number[];
+
+  constructor(workbookId: number, questionIds: number[]) {
+    this.workbookId = workbookId;
+    this.questionIds = questionIds;
+  }
+}

--- a/BE/src/question/fixture/question.fixture.ts
+++ b/BE/src/question/fixture/question.fixture.ts
@@ -1,6 +1,7 @@
 import { Question } from '../entity/question';
 import { CreateQuestionRequest } from '../dto/createQuestionRequest';
 import { workbookFixtureWithId } from '../../workbook/fixture/workbook.fixture';
+import { CopyQuestionRequest } from '../dto/copyQuestionRequest';
 
 export const questionFixture = new Question(
   1,
@@ -14,4 +15,9 @@ export const questionFixture = new Question(
 export const createQuestionRequestFixture = new CreateQuestionRequest(
   workbookFixtureWithId.id,
   'tester',
+);
+
+export const copyQuestionRequestFixture = new CopyQuestionRequest(
+  workbookFixtureWithId.id,
+  [1, 2, 3],
 );

--- a/BE/src/question/repository/question.repository.ts
+++ b/BE/src/question/repository/question.repository.ts
@@ -17,8 +17,17 @@ export class QuestionRepository {
     return await this.repository.save(question);
   }
 
+  async saveAll(questions: Question[]) {
+    await this.repository.insert(questions);
+  }
+
   async findByWorkbookId(workbookId: number) {
-    return await this.repository.findBy({ workbook: { id: workbookId } });
+    return await this.repository
+      .createQueryBuilder('Question')
+      .leftJoinAndSelect('Question.workbook', 'workbook')
+      .leftJoinAndSelect('Question.origin', 'origin')
+      .where('workbook.id = :workbookId', { workbookId })
+      .getMany();
   }
 
   async findById(questionId: number) {
@@ -31,7 +40,14 @@ export class QuestionRepository {
       .leftJoinAndSelect('Question.origin', 'origin')
       .where('Question.id = :id', { id })
       .getOne();
+    return this.fetchOrigin(question);
+  }
 
+  async remove(question: Question) {
+    await this.repository.remove(question);
+  }
+
+  private fetchOrigin(question: Question) {
     if (!question) {
       return null;
     }
@@ -43,9 +59,5 @@ export class QuestionRepository {
     }
 
     return originQuestion;
-  }
-
-  async remove(question: Question) {
-    await this.repository.remove(question);
   }
 }


### PR DESCRIPTION
[![NDD-287](https://badgen.net/badge/JIRA/NDD-287/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-287) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- 회원이 문제집에서 문제들을 일부 복제할 때 이를 수행하는 기능을 만들어야 한다. 
- 이를 save로 전체를 처리하면 select & insert가 반복될 수 있다는 위험을 느꼈다. 
- 이로 인해 insert를 직접 처리하게 했다.

# How

```
// repository
async saveAll(questions: Question[]) {
    await this.repository.insert(questions);
  }

async findByWorkbookId(workbookId: number) {
    return await this.repository
      .createQueryBuilder('Question')
      .leftJoinAndSelect('Question.workbook', 'workbook')
      .leftJoinAndSelect('Question.origin', 'origin')
      .where('workbook.id = :workbookId', { workbookId })
      .getMany();
  }
```

- 해당 로직을 통해 workbookId로 조회할 때, Member와 origin을 전체 조회하게 했다. 
- 복제시에 기존 질문이 복사본일 경우, 복사본이 아닌 원본을 다시 복제해야 하기 때문에 이렇게 처리했다. 

```
// service
async copyQuestions(
    copyQuestionRequest: CopyQuestionRequest,
    member: Member,
  ) {
    const workbook = await this.workbookRepository.findById(
      copyQuestionRequest.workbookId,
    );
    validateWorkbook(workbook);
    validateWorkbookOwner(workbook, member);

    const questions = (
      await this.questionRepository.findByWorkbookId(workbook.id)
    )
      .filter((each) => copyQuestionRequest.questionIds.includes(each.id))
      .map((question) => this.createCopy(question, workbook));
    await this.questionRepository.saveAll(questions);
    return WorkbookIdResponse.of(workbook);
  }

private createCopy(question: Question, workbook: Workbook) {
    if (question.origin) {
      return Question.copyOf(question.origin, workbook);
    }

    return Question.copyOf(question, workbook);
  }
```

- workbookId로 받은 문제집을 조회해 존재 여부와 권한을 검증한다. 
- 문제집id로 질문들을 받아온다. 
- 저장할 질문 id인지 검증한다. 
- 저장할 질문들을 복제본으로 새로운 Question 객체로 만든다. 
- insert로 전체를 저장한다. 
- 문제집 id를 반환한다.

# Prize

- save -> insert로 전체적인 select & insert가 아닌 단순 insert로 처리 
- insert에서 배열을 한번에 입력받게 해 벌크 처리 가능
- fetch를 통해 데이터의 누락 위험을 없앨 수 있다.

[NDD-287]: https://milk717.atlassian.net/browse/NDD-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ