### PR TITLE
[NDD-256]: DB에 다른 비디오 링크를 넣을 수 없도록 변경 (0.5h / 1h)

### DIFF
--- a/BE/src/video/dto/createVideoRequest.ts
+++ b/BE/src/video/dto/createVideoRequest.ts
@@ -20,10 +20,17 @@ export class CreateVideoRequest {
   videoName: string;
 
   @ApiProperty(
-    createPropertyOption('https://video-example.com', '비디오 URL', String),
+    createPropertyOption(
+      'https://u2e0.c18.e2-4.dev/videos/example.mp4',
+      '비디오 URL',
+      String,
+    ),
   )
   @IsString()
   @IsNotEmpty()
+  @Matches(/^https:\/\/u2e0\.c18\.e2-4\.dev\/videos/, {
+    message: '비디오 URL 형식이 올바르지 않습니다.',
+  })
   url: string;
 
   @ApiProperty(

--- a/BE/src/video/fixture/video.fixture.ts
+++ b/BE/src/video/fixture/video.fixture.ts
@@ -93,7 +93,7 @@ export const videoOfWithdrawnMemberFixture = new Video(
 export const createVideoRequestFixture = new CreateVideoRequest(
   1,
   'foobar.webm',
-  'https://foo.com',
+  'https://u2e0.c18.e2-4.dev/videos/example.mp4',
   'https://bar.com',
   '03:29',
 );


### PR DESCRIPTION
[![NDD-256](https://badgen.net/badge/JIRA/NDD-256/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-256) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/7f72a2cb-dd62-4887-88e7-47db98ce9f42)
DB에 위와 같이 현재 서비스에서 제공하는 IDrive에 저장하지 않은 외부의 영상을 저장해두고 서비스 내의 비디오 재생 시스템을 사용하는 경우가 있어 이를 방지하기 위한 간단한 방책으로 Request가 들어오면 유효한 URL인지 체크하는 로직을 구현했다.

# How
이전의 비디오 등록 요청 객체에서 시간이 올바른 형태(mm:ss)로 들어오는지 @Matches 어노테이션을 사용해 체크했던 로직을 그대로 사용했다.

```javascript
@ApiProperty(
  createPropertyOption(
    'https://u2e0.c18.e2-4.dev/videos/example.mp4',
    '비디오 URL',
    String,
  ),
)
@IsString()
@IsNotEmpty()
@Matches(/^https:\/\/u2e0\.c18\.e2-4\.dev\/videos/, {
  message: '비디오 URL 형식이 올바르지 않습니다.',
})
url: string;

```

# Result
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/a504f9ad-e42d-45be-bc94-c69a85b90491)
위의 사진과 같이 서비스에서 제공하지 않는 IDrive의 주소 외의 올바르지 않은 주소로 요청을 하면 400 에러를 반환한다.

![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/8af8ff4e-9a28-46a1-adaf-2a53959f95f4)
위의 사진과 같이 서비스에서 제공하는 올바른 IDrive의 주소로 요청을 하면 DB에 저장이 되고, 201 상태 코드를 반환한다.

# Prize
사용자가 자신의 임의의 비디오를 DB에 저장해두고 사용하는 경우를 미연에 방지할 수 있다.

확실히 다양한 형태의 값이 가능한 String의 경우에는 예외 처리를 잘 해두어 의도하지 않는 값이 요청으로 들어오지 않도록 미리 처리해야겠다는 생각이 들었다.

[NDD-256]: https://milk717.atlassian.net/browse/NDD-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ