### PR TITLE
[NDD-335] 문제집 페이지에서 All 탭이 없는 이슈 해결 (0.5h / 0.5h)

### DIFF
--- a/FE/src/apis/workbook.ts
+++ b/FE/src/apis/workbook.ts
@@ -17,7 +17,7 @@ export const postWorkbook = async (body: WorkbookAddReqDto) => {
   });
 };
 
-export const getWorkbookByCategory = async (categoryId: number) => {
+export const getWorkbookByCategory = async (categoryId: string) => {
   return await getAPIResponseData<WorkbookListResDto>({
     method: 'get',
     url: API.WORKBOOK_CATEGORY_ID(categoryId),

--- a/FE/src/components/workbookPage/CategoryMenu.tsx
+++ b/FE/src/components/workbookPage/CategoryMenu.tsx
@@ -39,15 +39,27 @@ const CategoryMenu: React.FC<CategoryMenuProps> = ({ handleTabChange }) => {
             `}
             onTabChange={handleTabChange}
           >
-            {categories?.map((category, index) => (
-              <Tabs.Tab value={index.toString()} key={category.id}>
+            <Tabs.Tab value="" key="0">
+              <SelectionBox
+                id={`category-all`}
+                name="category-list"
+                lineDirection={isDeviceBreakpoint('laptop') ? 'bottom' : 'left'}
+                defaultChecked={true}
+                css={css`
+                  padding: 0.5rem 1rem;
+                `}
+              >
+                <Typography variant="title4">ALL</Typography>
+              </SelectionBox>
+            </Tabs.Tab>
+            {categories?.map((category) => (
+              <Tabs.Tab value={category.id.toString()} key={category.id}>
                 <SelectionBox
                   id={`category-${category.id.toString()}`}
                   name="category-list"
                   lineDirection={
                     isDeviceBreakpoint('laptop') ? 'bottom' : 'left'
                   }
-                  defaultChecked={index === 0}
                   css={css`
                     padding: 0.5rem 1rem;
                   `}

--- a/FE/src/components/workbookPage/WorkbookList.tsx
+++ b/FE/src/components/workbookPage/WorkbookList.tsx
@@ -5,12 +5,12 @@ import Workbook from './Workbook';
 import GridWorkbookList from './GridWorkbookList';
 
 type WorkbookListProps = {
-  selectedTabIndex: string;
+  selectedCategoryId: string;
 };
 
-const WorkbookList: React.FC<WorkbookListProps> = ({ selectedTabIndex }) => {
+const WorkbookList: React.FC<WorkbookListProps> = ({ selectedCategoryId }) => {
   const isDeviceBreakpoint = useBreakpoint();
-  const { data: workbookList } = useWorkbookListQuery(selectedTabIndex);
+  const { data: workbookList } = useWorkbookListQuery(selectedCategoryId);
 
   if (!workbookList) {
     return;

--- a/FE/src/components/workbookPage/WorkbookList.tsx
+++ b/FE/src/components/workbookPage/WorkbookList.tsx
@@ -10,7 +10,7 @@ type WorkbookListProps = {
 
 const WorkbookList: React.FC<WorkbookListProps> = ({ selectedTabIndex }) => {
   const isDeviceBreakpoint = useBreakpoint();
-  const { data: workbookList } = useWorkbookListQuery(Number(selectedTabIndex));
+  const { data: workbookList } = useWorkbookListQuery(selectedTabIndex);
 
   if (!workbookList) {
     return;

--- a/FE/src/constants/api.ts
+++ b/FE/src/constants/api.ts
@@ -25,5 +25,5 @@ export const API = {
   WORKBOOK: '/workbook',
   WORKBOOK_TITLE: '/workbook/title',
   WORKBOOK_ID: (id?: Id) => `/workbook/${id ?? ':id'}`,
-  WORKBOOK_CATEGORY_ID: (id?: Id) => `/workbook?category=${id ?? ':id'}`,
+  WORKBOOK_CATEGORY_ID: (id?: string) => `/workbook?category=${id ?? ':id'}`,
 } as const;

--- a/FE/src/constants/queryKey.ts
+++ b/FE/src/constants/queryKey.ts
@@ -7,7 +7,7 @@ export const QUERY_KEY = {
   VIDEO: ['video'],
   VIDEO_ID: (videoId: number) => ['video', videoId],
   VIDEO_HASH: (videoHash: string) => ['video', videoHash],
-  WORKBOOK_CATEGORY: (categoryId: number) => ['workbook_category', categoryId],
+  WORKBOOK_CATEGORY: (categoryId: string) => ['workbook_category', categoryId],
   WORKBOOK_ID: (workbookId: number) => ['workbook', workbookId],
   WORKBOOK_TITLE: ['workbookTitle'],
   QUESTION_WORKBOOK_ID: (workbookId: number) => [

--- a/FE/src/hooks/apis/queries/useWorkbookListQuery.ts
+++ b/FE/src/hooks/apis/queries/useWorkbookListQuery.ts
@@ -9,7 +9,7 @@ import { getWorkbookByCategory } from '@/apis/workbook';
  *
  * 문제집 리스트 페이지에서 사용됩니다.
  */
-const useWorkbookListQuery = (categoryId: number) => {
+const useWorkbookListQuery = (categoryId: string) => {
   return useQuery({
     queryKey: QUERY_KEY.WORKBOOK_CATEGORY(categoryId),
     queryFn: () => getWorkbookByCategory(categoryId),

--- a/FE/src/mocks/handlers/workbook.ts
+++ b/FE/src/mocks/handlers/workbook.ts
@@ -9,6 +9,18 @@ const workbookHandlers = [
     const category = request.url.split('category=')[1];
 
     switch (category) {
+      case '':
+        return HttpResponse.json([
+          {
+            workbookId: 1,
+            nickname: 'milk717',
+            profileImg: 'https://avatars.githubusercontent.com/u/66554167?v=4',
+            copyCount: 717,
+            title: '전체리스트가 와야합니다 ',
+            content:
+              '취업하고싶어요! 돈벌고싶어요! 클라이밍, 피아노, 플라잉요가.... 하고싶은게 너무 많아요\n에버랜드, 스키장, 온천 가고싶어요.\n어디 놀러간 적이 100만년 전...',
+          },
+        ]);
       case '0':
         return HttpResponse.json(
           [

--- a/FE/src/page/workbookPage/index.tsx
+++ b/FE/src/page/workbookPage/index.tsx
@@ -11,10 +11,10 @@ import { Typography } from '@foundation/index';
 import { SyntheticEvent, useState } from 'react';
 
 const WorkbookPage: React.FC = () => {
-  const [selectedTabIndex, setSelectedTabIndex] = useState('');
+  const [selectedCategoryId, setSelectedCategoryId] = useState('');
 
   const handleTabChange = (_: SyntheticEvent, v: string) => {
-    setSelectedTabIndex(v);
+    setSelectedCategoryId(v);
   };
 
   return (
@@ -28,7 +28,7 @@ const WorkbookPage: React.FC = () => {
         면접 세트 목록
       </Typography>
       <CategoryMenu handleTabChange={handleTabChange} />
-      <WorkbookList selectedTabIndex={selectedTabIndex} />
+      <WorkbookList selectedCategoryId={selectedCategoryId} />
       <WorkbookPlusButton />
     </WorkbookPageLayout>
   );

--- a/FE/src/page/workbookPage/index.tsx
+++ b/FE/src/page/workbookPage/index.tsx
@@ -11,7 +11,7 @@ import { Typography } from '@foundation/index';
 import { SyntheticEvent, useState } from 'react';
 
 const WorkbookPage: React.FC = () => {
-  const [selectedTabIndex, setSelectedTabIndex] = useState('0');
+  const [selectedTabIndex, setSelectedTabIndex] = useState('');
 
   const handleTabChange = (_: SyntheticEvent, v: string) => {
     setSelectedTabIndex(v);


### PR DESCRIPTION
[![NDD-335](https://badgen.net/badge/JIRA/NDD-335/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-335) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

<img width="1437" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/77886826/0dca1ed9-c299-4876-a9f1-a8d533e06c48">

user 입장에서 default Tab이 All 이 아닌 FE 였기때문에 이를 해결하기 위해 조치를 취합니다. 

# How

<img width="519" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/77886826/8fcba3e6-8c76-4ed6-8d75-5acbbbcd9ea4">

카테고리 tab을 렌더링 하는 부분에서 default로서 기능하는 All 카테고리를 적용합니다. 

이 과정에서 BE 에서 filtering 할때, 빈 문자열의 경우 아무런 filtering을 진행하지 않는다는 의미 부여를 위해  FE 측에서 id를 식별하는 로직을 string으로 모두 반영합니다. 

# Result

<img width="1045" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/77886826/18c56dc3-5ca6-49ed-b647-c6d15687a591">

[NDD-335]: https://milk717.atlassian.net/browse/NDD-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ