### PR TITLE
[NDD-331]: 비디오/회원 API 쿼리 최적화 (3h / 3h)

### DIFF
--- a/BE/src/member/repository/member.repository.ts
+++ b/BE/src/member/repository/member.repository.ts
@@ -14,11 +14,11 @@ export class MemberRepository {
   }
 
   async findById(id: number) {
-    return await this.memberRepository.findOneBy({ id: id });
+    return await this.memberRepository.findOneBy({ id });
   }
 
   async findByEmail(email: string) {
-    return await this.memberRepository.findOneBy({ email: email });
+    return await this.memberRepository.findOneBy({ email });
   }
 
   async query(query: string) {

--- a/BE/src/video/entity/video.ts
+++ b/BE/src/video/entity/video.ts
@@ -1,5 +1,5 @@
 // video.entity.ts
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { DefaultEntity } from 'src/app.entity';
 import { Member } from 'src/member/entity/member';
 import { Question } from 'src/question/entity/question';
@@ -7,6 +7,8 @@ import { CreateVideoRequest } from '../dto/createVideoRequest';
 import { DEFAULT_THUMBNAIL } from 'src/constant/constant';
 
 @Entity({ name: 'Video' })
+@Index('idx_video_url', ['url'])
+// @Index('idx_video_createdAt', ['createdAt']) TODO: 추후 기능 구현 상황에 따라 인덱싱하기
 export class Video extends DefaultEntity {
   @Column({ nullable: true })
   memberId: number;

--- a/BE/src/video/repository/video.repository.ts
+++ b/BE/src/video/repository/video.repository.ts
@@ -23,11 +23,11 @@ export class VideoRepository {
   }
 
   async findById(id: number) {
-    return await this.videoRepository.findOneBy({ id: id });
+    return await this.videoRepository.findOneBy({ id: Number(id) });
   }
 
   async findByUrl(url: string) {
-    return await this.videoRepository.findOneBy({ url: url });
+    return await this.videoRepository.findOneBy({ url });
   }
 
   async toggleVideoStatus(videoId: number) {
@@ -35,7 +35,7 @@ export class VideoRepository {
       .createQueryBuilder()
       .update(Video)
       .set({ isPublic: () => 'NOT isPublic' })
-      .where('id = :id', { id: videoId })
+      .where('id = :id', { id: Number(videoId) })
       .execute();
   }
 


### PR DESCRIPTION
[![NDD-331](https://badgen.net/badge/JIRA/NDD-331/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-331) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
BE의 꽃, 테스트와 최적화 중 테스트를 어느 정도 마쳤기에 최적화를 진행해보았다.

1. 회원 API 최적화
회원 API 최적화를 위해 쿼리 분석을 진행했으나, 단순 조회 로직 밖에 없어 쿼리 최적화를 진행할 사항이 없었음

2. 비디오 API 최적화
- DB의 id의 형태와 똑같이 맞추기
조회 쿼리에서 Param으로 들어가는 요소가 형태가 맞지 않게 들어가는 경우가 있어 이를 알맞게 맞추기 위해 TypeORM 자체적으로 형변환을 진행하는 경우가 있다.
이를 방지하기 위해 코드적으로 형변환을 시켜 자체적인 형변환의 오버헤드를 줄이도록 하였다.

- 쿼리 최적화
조회 쿼리에서 PK, FK는 인덱싱이 되어 있기에, Where절이나 Order By 절에 쓰이는 KEY가 아닌 속성들을 인덱싱할 필요가 있었다.
그래서 인덱싱할 필요성이 있는 것이 Where절에 쓰인 url과 Order By 절에 쓰인 createdAt이었는데 결론적으로 url만 인덱싱의 필요성이 있었다.
왜냐하면 현재 DB 상태와 구현 기능들을 살펴보았을 때 createdAt에 대해 인덱싱을 진행해두어도 아래와 같이 Explain으로 살펴보았을 때 MySQL이 이를 사용하지 않기 때문이다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/d89fce73-5527-4754-a0e0-fba82f4b6e16)

더 자세한 내용과 그 외 쿼리 분석에 대한 내용은 아래 노션 문서 참조
https://www.notion.so/SQL-feaa8db6598d43f7b50cb05e032bc4ae

# How
DB 상의 형태와 똑같이 맞추기 위한 형변환은 아래와 같이 진행하였다.
```JavaScript
  async findById(id: number) {
    return await this.videoRepository.findOneBy({ id: Number(id) }); // 미리 number로 형변환
  }
...
  async toggleVideoStatus(videoId: number) {
    this.videoRepository
      .createQueryBuilder()
      .update(Video)
      .set({ isPublic: () => 'NOT isPublic' })
      .where('id = :id', { id: Number(videoId) }) // 미리 number로 형변환
      .execute();
  }
```

인덱싱은 아래와 같이 어노테이션으로 간단하게 진행하였다.
```JavaScript
@Index('idx_video_url', ['url'])
export class Video extends DefaultEntity {
  @Column({ nullable: true })
  memberId: number;
...
```
# Result
형변환이 잘 되어 넘어감을 확인할 수 있다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/a83286de-32d2-4a5e-845e-a2d8b7dc92ac)

인덱싱도 잘 진행되었음을 DDL을 통해 확인할 수 있다.
```SQL
CREATE TABLE `Video` (
  ...
  KEY `idx_video_url` (`url`),
  ...
  ) 
```

# Prize
아래 사진과 같이 url로 조회 시 인덱스를 잘 타는 것을 확인할 수 있다. 인덱싱을 하기 위해 쿼리 분석한 보람이 있었다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/d5916c56-8910-4748-9d72-647ef4ff6331)

아래 사진과 같이 테스트 시간도 감소하였음을 확인할 수 있다. 특히 Controller Test에서 실제로 API를 호출하는 E2E 테스트를 진행하는데 그래서 훨씬 시간이 많이 감소함을 확인할 수 있다.
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/205dc675-88e8-4e7f-bec5-4c946ff7869b)


# Reference
https://stackoverflow.com/questions/67392742/should-i-create-index-on-created-at-column-on-database

[NDD-331]: https://milk717.atlassian.net/browse/NDD-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ