### PR TITLE
[NDD-328]: Answer API 쿼리 기능 개선 && 인덱싱 추가 (1h / 1h)

### DIFF
--- a/BE/src/answer/repository/answer.repository.ts
+++ b/BE/src/answer/repository/answer.repository.ts
@@ -10,7 +10,8 @@ export class AnswerRepository {
   ) {}
 
   async save(answer: Answer) {
-    return await this.repository.save(answer);
+    await this.repository.insert(answer);
+    return answer;
   }
 
   async findById(id: number) {

--- a/BE/src/answer/service/answer.service.spec.ts
+++ b/BE/src/answer/service/answer.service.spec.ts
@@ -51,6 +51,8 @@ describe('AnswerService 단위 테스트', () => {
     findById: jest.fn(),
     findWithOriginById: jest.fn(),
     save: jest.fn(),
+    findOriginById: jest.fn(),
+    update: jest.fn(),
   };
 
   const mockWorkbookRepository = {
@@ -84,9 +86,7 @@ describe('AnswerService 단위 테스트', () => {
   describe('답변 추가', () => {
     it('질문에 답변을 추가한다.', async () => {
       //given
-      mockQuestionRepository.findWithOriginById.mockResolvedValue(
-        questionFixture,
-      );
+      mockQuestionRepository.findOriginById.mockResolvedValue(questionFixture);
 
       //when
       const answer = Answer.of('test', memberFixture, questionFixture);
@@ -100,7 +100,7 @@ describe('AnswerService 단위 테스트', () => {
 
     it('질문에 답변을 추가할 때 id로 질문을 확인할 수 없을 때 QuestionNotFoundException을 반환한다.', async () => {
       //given
-      mockQuestionRepository.findWithOriginById.mockRejectedValue(
+      mockQuestionRepository.findOriginById.mockRejectedValue(
         new QuestionNotFoundException(),
       );
 
@@ -121,7 +121,7 @@ describe('AnswerService 단위 테스트', () => {
 
       //when
       mockQuestionRepository.findById.mockResolvedValue(questionFixture);
-      mockQuestionRepository.save.mockResolvedValue(questionFixture);
+      mockQuestionRepository.update.mockResolvedValue(questionFixture);
       mockWorkbookRepository.findById.mockResolvedValue(workbookFixtureWithId);
       mockAnswerRepository.findById.mockResolvedValue(answerFixture);
 

--- a/BE/src/answer/service/answer.service.ts
+++ b/BE/src/answer/service/answer.service.ts
@@ -61,7 +61,7 @@ export class AnswerService {
     validateAnswer(answer);
 
     question.setDefaultAnswer(answer);
-    await this.questionRepository.save(question);
+    await this.questionRepository.update(question);
   }
 
   async deleteAnswer(id: number, member: Member) {

--- a/BE/src/answer/service/answer.service.ts
+++ b/BE/src/answer/service/answer.service.ts
@@ -13,6 +13,7 @@ import { validateQuestion } from '../../question/util/question.util';
 import { AnswerForbiddenException } from '../exception/answer.exception';
 import { WorkbookRepository } from '../../workbook/repository/workbook.repository';
 import { QuestionForbiddenException } from '../../question/exception/question.exception';
+import { validateWorkbook } from '../../workbook/util/workbook.util';
 
 @Injectable()
 export class AnswerService {
@@ -23,7 +24,7 @@ export class AnswerService {
   ) {}
 
   async addAnswer(createAnswerRequest: CreateAnswerRequest, member: Member) {
-    const question = await this.questionRepository.findWithOriginById(
+    const question = await this.questionRepository.findOriginById(
       createAnswerRequest.questionId,
     );
 
@@ -49,7 +50,7 @@ export class AnswerService {
     const workbook = await this.workbookRepository.findById(
       question.workbook.id,
     );
-
+    validateWorkbook(workbook);
     if (!workbook.isOwnedBy(member)) {
       throw new QuestionForbiddenException();
     }
@@ -80,7 +81,7 @@ export class AnswerService {
   async getAnswerList(questionId: number) {
     const question = await this.questionRepository.findById(questionId);
     const originalQuestion =
-      await this.questionRepository.findWithOriginById(questionId);
+      await this.questionRepository.findOriginById(questionId);
 
     validateQuestion(originalQuestion);
 

--- a/BE/src/question/repository/question.repository.ts
+++ b/BE/src/question/repository/question.repository.ts
@@ -54,6 +54,7 @@ export class QuestionRepository {
     return await this.repository
       .createQueryBuilder('Question')
       .leftJoinAndSelect('Question.origin', 'origin')
+      .leftJoinAndSelect('Question.defaultAnswer', 'defaultAnswer')
       .where('Question.id = :id', { id })
       .getOne();
   }

--- a/BE/src/question/repository/question.repository.ts
+++ b/BE/src/question/repository/question.repository.ts
@@ -50,12 +50,16 @@ export class QuestionRepository {
     return await this.repository.findOneBy({ id: questionId });
   }
 
-  async findWithOriginById(id: number): Promise<Question | null> {
-    const question = await this.repository
+  async findQuestionWithOriginById(id: number) {
+    return await this.repository
       .createQueryBuilder('Question')
       .leftJoinAndSelect('Question.origin', 'origin')
       .where('Question.id = :id', { id })
       .getOne();
+  }
+
+  async findOriginById(id: number): Promise<Question | null> {
+    const question = await this.findQuestionWithOriginById(id);
     return this.fetchOrigin(question);
   }
 

--- a/BE/src/question/repository/question.repository.ts
+++ b/BE/src/question/repository/question.repository.ts
@@ -59,6 +59,10 @@ export class QuestionRepository {
     return this.fetchOrigin(question);
   }
 
+  async update(question: Question) {
+    await this.repository.update({ id: question.id }, question);
+  }
+
   async remove(question: Question) {
     await this.repository.remove(question);
   }


### PR DESCRIPTION
[![NDD-328](https://badgen.net/badge/JIRA/NDD-328/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-328) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- Answer의 추가로직에서 save로 인해 불필요한 select쿼리가 나간다. 
- 질문을 가져오 대표질문이 있는지 조회하고, 있는지 다시 확인하는 과정에서 select 쿼리가 두 번 나가야 한다. 

# How

```
@Entity({ name: 'Answer' })
@Index('idx_createdAt', ['createdAt'])
export class Answer extends DefaultEntity {
...
}
```

```
//repository
async save(answer: Answer) {
    await this.repository.insert(answer);
    return answer;
  }

async findQuestionWithOriginById(id: number) {
    return await this.repository
      .createQueryBuilder('Question')
      .leftJoinAndSelect('Question.origin', 'origin')
      .leftJoinAndSelect('Question.defaultAnswer', 'defaultAnswer')
      .where('Question.id = :id', { id })
      .getOne();
  }
```

```
//service
async getAnswerList(id: number) {
    const question =
      await this.questionRepository.findQuestionWithOriginById(id);
    validateQuestion(question);
    const questionId = question.origin ? question.origin.id : question.id; 
    //원본을 fetch 해와서 해당 객체가 있으면 origin의 id로 답변 조회

    const answers = (
      await this.answerRepository.findAllByQuestionId(questionId)
    ).map((answer) => AnswerResponse.from(answer, answer.member));

    if (question.defaultAnswer) {
      return this.createAnswerResponsesWithDefaultAnswer(question, answers);
    }

    return answers;
  }
```

# Result

<img width="311" alt="스크린샷 2023-12-05 18 05 49" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/b8c07319-798e-4d5a-8549-abc5b09f2bf9">


# Prize

- 전체 테스트 0.1초 감소
- 현재 테스트에서는 많은 데이터를 사용하지 않는다(답변도 약 15~20개 정도 뿐이다)
- 해당 답변들에 createdAt으로 인덱싱했을 때 데이터가 많아질 수록 기댓값이 높아진다.

[NDD-328]: https://milk717.atlassian.net/browse/NDD-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ