### PR TITLE
[NDD-298]: 비디오, 회원 API 에러 케이스 Swagger 작성 (1h / 1h)

### DIFF
--- a/BE/src/constant/constant.ts
+++ b/BE/src/constant/constant.ts
@@ -22,4 +22,5 @@ export const BAD_REQUEST = 400;
 export const UNAUTHORIZED = 401;
 export const FORBIDDEN = 403;
 export const NOT_FOUND = 404;
+export const GONE = 410;
 export const INTERNAL_SERVER_ERROR = 500;

--- a/BE/src/member/controller/member.controller.ts
+++ b/BE/src/member/controller/member.controller.ts
@@ -32,6 +32,7 @@ export class MemberController {
       MemberResponse,
     ),
   )
+  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
   getMyInfo(@Req() req: Request) {
     validateManipulatedToken(req.user as Member);
     return MemberResponse.from(req.user as Member);
@@ -49,6 +50,8 @@ export class MemberController {
       MemberNicknameResponse,
     ),
   )
+  @ApiResponse(createApiResponseOption(401, 'T1', null))
+  @ApiResponse(createApiResponseOption(410, 'T2', null))
   async getNameForInterview(@Req() req: Request) {
     return await this.memberService.getNameForInterview(req);
   }

--- a/BE/src/member/exception/member.exception.ts
+++ b/BE/src/member/exception/member.exception.ts
@@ -1,7 +1,7 @@
-import { HttpException } from '@nestjs/common';
+import { HttpNotFoundException } from 'src/util/exception.util';
 
-export class MemberNotFoundException extends HttpException {
+export class MemberNotFoundException extends HttpNotFoundException {
   constructor() {
-    super('회원을 찾을 수 없습니다.', 404);
+    super('회원을 찾을 수 없습니다.', 'M1');
   }
 }

--- a/BE/src/member/service/member.service.ts
+++ b/BE/src/member/service/member.service.ts
@@ -16,16 +16,13 @@ export class MemberService {
     if (!req.cookies['accessToken'])
       return new MemberNicknameResponse(this.getNameWithPrefix(`면접자`));
 
-    return new MemberNicknameResponse(
-      this.getNameWithPrefix(
-        (await this.getMemberByToken(getTokenValue(req))).nickname,
-      ),
-    );
+    const member = await this.getMemberByToken(getTokenValue(req));
+    return new MemberNicknameResponse(this.getNameWithPrefix(member.nickname));
   }
 
   private async getMemberByToken(tokenValue: string) {
-    const memberId = (await this.tokenService.getPayload(tokenValue)).id;
-    return await this.memberRepository.findById(memberId);
+    const member = await this.tokenService.getPayload(tokenValue);
+    return await this.memberRepository.findById(member.id);
   }
 
   private getNameWithPrefix(nickname: string) {

--- a/BE/src/token/exception/token.exception.ts
+++ b/BE/src/token/exception/token.exception.ts
@@ -1,5 +1,8 @@
 import { HttpException } from '@nestjs/common';
-import { HttpInternalServerError } from '../../util/exception.util';
+import {
+  HttpGoneException,
+  HttpInternalServerError,
+} from '../../util/exception.util';
 
 class InvalidTokenException extends HttpException {
   constructor() {
@@ -7,9 +10,9 @@ class InvalidTokenException extends HttpException {
   }
 }
 
-class TokenExpiredException extends HttpException {
+class TokenExpiredException extends HttpGoneException {
   constructor() {
-    super('토큰이 만료되었습니다', 410);
+    super('토큰이 만료되었습니다', 'T1');
   }
 }
 

--- a/BE/src/token/exception/token.exception.ts
+++ b/BE/src/token/exception/token.exception.ts
@@ -2,17 +2,18 @@ import { HttpException } from '@nestjs/common';
 import {
   HttpGoneException,
   HttpInternalServerError,
+  HttpUnauthorizedException,
 } from '../../util/exception.util';
 
-class InvalidTokenException extends HttpException {
+class InvalidTokenException extends HttpUnauthorizedException {
   constructor() {
-    super('유효하지 않은 토큰입니다.', 401);
+    super('유효하지 않은 토큰입니다.', 'T1');
   }
 }
 
 class TokenExpiredException extends HttpGoneException {
   constructor() {
-    super('토큰이 만료되었습니다', 'T1');
+    super('토큰이 만료되었습니다', 'T2');
   }
 }
 

--- a/BE/src/token/service/token.service.ts
+++ b/BE/src/token/service/token.service.ts
@@ -98,16 +98,11 @@ export class TokenService {
   private async parseJwtError(message: string) {
     switch (message) {
       // 토큰에 대한 오류를 판단합니다.
-      case 'INVALID_TOKEN':
-      case 'TOKEN_IS_ARRAY':
-      case 'NO_USER':
-        throw new InvalidTokenException();
-
       case 'jwt expired':
         throw new TokenExpiredException();
 
       default:
-        throw new Error(message);
+        throw new InvalidTokenException();
     }
   }
 

--- a/BE/src/util/exception.util.ts
+++ b/BE/src/util/exception.util.ts
@@ -2,6 +2,7 @@ import { HttpException } from '@nestjs/common';
 import {
   BAD_REQUEST,
   FORBIDDEN,
+  GONE,
   INTERNAL_SERVER_ERROR,
   NOT_FOUND,
   UNAUTHORIZED,
@@ -37,6 +38,12 @@ class HttpNotFoundException extends HttpCustomException {
   }
 }
 
+class HttpGoneException extends HttpCustomException {
+  constructor(message: string, errorCode: string) {
+    super(message, errorCode, GONE);
+  }
+}
+
 class HttpInternalServerError extends HttpCustomException {
   constructor(message: string, errorCode: string) {
     super(message, errorCode, INTERNAL_SERVER_ERROR);
@@ -48,5 +55,6 @@ export {
   HttpUnauthorizedException,
   HttpForbiddenException,
   HttpNotFoundException,
+  HttpGoneException,
   HttpInternalServerError,
 };

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -41,6 +41,7 @@ export class VideoController {
     summary: '비디오 정보를 DB에 저장',
   })
   @ApiResponse(createApiResponseOption(201, '비디오 정보 저장 완료', null))
+  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
   async createVideo(
     @Req() req: Request,
     @Body() createVideoRequest: CreateVideoRequest,
@@ -61,6 +62,8 @@ export class VideoController {
       PreSignedUrlResponse,
     ),
   )
+  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
+  @ApiResponse(createApiResponseOption(500, 'V1', null))
   async getPreSignedUrl(@Req() req: Request) {
     return await this.videoService.getPreSignedUrl(req.user as Member);
   }
@@ -76,6 +79,7 @@ export class VideoController {
       SingleVideoResponse,
     ]),
   )
+  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
   async getAllVideo(@Req() req: Request) {
     return await this.videoService.getAllVideosByMemberId(req.user as Member);
   }
@@ -91,6 +95,10 @@ export class VideoController {
       VideoDetailResponse,
     ),
   )
+  @ApiResponse(createApiResponseOption(403, 'V2', null))
+  @ApiResponse(createApiResponseOption(404, 'V4', null))
+  @ApiResponse(createApiResponseOption(404, 'M1', null))
+  @ApiResponse(createApiResponseOption(500, 'V6', null))
   async getVideoDetailByHash(@Param('hash') hash: string) {
     return await this.videoService.getVideoDetailByHash(hash);
   }
@@ -108,6 +116,10 @@ export class VideoController {
       VideoDetailResponse,
     ),
   )
+  @ApiResponse(createApiResponseOption(403, 'V2', null))
+  @ApiResponse(createApiResponseOption(404, 'V3', null))
+  @ApiResponse(createApiResponseOption(404, 'V8', null))
+  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
   async getVideoDetail(@Param('videoId') videoId: number, @Req() req: Request) {
     return await this.videoService.getVideoDetail(videoId, req.user as Member);
   }
@@ -121,6 +133,12 @@ export class VideoController {
   @ApiResponse(
     createApiResponseOption(200, '비디오 상태 전환 완료', VideoHashResponse),
   )
+  @ApiResponse(createApiResponseOption(403, 'V2', null))
+  @ApiResponse(createApiResponseOption(404, 'V3', null))
+  @ApiResponse(createApiResponseOption(500, 'V5', null))
+  @ApiResponse(createApiResponseOption(500, 'V6', null))
+  @ApiResponse(createApiResponseOption(500, 'V7', null))
+  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
   async toggleVideoStatus(
     @Param('videoId') videoId: number,
     @Req() req: Request,
@@ -138,6 +156,9 @@ export class VideoController {
     summary: '비디오 삭제',
   })
   @ApiResponse(createApiResponseOption(204, '비디오 삭제 완료', null))
+  @ApiResponse(createApiResponseOption(403, 'V2', null))
+  @ApiResponse(createApiResponseOption(404, 'V3', null))
+  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
   async deleteVideo(
     @Param('videoId') videoId: number,
     @Req() req: Request,

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -62,8 +62,7 @@ export class VideoController {
       PreSignedUrlResponse,
     ),
   )
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
-  @ApiResponse(createApiResponseOption(500, 'V1', null))
+  @ApiResponse(createApiResponseOption(500, 'V1, SERVER', null))
   async getPreSignedUrl(@Req() req: Request) {
     return await this.videoService.getPreSignedUrl(req.user as Member);
   }
@@ -96,8 +95,7 @@ export class VideoController {
     ),
   )
   @ApiResponse(createApiResponseOption(403, 'V2', null))
-  @ApiResponse(createApiResponseOption(404, 'V4', null))
-  @ApiResponse(createApiResponseOption(404, 'M1', null))
+  @ApiResponse(createApiResponseOption(404, 'V4, M1', null))
   @ApiResponse(createApiResponseOption(500, 'V6', null))
   async getVideoDetailByHash(@Param('hash') hash: string) {
     return await this.videoService.getVideoDetailByHash(hash);
@@ -118,8 +116,7 @@ export class VideoController {
   )
   @ApiResponse(createApiResponseOption(403, 'V2', null))
   @ApiResponse(createApiResponseOption(404, 'V3', null))
-  @ApiResponse(createApiResponseOption(404, 'V8', null))
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
+  @ApiResponse(createApiResponseOption(500, 'V8, SERVER', null))
   async getVideoDetail(@Param('videoId') videoId: number, @Req() req: Request) {
     return await this.videoService.getVideoDetail(videoId, req.user as Member);
   }
@@ -135,10 +132,7 @@ export class VideoController {
   )
   @ApiResponse(createApiResponseOption(403, 'V2', null))
   @ApiResponse(createApiResponseOption(404, 'V3', null))
-  @ApiResponse(createApiResponseOption(500, 'V5', null))
-  @ApiResponse(createApiResponseOption(500, 'V6', null))
-  @ApiResponse(createApiResponseOption(500, 'V7', null))
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
+  @ApiResponse(createApiResponseOption(500, 'V5, V6, V7, SERVER', null))
   async toggleVideoStatus(
     @Param('videoId') videoId: number,
     @Req() req: Request,

--- a/BE/src/video/exception/video.exception.ts
+++ b/BE/src/video/exception/video.exception.ts
@@ -1,49 +1,53 @@
-import { HttpException } from '@nestjs/common';
+import {
+  HttpForbiddenException,
+  HttpInternalServerError,
+  HttpNotFoundException,
+} from 'src/util/exception.util';
 
-export class IDriveException extends HttpException {
+export class IDriveException extends HttpInternalServerError {
   constructor() {
-    super('IDrive 제공 API 처리 도중 에러가 발생하였습니다.', 500);
+    super('IDrive 제공 API 처리 도중 에러가 발생하였습니다.', 'V1');
   }
 }
 
-export class VideoAccessForbiddenException extends HttpException {
+export class VideoAccessForbiddenException extends HttpForbiddenException {
   constructor() {
-    super('해당 비디오에 접근 권한이 없습니다.', 403);
+    super('해당 비디오에 접근 권한이 없습니다.', 'V2');
   }
 }
 
-export class VideoNotFoundException extends HttpException {
+export class VideoNotFoundException extends HttpNotFoundException {
   constructor() {
-    super('존재하지 않는 비디오입니다.', 404);
+    super('존재하지 않는 비디오입니다.', 'V3');
   }
 }
 
-export class RedisSaveException extends HttpException {
+export class VideoOfWithdrawnMemberException extends HttpNotFoundException {
   constructor() {
-    super('Redis에 저장 중 오류가 발생하였습니다.', 500);
+    super('탈퇴한 회원의 비디오를 조회할 수 없습니다.', 'V4');
   }
 }
 
-export class RedisDeleteException extends HttpException {
+export class RedisDeleteException extends HttpInternalServerError {
   constructor() {
-    super('Redis에서 삭제 중 오류가 발생하였습니다.', 500);
+    super('Redis에서 비디오 정보 삭제 중 오류가 발생하였습니다.', 'V5');
   }
 }
 
-export class RedisRetrieveException extends HttpException {
+export class RedisRetrieveException extends HttpInternalServerError {
   constructor() {
-    super('Redis에서 정보를 가져오는 중 오류가 발생하였습니다.', 500);
+    super('Redis에서 비디오 정보를 가져오는 중 오류가 발생하였습니다.', 'V6');
   }
 }
 
-export class Md5HashException extends HttpException {
+export class RedisSaveException extends HttpInternalServerError {
   constructor() {
-    super('MD5 해시 생성 중 오류가 발생했습니다.', 500);
+    super('Redis에 비디오 정보 저장 중 오류가 발생하였습니다.', 'V7');
   }
 }
 
-export class VideoOfWithdrawnMemberException extends HttpException {
+export class Md5HashException extends HttpInternalServerError {
   constructor() {
-    super('탈퇴한 회원의 비디오를 조회할 수 없습니다.', 404);
+    super('MD5 해시 생성 중 오류가 발생했습니다.', 'V8');
   }
 }


### PR DESCRIPTION
[![NDD-298](https://badgen.net/badge/JIRA/NDD-298/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-298) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
회원 및 비디오 API에서 에러 발생 시 FE 측에 전달되는 에러의 HTTP 상태 코드와 메시지 뿐만 아니라 커스텀 코드도 전달하기 위함

# How
회원과 비디오 서비스의 에러에 다음과 같이 커스텀 코드 부여
1. 회원
- 회원을 찾을 수 없는 경우: M1

2. 토큰
- 유효하지 않는 토큰: T1
- 만료된 토큰: T2

3. 비디오
- IDrive API 사용 중 발생한 에러: V1
- 타인의 비디오에 접근하려 하는 경우: V2
- 존재하지 않는 비디오에 접근하려 하는 경우: V3
- 탈퇴한 회원의 비디오에 접근하려 하는 경우: V4
- Redis에서 비디오 정보 삭제 도중 발생한 에러: V5
- Redis에서 비디오 정보 조회 도중 발생한 에러: V6
- Redis에서 비디오 정보 저장 도중 발생한 에러: V7
- Md5 해시 생성 도중 발생한 에러: V8

# Result
아래 사진과 같이 상황에 맞게 HTTP 상태 코드, 메시지, 커스텀 에러 코드가 반환됨을 확인할 수 있음
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/b68aeb38-1700-4f0f-b12f-ff367eb4133c)


# Prize
에러 코드를 세분화 시켰기에 FE 측에서 에러 발생 시 커스텀 코드에 알맞은 클라이언트의 행동을 처리할 수 있음

[NDD-298]: https://milk717.atlassian.net/browse/NDD-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ