### PR TITLE
[NDD-337]: 면접용 닉네임 반환 API Controller 테스트 (1h / 1h)

### DIFF
--- a/BE/src/member/controller/member.controller.spec.ts
+++ b/BE/src/member/controller/member.controller.spec.ts
@@ -156,7 +156,7 @@ describe('MemberController 통합 테스트', () => {
   });
 
   describe('getMyInfo', () => {
-    it('쿠키를 가지고 회원 정보 반환 요청을 하면 200 상태 코드와 회원 정보가 반환된다.)', (done) => {
+    it('쿠키를 가지고 회원 정보 반환 요청을 하면 200 상태 코드와 회원 정보가 반환된다.', (done) => {
       authService.login(oauthRequestFixture).then((validToken) => {
         const agent = request.agent(app.getHttpServer());
         agent
@@ -172,7 +172,7 @@ describe('MemberController 통합 테스트', () => {
       });
     });
 
-    it('유효하지 않은 토큰으로 회원 정보 반환을 요청하면 401 상태코드가 반환된다.)', () => {
+    it('유효하지 않은 토큰으로 회원 정보 반환을 요청하면 401 상태코드가 반환된다.', () => {
       const agent = request.agent(app.getHttpServer());
       agent
         .get('/api/member')
@@ -182,7 +182,7 @@ describe('MemberController 통합 테스트', () => {
   });
 
   describe('getNameForInterview', () => {
-    it('쿠키를 가지고 면접 화면에 표출할 닉네임 반환 요청을 하면 200 상태 코드와 회원 닉네임이 들어간 채로 반환된다.)', (done) => {
+    it('쿠키를 가지고 면접 화면에 표출할 닉네임 반환 요청을 하면 200 상태 코드와 회원 닉네임이 들어간 채로 반환된다.', (done) => {
       authService.login(oauthRequestFixture).then((validToken) => {
         const agent = request.agent(app.getHttpServer());
         agent
@@ -198,7 +198,7 @@ describe('MemberController 통합 테스트', () => {
       });
     });
 
-    it('유효하지 않은 토큰으로 면접 화면에 표출할 닉네임 반환을 요청하면 401 상태코드가 반환된다.)', () => {
+    it('유효하지 않은 토큰으로 면접 화면에 표출할 닉네임 반환을 요청하면 401 상태코드가 반환된다.', () => {
       const agent = request.agent(app.getHttpServer());
       agent
         .get('/api/member/name')
@@ -206,7 +206,7 @@ describe('MemberController 통합 테스트', () => {
         .expect(401);
     });
 
-    it('만료된 토큰으로 면접 화면에 표출할 닉네임 반환을 요청하면 410 상태코드가 반환된다.)', async () => {
+    it('만료된 토큰으로 면접 화면에 표출할 닉네임 반환을 요청하면 410 상태코드가 반환된다.', async () => {
       const expirationTime = Math.floor(Date.now() / 1000) - 1;
       const expiredToken = await jwtService.signAsync(
         { id: memberFixture.id } as TokenPayload,

--- a/BE/src/member/dto/memberNicknameResponse.ts
+++ b/BE/src/member/dto/memberNicknameResponse.ts
@@ -3,7 +3,7 @@ import { createPropertyOption } from 'src/util/swagger.util';
 
 export class MemberNicknameResponse {
   @ApiProperty(createPropertyOption('foobar', '회원의 닉네임', String))
-  private nickname: string;
+  nickname: string;
 
   constructor(nickname: string) {
     this.nickname = nickname;

--- a/BE/src/member/exception/member.exception.ts
+++ b/BE/src/member/exception/member.exception.ts
@@ -2,6 +2,6 @@ import { HttpNotFoundException } from 'src/util/exception.util';
 
 export class MemberNotFoundException extends HttpNotFoundException {
   constructor() {
-    super('회원을 찾을 수 없습니다.', 'M1');
+    super('회원을 찾을 수 없습니다.', 'M01');
   }
 }

--- a/BE/src/member/repository/member.repository.ts
+++ b/BE/src/member/repository/member.repository.ts
@@ -20,4 +20,8 @@ export class MemberRepository {
   async findByEmail(email: string) {
     return await this.memberRepository.findOneBy({ email: email });
   }
+
+  async query(query: string) {
+    return await this.memberRepository.query(query);
+  }
 }

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -62,7 +62,7 @@ export class VideoController {
       PreSignedUrlResponse,
     ),
   )
-  @ApiResponse(createApiResponseOption(500, 'V1, SERVER', null))
+  @ApiResponse(createApiResponseOption(500, 'V01, SERVER', null))
   async getPreSignedUrl(@Req() req: Request) {
     return await this.videoService.getPreSignedUrl(req.user as Member);
   }
@@ -94,9 +94,9 @@ export class VideoController {
       VideoDetailResponse,
     ),
   )
-  @ApiResponse(createApiResponseOption(403, 'V2', null))
-  @ApiResponse(createApiResponseOption(404, 'V4, M1', null))
-  @ApiResponse(createApiResponseOption(500, 'V6', null))
+  @ApiResponse(createApiResponseOption(403, 'V02', null))
+  @ApiResponse(createApiResponseOption(404, 'V04, M01', null))
+  @ApiResponse(createApiResponseOption(500, 'V06', null))
   async getVideoDetailByHash(@Param('hash') hash: string) {
     return await this.videoService.getVideoDetailByHash(hash);
   }
@@ -114,9 +114,9 @@ export class VideoController {
       VideoDetailResponse,
     ),
   )
-  @ApiResponse(createApiResponseOption(403, 'V2', null))
-  @ApiResponse(createApiResponseOption(404, 'V3', null))
-  @ApiResponse(createApiResponseOption(500, 'V8, SERVER', null))
+  @ApiResponse(createApiResponseOption(403, 'V02', null))
+  @ApiResponse(createApiResponseOption(404, 'V03', null))
+  @ApiResponse(createApiResponseOption(500, 'V08, SERVER', null))
   async getVideoDetail(@Param('videoId') videoId: number, @Req() req: Request) {
     return await this.videoService.getVideoDetail(videoId, req.user as Member);
   }
@@ -130,9 +130,9 @@ export class VideoController {
   @ApiResponse(
     createApiResponseOption(200, '비디오 상태 전환 완료', VideoHashResponse),
   )
-  @ApiResponse(createApiResponseOption(403, 'V2', null))
-  @ApiResponse(createApiResponseOption(404, 'V3', null))
-  @ApiResponse(createApiResponseOption(500, 'V5, V6, V7, SERVER', null))
+  @ApiResponse(createApiResponseOption(403, 'V02', null))
+  @ApiResponse(createApiResponseOption(404, 'V03', null))
+  @ApiResponse(createApiResponseOption(500, 'V05, V06, V07, SERVER', null))
   async toggleVideoStatus(
     @Param('videoId') videoId: number,
     @Req() req: Request,
@@ -150,8 +150,8 @@ export class VideoController {
     summary: '비디오 삭제',
   })
   @ApiResponse(createApiResponseOption(204, '비디오 삭제 완료', null))
-  @ApiResponse(createApiResponseOption(403, 'V2', null))
-  @ApiResponse(createApiResponseOption(404, 'V3', null))
+  @ApiResponse(createApiResponseOption(403, 'V02', null))
+  @ApiResponse(createApiResponseOption(404, 'V03', null))
   @ApiResponse(createApiResponseOption(500, 'SERVER', null))
   async deleteVideo(
     @Param('videoId') videoId: number,

--- a/BE/src/video/exception/video.exception.ts
+++ b/BE/src/video/exception/video.exception.ts
@@ -6,48 +6,48 @@ import {
 
 export class IDriveException extends HttpInternalServerError {
   constructor() {
-    super('IDrive 제공 API 처리 도중 에러가 발생하였습니다.', 'V1');
+    super('IDrive 제공 API 처리 도중 에러가 발생하였습니다.', 'V01');
   }
 }
 
 export class VideoAccessForbiddenException extends HttpForbiddenException {
   constructor() {
-    super('해당 비디오에 접근 권한이 없습니다.', 'V2');
+    super('해당 비디오에 접근 권한이 없습니다.', 'V02');
   }
 }
 
 export class VideoNotFoundException extends HttpNotFoundException {
   constructor() {
-    super('존재하지 않는 비디오입니다.', 'V3');
+    super('존재하지 않는 비디오입니다.', 'V03');
   }
 }
 
 export class VideoOfWithdrawnMemberException extends HttpNotFoundException {
   constructor() {
-    super('탈퇴한 회원의 비디오를 조회할 수 없습니다.', 'V4');
+    super('탈퇴한 회원의 비디오를 조회할 수 없습니다.', 'V04');
   }
 }
 
 export class RedisDeleteException extends HttpInternalServerError {
   constructor() {
-    super('Redis에서 비디오 정보 삭제 중 오류가 발생하였습니다.', 'V5');
+    super('Redis에서 비디오 정보 삭제 중 오류가 발생하였습니다.', 'V05');
   }
 }
 
 export class RedisRetrieveException extends HttpInternalServerError {
   constructor() {
-    super('Redis에서 비디오 정보를 가져오는 중 오류가 발생하였습니다.', 'V6');
+    super('Redis에서 비디오 정보를 가져오는 중 오류가 발생하였습니다.', 'V06');
   }
 }
 
 export class RedisSaveException extends HttpInternalServerError {
   constructor() {
-    super('Redis에 비디오 정보 저장 중 오류가 발생하였습니다.', 'V7');
+    super('Redis에 비디오 정보 저장 중 오류가 발생하였습니다.', 'V07');
   }
 }
 
 export class Md5HashException extends HttpInternalServerError {
   constructor() {
-    super('MD5 해시 생성 중 오류가 발생했습니다.', 'V8');
+    super('MD5 해시 생성 중 오류가 발생했습니다.', 'V08');
   }
 }


### PR DESCRIPTION
[![NDD-337](https://badgen.net/badge/JIRA/NDD-337/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-337) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
면접용 닉네임을 반환하는 API에 대한 Member Controller 계층의 단위/통합 테스트를 진행하기 위함

# How
면접용 닉네임을 반환하는 API의 단위/통합 테스트 진행
- 올바른 요청에 대한 응답이 잘 이루어지는지
- 유효하지 않은 토큰에 대한 응답이 잘 이루어지는지
- 만료된 토큰에 대한 응답이 잘 이루어지는지

# Result
아래 사진과 같이 Video Controller 테스트가 모두 통과함을 확인할 수 있다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/cb75a014-cf39-436e-9373-3ea2a40655f8)

# Prize
면접용 닉네임을 반환하는 API가 요청 상태에 맞게 알맞은 응답을 하는지 확인할 수 있다.
또한 Member Controller의 전체적인 테스트를 완료하여, 예상되는 모든 상황에서 알맞은 응답을 클라이언트에게 넘겨줌을 확인할 수 있다.

[NDD-337]: https://milk717.atlassian.net/browse/NDD-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ