### PR TITLE
[NDD-339]: Member Service API 테스트 (1h / 1h)

### DIFF
--- a/BE/src/member/controller/member.controller.spec.ts
+++ b/BE/src/member/controller/member.controller.spec.ts
@@ -83,7 +83,7 @@ describe('MemberController 단위 테스트', () => {
   describe('getNameForInterview', () => {
     const nickname = 'fakeNickname';
 
-    it('면접 화면에 표출할 닉네임 반환 성공 시에는 MemberNicknameResponse 형태로 반환한다.', async () => {
+    it('면접 화면에 표출할 닉네임 반환 성공 시에는 MemberNicknameResponse 형식으로 반환한다.', async () => {
       // given
       const mockReq = mockReqWithMemberFixture;
 
@@ -207,7 +207,7 @@ describe('MemberController 통합 테스트', () => {
     });
 
     it('만료된 토큰으로 면접 화면에 표출할 닉네임 반환을 요청하면 410 상태코드가 반환된다.', async () => {
-      const expirationTime = Math.floor(Date.now() / 1000) - 1;
+      const expirationTime = -1;
       const expiredToken = await jwtService.signAsync(
         { id: memberFixture.id } as TokenPayload,
         {
@@ -226,6 +226,7 @@ describe('MemberController 통합 테스트', () => {
   afterEach(async () => {
     await memberRepository.query('delete from Member');
     await memberRepository.query('delete from Token');
+    await memberRepository.query('DELETE FROM sqlite_sequence'); // Auto Increment 초기화
   });
 
   afterAll(async () => await app.close());

--- a/BE/src/member/service/member.service.spec.ts
+++ b/BE/src/member/service/member.service.spec.ts
@@ -1,0 +1,117 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MemberService } from './member.service';
+import { MemberRepository } from '../repository/member.repository';
+import { TokenService } from 'src/token/service/token.service';
+import { MemberNicknameResponse } from '../dto/memberNicknameResponse';
+import { TokenPayload } from 'src/token/interface/token.interface';
+import { memberFixture } from '../fixture/member.fixture';
+import {
+  InvalidTokenException,
+  TokenExpiredException,
+} from 'src/token/exception/token.exception';
+
+describe('VideoService 단위 테스트', () => {
+  let memberService: MemberService;
+
+  const mockTokenService = {
+    getPayload: jest.fn(),
+  };
+
+  const mockMemberRepository = {
+    save: jest.fn(),
+    findById: jest.fn(),
+    findByEmail: jest.fn(),
+  };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MemberService, MemberRepository, TokenService],
+    })
+      .overrideProvider(TokenService)
+      .useValue(mockTokenService)
+      .overrideProvider(MemberRepository)
+      .useValue(mockMemberRepository)
+      .compile();
+
+    memberService = module.get<MemberService>(MemberService);
+  });
+
+  it('should be defined', () => {
+    expect(memberService).toBeDefined();
+  });
+
+  describe('getNameForInterview', () => {
+    it('면접 화면에 표출할 닉네임 반환 성공 시에는 MemberNicknameResponse 형태로 반환한다.', async () => {
+      // given
+      const member = memberFixture;
+      const req: any = {
+        cookies: {
+          accessToken: 'fakeAccessToken',
+        },
+      };
+
+      // when
+      mockTokenService.getPayload.mockResolvedValue({
+        id: member.id,
+      } as TokenPayload);
+      mockMemberRepository.findById.mockResolvedValue(member);
+
+      // then
+      const result = await memberService.getNameForInterview(req);
+
+      expect(result).toBeInstanceOf(MemberNicknameResponse);
+      expect(result.nickname).toContain(member.nickname);
+    });
+
+    it('면접 화면에 표출할 닉네임 반환 성공 시 비회원이라면 닉네임에 면접자를 포함하여 반환한다.', async () => {
+      // given
+      const req: any = {
+        cookies: {},
+      };
+
+      // when & then
+      const result = await memberService.getNameForInterview(req);
+
+      expect(result).toBeInstanceOf(MemberNicknameResponse);
+      expect(result.nickname).toContain('면접자');
+    });
+
+    it('면접 화면에 표출할 닉네임 반환 시 유효하지 않은 토큰으로 요청한다면 InvalidTokenException을 반환한다.', async () => {
+      // given
+      const req: any = {
+        cookies: {
+          accessToken: 'INVALID_TOKEN',
+        },
+      };
+
+      // when
+      mockTokenService.getPayload.mockRejectedValue(
+        new InvalidTokenException(),
+      );
+
+      //then
+      expect(memberService.getNameForInterview(req)).rejects.toThrow(
+        InvalidTokenException,
+      );
+    });
+
+    it('면접 화면에 표출할 닉네임 반환 시 만료된 토큰으로 요청한다면 TokenExpiredException을 반환한다.', async () => {
+      // given
+      const req: any = {
+        cookies: {
+          accessToken: 'EXPIRED_TOKEN',
+        },
+      };
+
+      // when
+      mockTokenService.getPayload.mockRejectedValue(
+        new TokenExpiredException(),
+      );
+
+      //then
+      expect(memberService.getNameForInterview(req)).rejects.toThrow(
+        TokenExpiredException,
+      );
+    });
+  });
+});

--- a/BE/src/member/service/member.service.spec.ts
+++ b/BE/src/member/service/member.service.spec.ts
@@ -4,13 +4,21 @@ import { MemberRepository } from '../repository/member.repository';
 import { TokenService } from 'src/token/service/token.service';
 import { MemberNicknameResponse } from '../dto/memberNicknameResponse';
 import { TokenPayload } from 'src/token/interface/token.interface';
-import { memberFixture } from '../fixture/member.fixture';
+import { memberFixture, oauthRequestFixture } from '../fixture/member.fixture';
 import {
   InvalidTokenException,
   TokenExpiredException,
 } from 'src/token/exception/token.exception';
+import { INestApplication } from '@nestjs/common';
+import { MemberModule } from '../member.module';
+import { Member } from '../entity/member';
+import { Token } from 'src/token/entity/token';
+import { addAppModules, createIntegrationTestModule } from 'src/util/test.util';
+import { AuthModule } from 'src/auth/auth.module';
+import { AuthService } from 'src/auth/service/auth.service';
+import { JwtService } from '@nestjs/jwt';
 
-describe('VideoService 단위 테스트', () => {
+describe('MemberService 단위 테스트', () => {
   let memberService: MemberService;
 
   const mockTokenService = {
@@ -41,7 +49,7 @@ describe('VideoService 단위 테스트', () => {
   });
 
   describe('getNameForInterview', () => {
-    it('면접 화면에 표출할 닉네임 반환 성공 시에는 MemberNicknameResponse 형태로 반환한다.', async () => {
+    it('면접 화면에 표출할 닉네임 반환 성공 시에는 MemberNicknameResponse 형식으로 반환한다.', async () => {
       // given
       const member = memberFixture;
       const req: any = {
@@ -113,5 +121,106 @@ describe('VideoService 단위 테스트', () => {
         TokenExpiredException,
       );
     });
+  });
+});
+
+describe('MemberService 통합 테스트', () => {
+  let app: INestApplication;
+  let memberService: MemberService;
+  let authService: AuthService;
+  let jwtService: JwtService;
+  let memberRepository: MemberRepository;
+
+  beforeAll(async () => {
+    const modules = [MemberModule, AuthModule];
+    const entities = [Member, Token];
+
+    const moduleFixture: TestingModule = await createIntegrationTestModule(
+      modules,
+      entities,
+    );
+
+    app = moduleFixture.createNestApplication();
+    addAppModules(app);
+    await app.init();
+
+    memberService = moduleFixture.get<MemberService>(MemberService);
+    authService = moduleFixture.get<AuthService>(AuthService);
+    jwtService = moduleFixture.get<JwtService>(JwtService);
+    memberRepository = moduleFixture.get<MemberRepository>(MemberRepository);
+  });
+
+  describe('getNameForInterview', () => {
+    it('면접 화면에 표출할 닉네임 반환 성공 시 MemberNicknameResponse 형식으로 반환된다.', async () => {
+      // given
+      const accessToken = await authService.login(oauthRequestFixture);
+      const req: any = {
+        cookies: {
+          accessToken,
+        },
+      };
+
+      // when
+      const result = await memberService.getNameForInterview(req);
+
+      // then
+      expect(result).toBeInstanceOf(MemberNicknameResponse);
+      expect(result.nickname).toContain(oauthRequestFixture.name);
+    });
+
+    it('면접 화면에 표출할 닉네임 반환 성공 시 비회원이라면 닉네임에 면접자를 포함하여 반환한다.', async () => {
+      // given
+      const req: any = {
+        cookies: {},
+      };
+
+      // when
+      const result = await memberService.getNameForInterview(req);
+
+      // then
+      expect(result).toBeInstanceOf(MemberNicknameResponse);
+      expect(result.nickname).toContain('면접자');
+    });
+
+    it('면접 화면에 표출할 닉네임 반환 시 유효하지 않은 토큰으로 요청한다면 InvalidTokenException을 반환한다.', async () => {
+      // given
+      const req: any = {
+        cookies: {
+          accessToken: 'INVALID_TOKEN',
+        },
+      };
+
+      // when & then
+      expect(memberService.getNameForInterview(req)).rejects.toThrow(
+        InvalidTokenException,
+      );
+    });
+
+    it('면접 화면에 표출할 닉네임 반환 시 만료된 토큰으로 요청한다면 TokenExpiredException을 반환한다.', async () => {
+      // given
+      const expirationTime = -1;
+      const expiredToken = await jwtService.signAsync(
+        { id: memberFixture.id } as TokenPayload,
+        {
+          expiresIn: expirationTime,
+        },
+      );
+      const req: any = {
+        cookies: {
+          accessToken: expiredToken,
+        },
+      };
+
+      // when & then
+      expect(memberService.getNameForInterview(req)).rejects.toThrow(
+        TokenExpiredException,
+      );
+    });
+  });
+
+  afterEach(async () => {
+    await memberRepository.query('delete from Member');
+    await memberRepository.query('delete from Token');
+    await memberRepository.query('DELETE FROM sqlite_sequence'); // Auto Increment 초기화
   });
 });


### PR DESCRIPTION
[![NDD-339](https://badgen.net/badge/JIRA/NDD-339/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-339) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
Member Service 계층에 대한 단위/통합 테스트를 진행하기 위함

# How
아래의 4가지 경우에 대한 Member Serivce 계층의 단위/통합 테스트 진행
1. 쿠키를 가진 회원의 면접 화면에 표출할 닉네임 반환 성공 시
2. 비회원의 면접 화면에 표출할 닉네임 반환 성공 시
3. 유효하지 않은 토큰으로 반환 요청 시
4. 만료된 토큰으로 반환 요청 시

추가적으로 만료된 토큰을 만드는 경우에는 만료 시간을 단순히 음수로 두면 이미 만료된 토큰을 발급 받을 수 있다고 한다.
```JavaScript
const expirationTime = -1;
const expiredToken = await jwtService.signAsync(
  { id: memberFixture.id } as TokenPayload,
  {
    expiresIn: expirationTime,
  },
);
const req: any = {
  cookies: {
    accessToken: expiredToken,
  },
};
```

# Result
아래와 같이 MemberService 테스트를 모두 통과함을 확인할 수 있다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/ddf74a58-2c8f-45c0-9699-29386700c478)


# Prize
테스트를 통해 Member Service가 요청과 내부 로직의 상황에 맞게 알맞은 응답을 하는지 확인할 수 있다.
또한 Member API의 전체적인 테스트를 완료하여, Member API가 예상되는 모든 상황에서 의도대로 작동함을 확인할 수 있다.

개인적으로도 테스트 코드를 반복적으로 짜다보니 어느덧 테스트에 익숙해질 수 있었다.

[NDD-339]: https://milk717.atlassian.net/browse/NDD-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ