### PR TITLE
[NDD-326]: Question API 리포지토리 로직 수정 && 인덱싱 확인 (1h / 1h)

### DIFF
--- a/BE/src/question/repository/question.repository.ts
+++ b/BE/src/question/repository/question.repository.ts
@@ -17,6 +17,11 @@ export class QuestionRepository {
     return await this.repository.save(question);
   }
 
+  async insert(question: Question) {
+    await this.repository.insert(question);
+    return question;
+  }
+
   async saveAll(questions: Question[]) {
     await this.repository.insert(questions);
   }

--- a/BE/src/question/service/question.service.spec.ts
+++ b/BE/src/question/service/question.service.spec.ts
@@ -46,6 +46,7 @@ describe('QuestionService', () => {
 
   const mockQuestionRepository = {
     save: jest.fn(),
+    insert: jest.fn(),
     saveAll: jest.fn(),
     findByWorkbookId: jest.fn(),
     findById: jest.fn(),
@@ -80,7 +81,7 @@ describe('QuestionService', () => {
 
       //when
       mockWorkbookRepository.findById.mockResolvedValue(workbookFixture);
-      mockQuestionRepository.save.mockResolvedValue(questionFixture);
+      mockQuestionRepository.insert.mockResolvedValue(questionFixture);
 
       //then
       await expect(

--- a/BE/src/question/service/question.service.ts
+++ b/BE/src/question/service/question.service.ts
@@ -35,7 +35,7 @@ export class QuestionService {
     validateWorkbook(workbook);
     validateWorkbookOwner(workbook, member);
 
-    const question = await this.questionRepository.save(
+    const question = await this.questionRepository.insert(
       Question.of(workbook, null, createQuestionRequest.content),
     );
 

--- a/BE/src/question/service/question.service.ts
+++ b/BE/src/question/service/question.service.ts
@@ -57,7 +57,6 @@ export class QuestionService {
         copyQuestionRequest.questionIds,
       )
     ).map((question) => this.createCopy(question, workbook));
-    console.log(questions);
     await this.questionRepository.saveAll(questions);
     return WorkbookIdResponse.of(workbook);
   }


### PR DESCRIPTION
[![NDD-326](https://badgen.net/badge/JIRA/NDD-326/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-326) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- DB의 로직 최적화 및 ORM에서 발생시키는 불필요한 쿼리를 줄였다.

# How

- 저장 로직에서 insert&select로 로직을 처리했다. 
- 기존의 save쿼리에서는 select & insert후 객체를 조회할 때 다시 select를 하는 번거로운 과정이 존재했다. 
- 이를 insert & select의 쿼리로 수정해 처리했다. 
```
async insert(question: Question) {
    await this.repository.insert(question);
    return question;
  }
```

- 인덱싱은, 조회의 left join이 외래키이고, 다른 파라미터 없이 id만를 조건으로 조회를 하기 때문에 인덱싱이 추가적으로 필요하지 않았다.

# Prize

<img width="341" alt="스크린샷 2023-12-05 16 39 53" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/9dc4dbf9-ce07-4647-9785-867033bbdfa5">

- 기존보다 테스트케이스가 5개 증가했지만, 실질적인 테스트 클리어 시간이 0.3초 단축되었다.

[NDD-326]: https://milk717.atlassian.net/browse/NDD-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ