### PR TITLE
[NDD-258] useModal 훅 추가 (8h/8h)

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -6,6 +6,7 @@ import { RecoilRoot } from 'recoil';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import GlobalSVGProvider from '@/GlobalSvgProvider';
 import AppRouter from '@/AppRouter';
+import ModalProvider from './modalProvider';
 
 function App() {
   const queryClient = new QueryClient();
@@ -18,6 +19,7 @@ function App() {
           <Global styles={_global} />
           <AppRouter queryClient={queryClient} />
           <GlobalSVGProvider />
+          <ModalProvider />
         </ThemeProvider>
       </RecoilRoot>
     </QueryClientProvider>

--- a/FE/src/atoms/modal.ts
+++ b/FE/src/atoms/modal.ts
@@ -11,3 +11,8 @@ export const QuestionAnswerSelectionModal = atom<{
     isOpen: false,
   },
 });
+
+export const modalState = atom<{ id: string; element: React.FC }[]>({
+  key: 'modalState',
+  default: [],
+});

--- a/FE/src/hooks/useModal.ts
+++ b/FE/src/hooks/useModal.ts
@@ -1,32 +1,29 @@
 import { modalState } from '@atoms/modal';
-import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { useCallback, useId, useMemo, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
+const isArrEmpty = (arr: unknown[]) => arr.length === 0;
+
 const useModal = (component: React.FC) => {
-  const [, setModal] = useRecoilState(modalState);
+  const [modalElements, setModal] = useRecoilState(modalState);
   const [isOpen, setIsOpen] = useState(false);
 
   const id = useId();
 
   const openModal = useCallback(() => {
     setIsOpen(true);
+    setModal((pre) => [...pre, { id: id, element: modalComponent }]);
     document.body.style.overflow = 'hidden';
   }, []);
 
   const closeModal = useCallback(() => {
     setIsOpen(false);
-    document.body.style.overflow = 'unset';
+    setModal((pre) => pre.filter((c) => c.id !== id));
+
+    if (isArrEmpty(modalElements)) document.body.style.overflow = 'unset';
   }, []);
 
   const modalComponent = useMemo(() => component, []);
-
-  useEffect(() => {
-    if (isOpen) {
-      setModal((pre) => [...pre, { id: id, element: modalComponent }]);
-    } else {
-      setModal((pre) => pre.filter((c) => c.id !== id));
-    }
-  }, [id, isOpen, modalComponent, setModal]);
 
   return { isOpen, openModal, closeModal };
 };

--- a/FE/src/hooks/useModal.ts
+++ b/FE/src/hooks/useModal.ts
@@ -1,0 +1,34 @@
+import { modalState } from '@atoms/modal';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { useRecoilState } from 'recoil';
+
+const useModal = (component: React.FC) => {
+  const [, setModal] = useRecoilState(modalState);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const id = useId();
+
+  const openModal = useCallback(() => {
+    setIsOpen(true);
+    document.body.style.overflow = 'hidden';
+  }, []);
+
+  const closeModal = useCallback(() => {
+    setIsOpen(false);
+    document.body.style.overflow = 'unset';
+  }, []);
+
+  const modalComponent = useMemo(() => component, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      setModal((pre) => [...pre, { id: id, element: modalComponent }]);
+    } else {
+      setModal((pre) => pre.filter((c) => c.id !== id));
+    }
+  }, [id, isOpen, modalComponent, setModal]);
+
+  return { isOpen, openModal, closeModal };
+};
+
+export default useModal;

--- a/FE/src/modalProvider.tsx
+++ b/FE/src/modalProvider.tsx
@@ -1,0 +1,19 @@
+import { modalState } from '@atoms/modal';
+import { useRecoilState } from 'recoil';
+
+const ModalProvider = () => {
+  const [state] = useRecoilState(modalState);
+  return (
+    <>
+      {state.map(({ id, element }) => {
+        return <Component key={id} component={element} />;
+      })}
+    </>
+  );
+};
+
+const Component = ({ component, ...rest }: { component: React.FC }) => {
+  return component({ ...rest });
+};
+
+export default ModalProvider;


### PR DESCRIPTION
[![NDD-258](https://badgen.net/badge/JIRA/NDD-258/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-258) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

너무 많은 modal을 관리하고 있어서 hook 으로 조금 더 관심사와 불필요한 코드를 줄이고자 합니다.
8h걸린 이유는 아이디어는 맞았으나 구현을 할때 element를 state에 저장한다는 개념이 매우 생소해서 구현하는데 애를 먹었습니다.

# How


## 구현 아이디어
modal은 해당 컴포넌트에 랜더링 할 필요가 없기 떄문에 이 컴포넌트를 가장 상위에 랜더링을 시키도록 하고 싶었습니다. 그러기위해서 첫번째 생각한 것이 protal이었는데 여전히 modal을 사용하는 코드에서 jsx를 연결해주어야 한다는 단점이 있습니다.
그래서 global state에 elemet를 저장해서 해당 element를 가장 상위에서 랜더링 하도록 하는 방법을 선택하였습니다.
자세한건 블로깅 해보죠


## 고민 점
React의 노드 타입은 ReactNode ReactElement ReactPortal 이 있습니다. 각자의 사용처가 다르더군요

1. ReactNode
React Node는 null string number props로 넘어오는 child까지 모든 노드 들을 나타내는 타입입니다. 아래에 있는 element portal등의 상위 집합이죠

2. ReactElement
createElement() 매서드를 사용해서 생성된 element입니다. 즉 jsx로 만들어진 타입이죠.

3. ReactPortal
다른 DOM에 랜더링 시킬때 나오는 타입입니다.

4. React.FC
ReactElement 를 반환하는 컴포넌트를 의미합니다.

따라서 global state에 element를 직접 넣어두고 랜더링을 시키려면 jsx자체를 반환하는것이 아닌 ReactNode가 필요하다고 생각하였습니다.

하지만 간과한것이 해당 modal 컴포넌트를 랜더링할때 다음과 같이 특정한 dom 위치에 랜더링을 해줘야 하는데 ReactNode는 Node 자체이기 떄문에 다음과 같은 코드로 랜더링을 할 수 없었습니다

```tsx
import { modalState } from '@atoms/modal';
import { useRecoilState } from 'recoil';

const ModalProvider = () => {
  const [state] = useRecoilState(modalState);
  return (
    <>
      {state.map(({ id, element }) => {
        return <Component key={id} component={element} />;
      })}
    </>
  );
};

const Component = ({ component, ...rest }: { component: React.FC }) => {
  return component({ ...rest });
};

export default ModalProvider;


```

따라서 타입을 랜더링을 시켜줄 수 있는 React.FC를 사용해야 했고 그에 따라서 ReactNode를 리턴을 시켜 주어야 합니다.



# Result

```tsx
  const { openModal, closeModal } = useModal(() => {
    return (
      <AnswerSelectionModal
        workbookId={workbookId}
        question={question}
        closeModal={closeModal}
      />
    );
  });

```

이런식으로 사용하면 가장 상위 태그에서 인자로 넘어간 modal 컴포넌트를 랜더링합니다.


# Link

https://github.com/mpontus/react-modal-hook/blob/master/src/ModalProvider.tsx

[NDD-258]: https://milk717.atlassian.net/browse/NDD-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ