### PR TITLE
[NDD-322]: Question 엔드포인트의 예외 HttpCustomException으로 수정 (0.5h / 1h)

### DIFF
--- a/BE/src/question/exception/question.exception.ts
+++ b/BE/src/question/exception/question.exception.ts
@@ -1,25 +1,9 @@
 import { HttpException } from '@nestjs/common';
 
-class ContentNotFoundException extends HttpException {
-  constructor() {
-    super('내용을 입력해주세요.', 404);
-  }
-}
-
-class NeedToFindByWorkbookIdException extends HttpException {
-  constructor() {
-    super('카테고리 id를 입력해주세요.', 400);
-  }
-}
-
 class QuestionNotFoundException extends HttpException {
   constructor() {
     super('해당 질문을 찾을 수 없습니다.', 404);
   }
 }
 
-export {
-  ContentNotFoundException,
-  NeedToFindByWorkbookIdException,
-  QuestionNotFoundException,
-};
+export { QuestionNotFoundException };

--- a/BE/src/question/exception/question.exception.ts
+++ b/BE/src/question/exception/question.exception.ts
@@ -1,8 +1,8 @@
-import { HttpException } from '@nestjs/common';
+import { HttpNotFoundException } from '../../util/exception.util';
 
-class QuestionNotFoundException extends HttpException {
+class QuestionNotFoundException extends HttpNotFoundException {
   constructor() {
-    super('해당 질문을 찾을 수 없습니다.', 404);
+    super('해당 질문을 찾을 수 없습니다.', 'Q01');
   }
 }
 

--- a/BE/src/question/service/question.service.spec.ts
+++ b/BE/src/question/service/question.service.spec.ts
@@ -18,10 +18,7 @@ import {
   memberFixture,
   otherMemberFixture,
 } from '../../member/fixture/member.fixture';
-import {
-  NeedToFindByWorkbookIdException,
-  QuestionNotFoundException,
-} from '../exception/question.exception';
+import { QuestionNotFoundException } from '../exception/question.exception';
 import { ManipulatedTokenNotFiltered } from '../../token/exception/token.exception';
 import { Answer } from '../../answer/entity/answer';
 import { AnswerModule } from '../../answer/answer.module';
@@ -33,6 +30,7 @@ import {
 import { WorkbookModule } from '../../workbook/workbook.module';
 import { Workbook } from '../../workbook/entity/workbook';
 import {
+  NeedToFindByWorkbookIdException,
   WorkbookForbiddenException,
   WorkbookNotFoundException,
 } from '../../workbook/exception/workbook.exception';

--- a/BE/src/question/service/question.service.ts
+++ b/BE/src/question/service/question.service.ts
@@ -75,8 +75,8 @@ export class QuestionService {
   async deleteQuestionById(questionId: number, member: Member) {
     validateManipulatedToken(member);
     const question = await this.questionRepository.findById(questionId);
-    validateQuestion(question);
     await this.validateMembersWorkbookById(question.workbook.id, member);
+    validateQuestion(question);
     await this.questionRepository.remove(question);
   }
 

--- a/BE/src/question/service/question.service.ts
+++ b/BE/src/question/service/question.service.ts
@@ -5,7 +5,6 @@ import { isEmpty } from 'class-validator';
 import { Question } from '../entity/question';
 import { QuestionResponse } from '../dto/questionResponse';
 import { Member } from '../../member/entity/member';
-import { NeedToFindByWorkbookIdException } from '../exception/question.exception';
 import { validateManipulatedToken } from '../../util/token.util';
 import { validateQuestion } from '../util/question.util';
 import { WorkbookRepository } from '../../workbook/repository/workbook.repository';
@@ -16,6 +15,7 @@ import {
 import { CopyQuestionRequest } from '../dto/copyQuestionRequest';
 import { Workbook } from '../../workbook/entity/workbook';
 import { WorkbookIdResponse } from '../../workbook/dto/workbookIdResponse';
+import { NeedToFindByWorkbookIdException } from '../../workbook/exception/workbook.exception';
 
 @Injectable()
 export class QuestionService {

--- a/BE/src/question/service/question.service.ts
+++ b/BE/src/question/service/question.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { QuestionRepository } from '../repository/question.repository';
 import { CreateQuestionRequest } from '../dto/createQuestionRequest';
 import { isEmpty } from 'class-validator';
@@ -33,10 +33,7 @@ export class QuestionService {
     );
 
     validateWorkbook(workbook);
-
-    if (!workbook.isOwnedBy(member)) {
-      throw new UnauthorizedException();
-    }
+    validateWorkbookOwner(workbook, member);
 
     const question = await this.questionRepository.save(
       Question.of(workbook, null, createQuestionRequest.content),

--- a/BE/src/question/service/question.service.ts
+++ b/BE/src/question/service/question.service.ts
@@ -75,8 +75,8 @@ export class QuestionService {
   async deleteQuestionById(questionId: number, member: Member) {
     validateManipulatedToken(member);
     const question = await this.questionRepository.findById(questionId);
-    await this.validateMembersWorkbookById(question.workbook.id, member);
     validateQuestion(question);
+    await this.validateMembersWorkbookById(question.workbook.id, member);
     await this.questionRepository.remove(question);
   }
 

--- a/BE/src/token/exception/token.exception.ts
+++ b/BE/src/token/exception/token.exception.ts
@@ -15,7 +15,7 @@ class TokenExpiredException extends HttpException {
 
 class ManipulatedTokenNotFiltered extends HttpInternalServerError {
   constructor() {
-    super('토큰 암호화가 뚫렸습니다.', 'SERVER');
+    super('', 'SERVER');
   }
 }
 

--- a/BE/src/workbook/exception/workbook.exception.ts
+++ b/BE/src/workbook/exception/workbook.exception.ts
@@ -1,4 +1,5 @@
 import {
+  HttpBadRequestException,
   HttpForbiddenException,
   HttpNotFoundException,
 } from '../../util/exception.util';
@@ -15,4 +16,14 @@ class WorkbookForbiddenException extends HttpForbiddenException {
   }
 }
 
-export { WorkbookNotFoundException, WorkbookForbiddenException };
+class NeedToFindByWorkbookIdException extends HttpBadRequestException {
+  constructor() {
+    super('문제집 id를 입력해주세요.', 'W03');
+  }
+}
+
+export {
+  WorkbookNotFoundException,
+  WorkbookForbiddenException,
+  NeedToFindByWorkbookIdException,
+};


### PR DESCRIPTION
[![NDD-322](https://badgen.net/badge/JIRA/NDD-322/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-322) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- Question의 엔드포인트 문서화 및 CustomHttpException으로 상속클래스 수정

# How

- class 에 extends를 Http~~Execption로 수정

# Result

<img width="771" alt="스크린샷 2023-12-04 19 44 38" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/79d9b1a0-63d2-49c0-a1be-3b0e60da85cb">

[NDD-322]: https://milk717.atlassian.net/browse/NDD-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ