### PR TITLE
[NDD-332]: 게시물 수정시에 공개여부 설정 기능 추가 && 조회시 공개여부를 통한 필터링 추가 (1h / 1h)

### DIFF
--- a/BE/src/answer/service/answer.service.spec.ts
+++ b/BE/src/answer/service/answer.service.spec.ts
@@ -160,6 +160,7 @@ describe('AnswerService 단위 테스트', () => {
             'https://jangsarchive.tistory.com',
             new Date(),
           ),
+          true,
         ),
       );
       mockAnswerRepository.findById.mockResolvedValue(answerFixture);

--- a/BE/src/question/dto/questionResponse.ts
+++ b/BE/src/question/dto/questionResponse.ts
@@ -31,7 +31,6 @@ export class QuestionResponse {
 
   static from(question: Question) {
     const answer = question.defaultAnswer;
-    console.log(answer);
     if (isEmpty(answer))
       return new QuestionResponse(question.id, question.content, null, null);
 

--- a/BE/src/question/service/question.service.spec.ts
+++ b/BE/src/question/service/question.service.spec.ts
@@ -368,7 +368,7 @@ describe('QuestionService 통합 테스트', () => {
     }
     const other = await memberRepository.save(otherMemberFixture);
     const othersWorkbook = await workbookRepository.save(
-      Workbook.of('test', 'test', categoryFixtureWithId, other),
+      Workbook.of('test', 'test', categoryFixtureWithId, other, true),
     );
     //when
     const copyRequest = new CopyQuestionRequest(othersWorkbook.id, [1, 2, 3]);

--- a/BE/src/workbook/controller/workbook.controller.spec.ts
+++ b/BE/src/workbook/controller/workbook.controller.spec.ts
@@ -637,6 +637,7 @@ describe('WorkbookController 통합테스트', () => {
           each,
           'test content',
           category.id,
+          true,
         );
 
         const agent = request.agent(app.getHttpServer());
@@ -662,6 +663,7 @@ describe('WorkbookController 통합테스트', () => {
         'test title',
         'test content',
         category.id,
+        true,
       );
 
       const agent = request.agent(app.getHttpServer());
@@ -686,6 +688,7 @@ describe('WorkbookController 통합테스트', () => {
         'test title',
         'test content',
         151231,
+        true,
       );
 
       const agent = request.agent(app.getHttpServer());

--- a/BE/src/workbook/controller/workbook.controller.spec.ts
+++ b/BE/src/workbook/controller/workbook.controller.spec.ts
@@ -358,6 +358,7 @@ describe('WorkbookController 통합테스트', () => {
           title,
           'test content',
           categoryFixtureWithId.id,
+          true,
         );
         await agent
           .post('/api/workbook')
@@ -379,6 +380,7 @@ describe('WorkbookController 통합테스트', () => {
         'test title',
         'test content',
         12345,
+        true,
       );
       await agent
         .post('/api/workbook')
@@ -399,6 +401,7 @@ describe('WorkbookController 통합테스트', () => {
             `content_${category.name}`,
             category,
             member,
+            true,
           ),
         );
       }
@@ -448,6 +451,7 @@ describe('WorkbookController 통합테스트', () => {
             `content_${category.name}`,
             category,
             member,
+            true,
           ),
         );
       }
@@ -459,6 +463,7 @@ describe('WorkbookController 통합테스트', () => {
           `other${category.name}`,
           category,
           other,
+          true,
         ),
       );
     });
@@ -492,6 +497,7 @@ describe('WorkbookController 통합테스트', () => {
           `content_${category.name}`,
           category,
           member,
+          true,
         );
         for (
           let index = 0;
@@ -511,6 +517,7 @@ describe('WorkbookController 통합테스트', () => {
         `other${category.name}`,
         category,
         other,
+        true,
       );
       for (let index = 0; index < 10; index++) {
         workbook.increaseCopyCount();
@@ -545,6 +552,7 @@ describe('WorkbookController 통합테스트', () => {
         `other${category.name}`,
         category,
         other,
+        true,
       );
       await workbookRepository.save(workbook);
 

--- a/BE/src/workbook/controller/workbook.controller.ts
+++ b/BE/src/workbook/controller/workbook.controller.ts
@@ -60,6 +60,8 @@ export class WorkbookController {
   }
 
   @Get()
+  @OptionalGuard()
+  @UseGuards(TokenSoftGuard)
   @ApiOperation({
     summary: '카테고리별(null이면 전체) 문제집 조회',
   })
@@ -123,9 +125,9 @@ export class WorkbookController {
   @UseGuards(AuthGuard('jwt'))
   @ApiCookieAuth()
   @ApiOperation({
-    summary: '문제집 수정',
+    summary: '문제집 삭제',
   })
-  @ApiResponse(createApiResponseOption(204, '문제집 수정 완료', null))
+  @ApiResponse(createApiResponseOption(204, '문제집 삭제 완료', null))
   async deleteAnswer(
     @Req() req: Request,
     @Param('workbookId') workbookId: number,

--- a/BE/src/workbook/dto/createWorkbookRequest.ts
+++ b/BE/src/workbook/dto/createWorkbookRequest.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { createPropertyOption } from '../../util/swagger.util';
 import { IsNotEmpty, IsString } from '@nestjs/class-validator';
-import { IsNumber } from 'class-validator';
+import { IsBoolean, IsNumber } from 'class-validator';
 
 export class CreateWorkbookRequest {
   @ApiProperty(createPropertyOption('장희문제집', '문제집 이름', String))
@@ -20,9 +20,19 @@ export class CreateWorkbookRequest {
   @IsNotEmpty()
   categoryId: number;
 
-  constructor(title: string, content: string, categoryId: number) {
+  @ApiProperty(createPropertyOption(true, '문제집 공개여부', Boolean))
+  @IsBoolean()
+  isPublic: boolean;
+
+  constructor(
+    title: string,
+    content: string,
+    categoryId: number,
+    isPublic: boolean,
+  ) {
     this.title = title;
     this.content = content;
     this.categoryId = categoryId;
+    this.isPublic = isPublic;
   }
 }

--- a/BE/src/workbook/dto/updateWorkbookRequest.ts
+++ b/BE/src/workbook/dto/updateWorkbookRequest.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { createPropertyOption } from '../../util/swagger.util';
 import { IsNotEmpty, IsString } from '@nestjs/class-validator';
-import { IsNumber } from 'class-validator';
+import { IsBoolean, IsNumber } from 'class-validator';
 
 export class UpdateWorkbookRequest {
   @ApiProperty(createPropertyOption(1, '문제집 id', Number))
@@ -25,15 +25,21 @@ export class UpdateWorkbookRequest {
   @IsNotEmpty()
   categoryId: number;
 
+  @ApiProperty(createPropertyOption(true, '문제집 공개여부', Boolean))
+  @IsBoolean()
+  isPublic: boolean;
+
   constructor(
     workbookId: number,
     title: string,
     content: string,
     categoryId: number,
+    isPublic: boolean,
   ) {
     this.workbookId = workbookId;
     this.title = title;
     this.content = content;
     this.categoryId = categoryId;
+    this.isPublic = isPublic;
   }
 }

--- a/BE/src/workbook/dto/workbookResponse.ts
+++ b/BE/src/workbook/dto/workbookResponse.ts
@@ -1,6 +1,7 @@
 import { Workbook } from '../entity/workbook';
 import { ApiProperty } from '@nestjs/swagger';
 import { createPropertyOption } from '../../util/swagger.util';
+import { isEmpty } from 'class-validator';
 
 export class WorkbookResponse {
   @ApiProperty(createPropertyOption(1, '문제집 ID', Number))
@@ -47,7 +48,7 @@ export class WorkbookResponse {
     this.profileImg = profileImg;
     this.copyCount = copyCount;
     this.title = title;
-    this.content = content.toString();
+    this.content = isEmpty(content) ? '' : content.toString();
   }
 
   static of(workbook: Workbook) {

--- a/BE/src/workbook/dto/workbookResponse.ts
+++ b/BE/src/workbook/dto/workbookResponse.ts
@@ -33,6 +33,9 @@ export class WorkbookResponse {
   @ApiProperty(createPropertyOption('내꺼 건들 ㄴㄴ해', '문제집 설명', String))
   content: string;
 
+  @ApiProperty(createPropertyOption(true, '문제집 공개여부', Boolean))
+  isPublic: boolean;
+
   constructor(
     workbookId: number,
     categoryId: number,
@@ -41,6 +44,7 @@ export class WorkbookResponse {
     copyCount: number,
     title: string,
     content: string,
+    isPublic: boolean,
   ) {
     this.workbookId = workbookId;
     this.categoryId = categoryId;
@@ -49,6 +53,7 @@ export class WorkbookResponse {
     this.copyCount = copyCount;
     this.title = title;
     this.content = isEmpty(content) ? '' : content.toString();
+    this.isPublic = isPublic;
   }
 
   static of(workbook: Workbook) {
@@ -61,6 +66,7 @@ export class WorkbookResponse {
       workbook.copyCount,
       workbook.title,
       workbook.content,
+      workbook.isPublic,
     );
   }
 }

--- a/BE/src/workbook/entity/workbook.ts
+++ b/BE/src/workbook/entity/workbook.ts
@@ -23,7 +23,7 @@ export class Workbook extends DefaultEntity {
   @JoinColumn({ name: 'member' })
   member: Member;
 
-  @Column()
+  @Column({ default: true })
   isPublic: boolean;
 
   constructor(

--- a/BE/src/workbook/entity/workbook.ts
+++ b/BE/src/workbook/entity/workbook.ts
@@ -50,6 +50,7 @@ export class Workbook extends DefaultEntity {
     content: string,
     category: Category,
     member: Member,
+    isPublic: boolean,
   ): Workbook {
     return new Workbook(
       null,
@@ -59,7 +60,7 @@ export class Workbook extends DefaultEntity {
       category,
       0,
       member,
-      true,
+      isPublic,
     );
   }
 

--- a/BE/src/workbook/entity/workbook.ts
+++ b/BE/src/workbook/entity/workbook.ts
@@ -23,6 +23,9 @@ export class Workbook extends DefaultEntity {
   @JoinColumn({ name: 'member' })
   member: Member;
 
+  @Column()
+  isPublic: boolean;
+
   constructor(
     id: number,
     createdAt: Date,
@@ -31,6 +34,7 @@ export class Workbook extends DefaultEntity {
     category: Category,
     copyCount: number,
     member: Member,
+    isPublic: boolean,
   ) {
     super(id, createdAt);
     this.title = title;
@@ -38,6 +42,7 @@ export class Workbook extends DefaultEntity {
     this.category = category;
     this.copyCount = copyCount;
     this.member = member;
+    this.isPublic = isPublic;
   }
 
   static of(
@@ -46,7 +51,16 @@ export class Workbook extends DefaultEntity {
     category: Category,
     member: Member,
   ): Workbook {
-    return new Workbook(null, new Date(), title, content, category, 0, member);
+    return new Workbook(
+      null,
+      new Date(),
+      title,
+      content,
+      category,
+      0,
+      member,
+      true,
+    );
   }
 
   isOwnedBy(member: Member) {

--- a/BE/src/workbook/fixture/workbook.fixture.ts
+++ b/BE/src/workbook/fixture/workbook.fixture.ts
@@ -33,5 +33,5 @@ export const updateWorkbookRequestFixture = new UpdateWorkbookRequest(
   'newT',
   'newC',
   categoryFixtureWithId.id,
-  true,
+  false,
 );

--- a/BE/src/workbook/fixture/workbook.fixture.ts
+++ b/BE/src/workbook/fixture/workbook.fixture.ts
@@ -19,6 +19,7 @@ export const workbookFixtureWithId = new Workbook(
   categoryFixtureWithId,
   0,
   memberFixture,
+  true,
 );
 
 export const createWorkbookRequestFixture = new CreateWorkbookRequest(
@@ -32,4 +33,5 @@ export const updateWorkbookRequestFixture = new UpdateWorkbookRequest(
   'newT',
   'newC',
   categoryFixtureWithId.id,
+  true,
 );

--- a/BE/src/workbook/fixture/workbook.fixture.ts
+++ b/BE/src/workbook/fixture/workbook.fixture.ts
@@ -9,6 +9,7 @@ export const workbookFixture = Workbook.of(
   '테스트로 만드는 문제집입니다.',
   categoryFixtureWithId,
   memberFixture,
+  true,
 );
 
 export const workbookFixtureWithId = new Workbook(
@@ -26,6 +27,7 @@ export const createWorkbookRequestFixture = new CreateWorkbookRequest(
   workbookFixture.title,
   workbookFixture.content,
   categoryFixtureWithId.id,
+  true,
 );
 
 export const updateWorkbookRequestFixture = new UpdateWorkbookRequest(

--- a/BE/src/workbook/repository/workbook.repository.ts
+++ b/BE/src/workbook/repository/workbook.repository.ts
@@ -48,7 +48,7 @@ export class WorkbookRepository {
       .leftJoinAndSelect('Workbook.member', 'member')
       .leftJoinAndSelect('Workbook.category', 'category')
       .where('Workbook.isPublic = :state', { state: true })
-      .orWhere('category.id = :categoryId', { categoryId })
+      .andWhere('category.id = :categoryId', { categoryId })
       .getMany();
   }
 

--- a/BE/src/workbook/repository/workbook.repository.ts
+++ b/BE/src/workbook/repository/workbook.repository.ts
@@ -34,19 +34,21 @@ export class WorkbookRepository {
   }
 
   async findAll() {
-    return await this.repository
+    return this.repository
       .createQueryBuilder('Workbook')
       .leftJoinAndSelect('Workbook.category', 'category')
       .leftJoinAndSelect('Workbook.member', 'member')
+      .where('Workbook.isPublic = :state', { state: true })
       .getMany();
   }
 
   async findAllByCategoryId(categoryId: number) {
-    return await this.repository
+    return this.repository
       .createQueryBuilder('Workbook')
       .leftJoinAndSelect('Workbook.member', 'member')
       .leftJoinAndSelect('Workbook.category', 'category')
-      .where('category.id = :categoryId', { categoryId })
+      .where('Workbook.isPublic = :state', { state: true })
+      .orWhere('category.id = :categoryId', { categoryId })
       .getMany();
   }
 
@@ -54,6 +56,7 @@ export class WorkbookRepository {
     return await this.repository
       .createQueryBuilder('Workbook')
       .select()
+      .where('Workbook.isPublic = :state', { state: true })
       .orderBy('Workbook.copyCount', 'DESC')
       .limit(5)
       .getMany();

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -375,6 +375,7 @@ describe('WorkbookService 통합테스트', () => {
         'test title',
         'test content',
         category.id,
+        true,
       );
       const workbook = await workbookService.createWorkbook(
         createWorkbookRequest,
@@ -401,6 +402,7 @@ describe('WorkbookService 통합테스트', () => {
               `${each.name}_${index}`,
               category,
               member,
+              true,
             ),
           );
         }
@@ -428,6 +430,7 @@ describe('WorkbookService 통합테스트', () => {
               `${each.name}_${index}`,
               category,
               member,
+              true,
             ),
           );
         }
@@ -453,6 +456,7 @@ describe('WorkbookService 통합테스트', () => {
               `${each.name}_${index}`,
               category,
               member,
+              true,
             ),
           );
         }
@@ -480,6 +484,7 @@ describe('WorkbookService 통합테스트', () => {
               `${each.name}_${index}`,
               category,
               member,
+              true,
             ),
           );
         }
@@ -506,6 +511,7 @@ describe('WorkbookService 통합테스트', () => {
               `${each.name}_${index}`,
               category,
               member,
+              true,
             ),
           );
         }
@@ -532,6 +538,7 @@ describe('WorkbookService 통합테스트', () => {
         'test title',
         'test content',
         category.id,
+        true,
       );
       const workbook = await workbookService.createWorkbook(
         createWorkbookRequest,

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -667,7 +667,7 @@ describe('WorkbookService 통합테스트', () => {
       ).rejects.toThrow(new ManipulatedTokenNotFiltered());
     });
 
-    it('다른 회원이 문제집 수정을 요청하면 WorkbookForbidden예외처리한다.', async () => {
+    it('다른 회원이 문제집 삭제를 요청하면 WorkbookForbidden예외처리한다.', async () => {
       //given
       await memberRepository.save(memberFixture);
       await categoryRepository.save(categoryFixtureWithId);

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -261,6 +261,7 @@ describe('WorkbookService 단위테스트', () => {
         'newT',
         'newC',
         categoryFixtureWithId.id,
+        true,
       );
       //then
       const cases = [otherMemberFixture, null];
@@ -587,7 +588,13 @@ describe('WorkbookService 통합테스트', () => {
       //then
       await expect(
         workbookService.updateWorkbook(
-          new UpdateWorkbookRequest(workbookFixture.id, 'newT', 'newC', 12345),
+          new UpdateWorkbookRequest(
+            workbookFixture.id,
+            'newT',
+            'newC',
+            12345,
+            true,
+          ),
           member,
         ),
       ).rejects.toThrow(new CategoryNotFoundException());
@@ -604,7 +611,7 @@ describe('WorkbookService 통합테스트', () => {
       //then
       await expect(
         workbookService.updateWorkbook(
-          new UpdateWorkbookRequest(123142, 'newT', 'newC', category.id),
+          new UpdateWorkbookRequest(123142, 'newT', 'newC', category.id, true),
           member,
         ),
       ).rejects.toThrow(new WorkbookNotFoundException());

--- a/BE/src/workbook/service/workbook.service.ts
+++ b/BE/src/workbook/service/workbook.service.ts
@@ -35,6 +35,7 @@ export class WorkbookService {
         createWorkbookRequest.content,
         category,
         member,
+        createWorkbookRequest.isPublic,
       ),
     );
   }


### PR DESCRIPTION
[![NDD-332](https://badgen.net/badge/JIRA/NDD-332/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-332) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

- 기획상, 수정시에 문제집을 다른 사람들에게 공개할지에 대한 선택권을 회원에게 주어야 한다는 이야기가 나왔다. 
- 수정된 경우, 전체/카테고리별 조회에서는 문제집을 볼 수 없어야 한다. 
- 자신의 문제집의 경우 공개/비공개를 모두 조회시킨다. 

# How

```
.where('Workbook.isPublic = :state', { state: true })
```
이런 로직을 통해 조회시에 상태가 public 상태와 같은지 검증할 수 있다. 
```
.where('Workbook.isPublic = :state', { state: true })
      .andWhere('category.id = :categoryId', { categoryId })
```
카테고리별 조회에서는 andWhere로 public이면서 category가 해당되는 경우에만 조회하게 했다. 

# Result

- 공개여부에 따른 조회 성공
- WorkbookResponse, UpdateWorkbookRequest에 isPublic인스턴스 추가
- Workbook객체에 isPublic 인스턴스 추가
- isPublic인스턴스를 통해 공개여부 설정 가능

[NDD-332]: https://milk717.atlassian.net/browse/NDD-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ