### PR TITLE
[NDD-349] 모달과 헤더 겹침 문제 해결하고 zIndex 테마로 지정해서 관리 (0.5h / 1h)

### DIFF
--- a/FE/src/components/common/StartButton/StartButton.tsx
+++ b/FE/src/components/common/StartButton/StartButton.tsx
@@ -21,7 +21,7 @@ const InterviewStartButton: React.FC = () => {
             background: ${theme.gradient.linear.blue};
             box-shadow: ${theme.shadow.buttonLargeDefaultShadow};
             width: 100%;
-            z-index: 2;
+            z-index: ${theme.zIndex.contentOverlay.overlay5};
 
             &:hover {
               transform: translateY(0.25rem);

--- a/FE/src/components/foundation/CardCover/CardCover.tsx
+++ b/FE/src/components/foundation/CardCover/CardCover.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { HTMLElementTypes } from '@/types/utils';
+import { theme } from '@styles/theme';
 
 type CardCoverProps = {
   children: React.ReactNode;
@@ -26,7 +27,7 @@ const CardCover: React.FC<CardCoverProps> = ({
           bottom: 0;
           background-color: rgba(0, 0, 0, 0.3);
           border-radius: ${borderRadius};
-          z-index: 1;
+          z-index: ${theme.zIndex.contentOverlay.overlay1};
         }
       `}
       {...args}

--- a/FE/src/components/foundation/Menu/Menu.tsx
+++ b/FE/src/components/foundation/Menu/Menu.tsx
@@ -29,7 +29,7 @@ const Menu: React.FC<MenuProps> = ({
           width: 100vw;
           height: 100svh;
           background-color: ${backdropColor};
-          z-index: 99;
+          z-index: ${theme.zIndex.menu.backdrop};
         `}
       />
       <div
@@ -42,7 +42,7 @@ const Menu: React.FC<MenuProps> = ({
           padding: 0.25rem 0;
           background-color: ${theme.colors.surface.default};
           border-radius: 0.5rem;
-          z-index: 999;
+          z-index: ${theme.zIndex.menu.content};
         `}
         {...args}
       >

--- a/FE/src/components/foundation/Modal/ModalLayout.tsx
+++ b/FE/src/components/foundation/Modal/ModalLayout.tsx
@@ -24,7 +24,7 @@ const ModalLayout: React.FC<ModalLayoutProps> = ({
         align-items: center;
         top: 0;
         left: 0;
-        z-index: 100;
+        z-index: ${theme.zIndex.modal.backdrop};
         width: 100%;
         height: 100%;
         background-color: ${theme.colors.shadow.modalShadow};
@@ -36,7 +36,7 @@ const ModalLayout: React.FC<ModalLayoutProps> = ({
     >
       <Box
         css={css`
-          z-index: 101;
+          z-index: ${theme.zIndex.modal.content};
           background-color: ${theme.colors.text.white};
           height: auto;
           width: auto;

--- a/FE/src/components/interviewPage/InterviewHeader/InterviewHeader.tsx
+++ b/FE/src/components/interviewPage/InterviewHeader/InterviewHeader.tsx
@@ -23,7 +23,7 @@ const InterviewHeader: React.FC<InterviewHeaderProps> = ({ isRecording }) => {
         width: 100%;
         height: 3.125rem;
         background-color: ${theme.colors.surface.black100};
-        z-index: 10;
+        z-index: ${theme.zIndex.header.content};
       `}
     >
       <RecordStatus isRecording={isRecording} />

--- a/FE/src/components/interviewPage/InterviewMain/InterviewAnswer.tsx
+++ b/FE/src/components/interviewPage/InterviewMain/InterviewAnswer.tsx
@@ -11,20 +11,20 @@ const InterviewAnswer: React.FC<InterviewAnswerProps> = ({ answer }) => {
   return (
     <div
       css={css`
-        display: 'flex';
+        display: flex;
         justify-content: center;
         align-items: center;
         position: absolute;
         bottom: 0;
         left: 50%;
         transform: translateX(-50%);
-        z-index: 1;
+        z-index: ${theme.zIndex.contentOverlay.overlay5};
         width: 62.5rem;
         height: 11.5rem;
         background-color: ${theme.colors.surface.black100};
         color: ${theme.colors.text.white};
         opacity: 60%;
-        border-radius: 2rem 2rem 0rem 0rem;
+        border-radius: 2rem 2rem 0 0;
         padding: 1.25rem;
 
         @media (max-width: ${theme.breakpoints.laptop}) {

--- a/FE/src/components/interviewPage/InterviewMain/InterviewQuestion.tsx
+++ b/FE/src/components/interviewPage/InterviewMain/InterviewQuestion.tsx
@@ -16,7 +16,7 @@ const InterviewQuestion: React.FC<InterviewQuestionProps> = ({ question }) => {
         top: 3.125rem;
         left: 50%;
         transform: translateX(-50%);
-        z-index: 1;
+        z-index: ${theme.zIndex.contentOverlay.overlay5};
         width: 62.5rem;
         height: 5rem;
         background-color: ${theme.colors.surface.black100};

--- a/FE/src/components/interviewPage/InterviewPageLayout.tsx
+++ b/FE/src/components/interviewPage/InterviewPageLayout.tsx
@@ -1,5 +1,6 @@
 import Layout from '@/components/layout/Layout';
 import { css } from '@emotion/react';
+import { theme } from '@styles/theme';
 
 type InterviewPageLayoutProps = {
   children: React.ReactNode;
@@ -15,7 +16,7 @@ const InterviewPageLayout: React.FC<InterviewPageLayoutProps> = ({
           width: 100vw;
           height: 100vh;
           position: fixed;
-          z-index: -100;
+          z-index: ${theme.zIndex.bottom.default};
           background-color: black;
         `}
       />

--- a/FE/src/components/landingPage/GoogleLoginButton.tsx
+++ b/FE/src/components/landingPage/GoogleLoginButton.tsx
@@ -24,7 +24,7 @@ const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({ ...args }) => {
         border: 0.0625rem solid ${theme.colors.border.default};
         transition: transform 0.15s ease-in-out;
         background-color: ${theme.colors.surface.default};
-        z-index: 1;
+        z-index: ${theme.zIndex.contentOverlay.overlay5};
 
         &:hover {
           transform: translateY(-0.25rem);

--- a/FE/src/components/layout/Header/Header.tsx
+++ b/FE/src/components/layout/Header/Header.tsx
@@ -15,7 +15,7 @@ const Header: React.FC = () => {
         justify-content: space-between;
         align-items: center;
         padding: 1rem 1.5rem;
-        z-index: 999;
+        z-index: ${theme.zIndex.header.content};
         background-color: rgba(255, 255, 255, 0.5);
         backdrop-filter: blur(10px); /* 10px 블러 효과 */
       `}

--- a/FE/src/components/layout/Header/NavigationMenu.tsx
+++ b/FE/src/components/layout/Header/NavigationMenu.tsx
@@ -38,7 +38,6 @@ const NavigationMenu: React.FC<PropsWithChildren> = ({ children }) => {
           margin-top: -3rem;
           box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
           animation: ${dropDown} 300ms ease-out;
-          z-index: 999;
         `}
       >
         {children}

--- a/FE/src/components/myPage/Thumbnail.tsx
+++ b/FE/src/components/myPage/Thumbnail.tsx
@@ -61,7 +61,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({
             padding: 0.25rem;
             border-radius: 1rem;
             background-color: ${theme.colors.surface.default};
-            z-index: 1000;
+            z-index: ${theme.zIndex.contentOverlay.overlay5};
           `}
         >
           <Icon id="trash" width="20" height="20" />

--- a/FE/src/page/interviewSettingPage/VideoSettingPage.tsx
+++ b/FE/src/page/interviewSettingPage/VideoSettingPage.tsx
@@ -83,7 +83,7 @@ const VideoSettingPage: React.FC<VideoSettingPageProps> = ({
             position: absolute;
             top: 1rem;
             left: 1rem;
-            z-index: 1;
+            z-index: ${theme.zIndex.contentOverlay.overlay5};
             padding: 0.5rem;
             border-radius: 0.5rem;
             background-color: ${theme.colors.shadow.modalShadow};

--- a/FE/src/page/interviewSettingPage/index.tsx
+++ b/FE/src/page/interviewSettingPage/index.tsx
@@ -15,6 +15,7 @@ import { ProgressStepBar } from '@common/index';
 import StepPage from '@foundation/StepPages';
 import { InterviewSettingPageLayout } from '@components/interviewSettingPage';
 import ServiceTermsPage from './ServiceTermsPage';
+import { theme } from '@styles/theme';
 
 const FIRST_PAGE_INDEX = 0;
 const PREV_PAGE_INDEX = -1;
@@ -109,7 +110,7 @@ const InterviewSettingPage: React.FC = () => {
           width: 100%;
           background-color: rgba(255, 255, 255, 0.5);
           backdrop-filter: blur(10px); /* 10px 블러 효과 */
-          z-index: 10;
+          z-index: ${theme.zIndex.header.content};
         `}
       >
         <ProgressStepBar>

--- a/FE/src/styles/_zIndex.ts
+++ b/FE/src/styles/_zIndex.ts
@@ -1,0 +1,40 @@
+/**
+ * 아래 배열에서 위쪽에 위치한 요소일수록 화면 최상단에 배치되어야 합니다.
+ *
+ * ex) modal, toast, header가 동시에 겹칠 경우 모달이 가장 상단에 떠야 합니다.
+ */
+export const zIndex = {
+  modal: {
+    content: 10000,
+    backdrop: 9999,
+  },
+  toast: {
+    content: 999,
+  },
+  menu: {
+    content: 100,
+    backdrop: 99,
+  },
+  /**
+   * 헤더 메뉴 오픈시 backdrop 메뉴를 사용하고 있음
+   */
+  header: {
+    content: 10,
+  },
+  /**
+   * 겹치는 요소의 오버레이에 사용됩니다.
+   * 오버레이 요소간에도 겹치는 부분이 있어 1 ~ 5까지 범위로 설정했습니다.
+   *
+   * ex) 비디오 태그 위에 녹화중 컴포넌트, 인터뷰 페이지의 질문창
+   */
+  contentOverlay: {
+    overlay5: 5,
+    overlay4: 4,
+    overlay3: 3,
+    overlay2: 2,
+    overlay1: 1,
+  },
+  bottom: {
+    default: -1,
+  },
+};

--- a/FE/src/styles/theme.ts
+++ b/FE/src/styles/theme.ts
@@ -3,8 +3,16 @@ import { typography } from './_typography';
 import { shadow } from '@styles/_shadow';
 import { gradient } from '@styles/_gradient';
 import { breakpoints } from '@styles/_breakpoints';
+import { zIndex } from '@styles/_zIndex';
 
-export const theme = { colors, typography, shadow, gradient, breakpoints };
+export const theme = {
+  colors,
+  typography,
+  shadow,
+  gradient,
+  breakpoints,
+  zIndex,
+};
 export type ThemeType = typeof theme;
 
 /*


### PR DESCRIPTION
[![NDD-349](https://badgen.net/badge/JIRA/NDD-349/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-349) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

![image](https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/1115c684-e4ac-4cf1-8f3a-d1e021f598eb)

z-index 문제로 인해 위와 같은 현상이 발생해서 해결했습니다.
추가로 z-index 종류가 늘어남에 따라 이로 인해 발생하는 이슈가 많아져서 zIndex를 테마로 관리하도록 분리했습니다.

# How

아래와 같이 z-index를 테마로 관리합니다.
모든 z-index 종류를 한곳에서 볼 수 있어서 관리가 용이합니다.
앞으로 z-index를 추가할 일이 있을 때는 꼭 테마에 추가한 후 사용하도록 합시다!

```ts
/**
 * 아래 배열에서 위쪽에 위치한 요소일수록 화면 최상단에 배치되어야 합니다.
 *
 * ex) modal, toast, header가 동시에 겹칠 경우 모달이 가장 상단에 떠야 합니다.
 */
export const zIndex = {
  modal: {
    content: 10000,
    backdrop: 9999,
  },
  toast: {
    content: 999,
  },
  menu: {
    content: 100,
    backdrop: 99,
  },
  /**
   * 헤더 메뉴 오픈시 backdrop 메뉴를 사용하고 있음
   */
  header: {
    content: 10,
  },
  /**
   * 겹치는 요소의 오버레이에 사용됩니다.
   * 오버레이 요소간에도 겹치는 부분이 있어 1 ~ 5까지 범위로 설정했습니다.
   *
   * ex) 비디오 태그 위에 녹화중 컴포넌트, 인터뷰 페이지의 질문창
   */
  contentOverlay: {
    overlay5: 5,
    overlay4: 4,
    overlay3: 3,
    overlay2: 2,
    overlay1: 1,
  },
  bottom: {
    default: -1,
  },
};
```

[NDD-349]: https://milk717.atlassian.net/browse/NDD-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ