### PR TITLE
[NDD-253]: BE docker pull needs 수정

### DIFF
--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -22,7 +22,7 @@ jobs:
           sudo docker push ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}}
 
   deploy-with-runner:
-    needs: pull-and-deploy
+    needs: build-and-push
     name: Deploy with runner
     runs-on: self-hosted
 


### PR DESCRIPTION
[![NDD-253](https://badgen.net/badge/JIRA/NDD-253/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-253) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
needs 이름을 잘못 설정해서 CD 과정 중 바로 실행이 중지되어 이를 변경하기 위함

# How
```
deploy-with-runner:
  needs: build-and-push
  name: Deploy with runner
  runs-on: self-hosted
```
이처럼 needs를 알맞은 이름으로 변경

# Result
저번에 CD 실행 자체가 안됐지만, 이번 변경을 통해 CD 스크립트가 실행될 것임 

# Prize
자동 CD가 될 것으로 기대

[NDD-253]: https://milk717.atlassian.net/browse/NDD-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ