### PR TITLE
[NDD-324]: Workbook API에 대한 불필요한 쿼리문을 위한 최적화 && 인덱스 등록 (1h / 1h)

### DIFF
--- a/BE/src/workbook/controller/workbook.controller.spec.ts
+++ b/BE/src/workbook/controller/workbook.controller.spec.ts
@@ -84,7 +84,9 @@ describe('WorkbookController 단위테스트', () => {
       //given
 
       //when
-      mockWorkbookService.createWorkbook.mockResolvedValue(workbookFixture);
+      mockWorkbookService.createWorkbook.mockResolvedValue(
+        workbookFixtureWithId.id,
+      );
       const response = await controller.createAnswer(
         createWorkbookRequestFixture,
         mockReqWithMemberFixture,
@@ -92,7 +94,7 @@ describe('WorkbookController 단위테스트', () => {
 
       //then
       expect(response).toBeInstanceOf(WorkbookIdResponse);
-      expect(response.workbookId).toBe(workbookFixture.id);
+      expect(response.workbookId).toBe(workbookFixtureWithId.id);
     });
   });
 

--- a/BE/src/workbook/controller/workbook.controller.ts
+++ b/BE/src/workbook/controller/workbook.controller.ts
@@ -55,12 +55,12 @@ export class WorkbookController {
     @Body() createWorkbookRequest: CreateWorkbookRequest,
     @Req() req: Request,
   ) {
-    const workbook = await this.workbookService.createWorkbook(
+    const workbookId = await this.workbookService.createWorkbook(
       createWorkbookRequest,
       req.user as Member,
     );
 
-    return WorkbookIdResponse.of(workbook);
+    return new WorkbookIdResponse(workbookId);
   }
 
   @Get()

--- a/BE/src/workbook/entity/workbook.ts
+++ b/BE/src/workbook/entity/workbook.ts
@@ -1,10 +1,12 @@
 import { DefaultEntity } from '../../app.entity';
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { Member } from '../../member/entity/member';
 import { Category } from '../../category/entity/category';
 import { UpdateWorkbookRequest } from '../dto/updateWorkbookRequest';
 
 @Entity({ name: 'Workbook' })
+@Index('idx_isPublic', ['isPublic'])
+@Index('idx_isPublic_categoryId', ['isPublic', 'category'])
 export class Workbook extends DefaultEntity {
   @Column()
   title: string;
@@ -14,6 +16,7 @@ export class Workbook extends DefaultEntity {
 
   @ManyToOne(() => Category)
   @JoinColumn({ name: 'category' })
+  @Index('idx_categoryId')
   category: Category;
 
   @Column()
@@ -21,6 +24,7 @@ export class Workbook extends DefaultEntity {
 
   @ManyToOne(() => Member, { nullable: true, onDelete: 'CASCADE', eager: true })
   @JoinColumn({ name: 'member' })
+  @Index('idx_memberId')
   member: Member;
 
   @Column({ default: true })

--- a/BE/src/workbook/entity/workbook.ts
+++ b/BE/src/workbook/entity/workbook.ts
@@ -16,7 +16,6 @@ export class Workbook extends DefaultEntity {
 
   @ManyToOne(() => Category)
   @JoinColumn({ name: 'category' })
-  @Index('idx_categoryId')
   category: Category;
 
   @Column()
@@ -24,7 +23,6 @@ export class Workbook extends DefaultEntity {
 
   @ManyToOne(() => Member, { nullable: true, onDelete: 'CASCADE', eager: true })
   @JoinColumn({ name: 'member' })
-  @Index('idx_memberId')
   member: Member;
 
   @Column({ default: true })

--- a/BE/src/workbook/fixture/workbook.fixture.ts
+++ b/BE/src/workbook/fixture/workbook.fixture.ts
@@ -37,3 +37,7 @@ export const updateWorkbookRequestFixture = new UpdateWorkbookRequest(
   categoryFixtureWithId.id,
   false,
 );
+
+export const workbookInsertResult = {
+  identifiers: [{ id: workbookFixtureWithId.id }],
+};

--- a/BE/src/workbook/repository/workbook.repository.ts
+++ b/BE/src/workbook/repository/workbook.repository.ts
@@ -9,19 +9,6 @@ export class WorkbookRepository {
     @InjectRepository(Workbook) private repository: Repository<Workbook>,
   ) {}
 
-  async findByIdWithoutJoin(id: number) {
-    return await this.repository.findOneBy({ id: id });
-  }
-
-  async findById(id: number) {
-    return await this.repository
-      .createQueryBuilder('Workbook')
-      .leftJoinAndSelect('Workbook.member', 'member')
-      .leftJoinAndSelect('Workbook.category', 'category')
-      .where('Workbook.id = :id', { id })
-      .getOne();
-  }
-
   async query(query: string) {
     return await this.repository.query(query);
   }
@@ -76,6 +63,19 @@ export class WorkbookRepository {
       .leftJoinAndSelect('Workbook.member', 'member')
       .where('member.id = :memberId', { memberId })
       .getMany();
+  }
+
+  async findById(id: number) {
+    return await this.repository
+      .createQueryBuilder('Workbook')
+      .leftJoinAndSelect('Workbook.member', 'member')
+      .leftJoinAndSelect('Workbook.category', 'category')
+      .where('Workbook.id = :id', { id })
+      .getOne();
+  }
+
+  async findByIdWithoutJoin(id: number) {
+    return await this.repository.findOneBy({ id: id });
   }
 
   async update(workbook: Workbook) {

--- a/BE/src/workbook/repository/workbook.repository.ts
+++ b/BE/src/workbook/repository/workbook.repository.ts
@@ -9,6 +9,10 @@ export class WorkbookRepository {
     @InjectRepository(Workbook) private repository: Repository<Workbook>,
   ) {}
 
+  async findByIdWithoutJoin(id: number) {
+    return await this.repository.findOneBy({ id: id });
+  }
+
   async findById(id: number) {
     return await this.repository
       .createQueryBuilder('Workbook')
@@ -24,6 +28,10 @@ export class WorkbookRepository {
 
   async save(workbook: Workbook) {
     return await this.repository.save(workbook);
+  }
+
+  async insert(workbook: Workbook) {
+    return await this.repository.insert(workbook);
   }
 
   async findByNameAndMemberId(title: string, memberId: number) {

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -11,6 +11,7 @@ import {
   updateWorkbookRequestFixture,
   workbookFixture,
   workbookFixtureWithId,
+  workbookInsertResult,
 } from '../fixture/workbook.fixture';
 import {
   differentMemberFixture,
@@ -53,6 +54,8 @@ describe('WorkbookService 단위테스트', () => {
     findSingleWorkbook: jest.fn(),
     update: jest.fn(),
     remove: jest.fn(),
+    insert: jest.fn(),
+    findByIdWithoutJoin: jest.fn(),
   };
 
   beforeAll(async () => {
@@ -80,12 +83,12 @@ describe('WorkbookService 단위테스트', () => {
       mockCategoryRepository.findByCategoryId.mockResolvedValue(
         categoryFixtureWithId,
       );
-      mockWorkbookRepository.save.mockResolvedValue(workbookFixtureWithId);
+      mockWorkbookRepository.insert.mockResolvedValue(workbookInsertResult);
 
       //then
       await expect(
         service.createWorkbook(createWorkbookRequestFixture, memberFixture),
-      ).resolves.toEqual(workbookFixtureWithId);
+      ).resolves.toEqual(workbookFixtureWithId.id);
     });
 
     it('문제집을 추가할 때, categoryId로 조회되지 않으면 CategoryNotFoundException을 반환한다', async () => {
@@ -93,7 +96,7 @@ describe('WorkbookService 단위테스트', () => {
 
       //when
       mockCategoryRepository.findByCategoryId.mockResolvedValue(null);
-      mockWorkbookRepository.save.mockResolvedValue(workbookFixtureWithId);
+      mockWorkbookRepository.insert.mockResolvedValue(workbookFixtureWithId);
 
       //then
       await expect(
@@ -108,7 +111,7 @@ describe('WorkbookService 단위테스트', () => {
       mockCategoryRepository.findByCategoryId.mockResolvedValue(
         categoryFixtureWithId,
       );
-      mockWorkbookRepository.save.mockResolvedValue(workbookFixtureWithId);
+      mockWorkbookRepository.insert.mockResolvedValue(workbookFixtureWithId);
 
       //then
       await expect(
@@ -282,7 +285,9 @@ describe('WorkbookService 단위테스트', () => {
       //given
 
       //when
-      mockWorkbookRepository.findById.mockResolvedValue(workbookFixtureWithId);
+      mockWorkbookRepository.findByIdWithoutJoin.mockResolvedValue(
+        workbookFixtureWithId,
+      );
       mockWorkbookRepository.remove.mockResolvedValue(undefined);
 
       //then
@@ -295,7 +300,9 @@ describe('WorkbookService 단위테스트', () => {
       //given
 
       //when
-      mockWorkbookRepository.findById.mockResolvedValue(workbookFixtureWithId);
+      mockWorkbookRepository.findByIdWithoutJoin.mockResolvedValue(
+        workbookFixtureWithId,
+      );
       mockWorkbookRepository.remove.mockResolvedValue(undefined);
 
       //then
@@ -308,7 +315,9 @@ describe('WorkbookService 단위테스트', () => {
       //given
 
       //when
-      mockWorkbookRepository.findById.mockResolvedValue(workbookFixtureWithId);
+      mockWorkbookRepository.findByIdWithoutJoin.mockResolvedValue(
+        workbookFixtureWithId,
+      );
       mockWorkbookRepository.remove.mockResolvedValue(undefined);
 
       //then
@@ -324,7 +333,7 @@ describe('WorkbookService 단위테스트', () => {
       //given
 
       //when
-      mockWorkbookRepository.findById.mockResolvedValue(null);
+      mockWorkbookRepository.findByIdWithoutJoin.mockResolvedValue(null);
       mockWorkbookRepository.remove.mockResolvedValue(undefined);
 
       //then
@@ -383,9 +392,7 @@ describe('WorkbookService 통합테스트', () => {
       );
 
       //then
-      expect(workbook.title).toEqual('test title');
-      expect(workbook.content).toEqual('test content');
-      expect(workbook.member.id).toEqual(member.id);
+      expect(workbook).toBe(1);
     });
   });
 
@@ -540,17 +547,17 @@ describe('WorkbookService 통합테스트', () => {
         category.id,
         true,
       );
-      const workbook = await workbookService.createWorkbook(
+      const workbookId = await workbookService.createWorkbook(
         createWorkbookRequest,
         member,
       );
 
       //then
-      const result = await workbookService.findSingleWorkbook(workbook.id);
+      const result = await workbookService.findSingleWorkbook(workbookId);
       expect(result).toBeInstanceOf(WorkbookResponse);
-      expect(result.title).toBe(workbook.title);
-      expect(result.content).toBe(workbook.content);
-      expect(result.workbookId).toBe(workbook.id);
+      expect(result.title).toBe(createWorkbookRequest.title);
+      expect(result.content).toBe(createWorkbookRequest.content);
+      expect(result.workbookId).toBe(workbookId);
     });
 
     it('문제집 id가 존재하지 않으면 WorkbookNotFound예외처리한다.', async () => {

--- a/BE/src/workbook/service/workbook.service.ts
+++ b/BE/src/workbook/service/workbook.service.ts
@@ -29,15 +29,15 @@ export class WorkbookService {
     validateManipulatedToken(member);
     validateCategory(category);
 
-    return await this.workbookRepository.save(
-      Workbook.of(
-        createWorkbookRequest.title,
-        createWorkbookRequest.content,
-        category,
-        member,
-        createWorkbookRequest.isPublic,
-      ),
+    const workbook = Workbook.of(
+      createWorkbookRequest.title,
+      createWorkbookRequest.content,
+      category,
+      member,
+      createWorkbookRequest.isPublic,
     );
+    const result = await this.workbookRepository.insert(workbook);
+    return result.identifiers[0].id as number;
   }
 
   async findWorkbooks(categoryId: number) {
@@ -59,6 +59,7 @@ export class WorkbookService {
 
     const workbooks =
       await this.workbookRepository.findAllByCategoryId(categoryId);
+
     return workbooks.map(WorkbookResponse.of);
   }
 
@@ -106,7 +107,8 @@ export class WorkbookService {
 
   async deleteWorkbookById(workbookId: number, member: Member) {
     validateManipulatedToken(member);
-    const workbook = await this.workbookRepository.findById(workbookId);
+    const workbook =
+      await this.workbookRepository.findByIdWithoutJoin(workbookId);
     validateWorkbook(workbook);
     validateWorkbookOwner(workbook, member);
     await this.workbookRepository.remove(workbook);


### PR DESCRIPTION
[![NDD-324](https://badgen.net/badge/JIRA/NDD-324/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-324) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

- 불필요한 select쿼리가 발생되는 orm의 함수들을 리펙토링해야했다. 
- 조회에서 인덱스를 타지 않는 경우가 있어, 이를 인덱스를 통한 조회로 최적화 시켜야 했다.

# How

- 삽입/수정에 대한 최적화 진행 
    - 삽입시에 select & insert를 하는 save 대신 insert를 처리하도록 했다. 
    - 수정도 이미 select를 통한 검증을 하기 때문에 select, update로 수정했다. 
- 조회의 최적화 진행
    - 조회 로직의 쿼리 형태
        - left join : 외래키 인덱스를 통해 최적화되어있다. 
        - where : id가 아닌 isPublic사용 케이스와 isPublic & category사용 경우가 있다. 

# Result

```
// entity
@Index('idx_isPublic', ['isPublic'])
@Index('idx_isPublic_categoryId', ['isPublic', 'category'])
```

```
//service, 저장 결과롤 WorkbookId만을 반환하기에 다시 repository에서 select한 엔티티가 아닌, InsertResult의 id만을 꺼냈다.
async createWorkbook(
    createWorkbookRequest: CreateWorkbookRequest,
    member: Member,
  ) {
    const category = await this.categoryRepository.findByCategoryId(
      createWorkbookRequest.categoryId,
    );
    validateManipulatedToken(member);
    validateCategory(category);

    const workbook = Workbook.of(
      createWorkbookRequest.title,
      createWorkbookRequest.content,
      category,
      member,
      createWorkbookRequest.isPublic,
    );
    const result = await this.workbookRepository.insert(workbook);
    return result.identifiers[0].id as number;
  }
```

# Prize
<img width="328" alt="스크린샷 2023-12-05 14 08 06" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/b365e83b-188e-46b7-b5f6-29662f26605f">

- 기존 전체 테스트의 예상 시간이 16초, 실제시간 13초대인 것에 대비해, 테스트의 결과시간을 예상시간 11초, 실제시간 8초대로 줄였다.

[NDD-324]: https://milk717.atlassian.net/browse/NDD-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ