### PR TITLE
[NDD-347]: accessToken strategy를 사용하는 경우 만료된 토큰에 대한 확인이 불가능한 문제 해결 (3h / 2h)

### DIFF
--- a/BE/src/answer/answer.module.ts
+++ b/BE/src/answer/answer.module.ts
@@ -14,6 +14,7 @@ import { Category } from '../category/entity/category';
 import { Workbook } from '../workbook/entity/workbook';
 import { WorkbookRepository } from '../workbook/repository/workbook.repository';
 import { WorkbookModule } from '../workbook/workbook.module';
+import { TokenModule } from 'src/token/token.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { WorkbookModule } from '../workbook/workbook.module';
     QuestionModule,
     CategoryModule,
     WorkbookModule,
+    TokenModule,
   ],
   providers: [
     AnswerRepository,

--- a/BE/src/answer/controller/answer.controller.ts
+++ b/BE/src/answer/controller/answer.controller.ts
@@ -24,6 +24,7 @@ import { createApiResponseOption } from '../../util/swagger.util';
 import { Member } from '../../member/entity/member';
 import { AnswerResponse } from '../dto/answerResponse';
 import { DefaultAnswerRequest } from '../dto/defaultAnswerRequest';
+import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
 
 @ApiTags('answer')
 @Controller('/api/answer')
@@ -31,7 +32,7 @@ export class AnswerController {
   constructor(private answerService: AnswerService) {}
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiBody({ type: CreateAnswerRequest })
   @ApiOperation({
@@ -53,7 +54,7 @@ export class AnswerController {
   }
 
   @Post('default')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiBody({ type: DefaultAnswerRequest })
   @ApiOperation({
@@ -88,7 +89,7 @@ export class AnswerController {
   }
 
   @Delete(':answerId')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiOperation({
     summary: '답변 삭제',

--- a/BE/src/answer/controller/answer.controller.ts
+++ b/BE/src/answer/controller/answer.controller.ts
@@ -19,7 +19,6 @@ import {
 import { AnswerService } from '../service/answer.service';
 import { CreateAnswerRequest } from '../dto/createAnswerRequest';
 import { Request, Response } from 'express';
-import { AuthGuard } from '@nestjs/passport';
 import { createApiResponseOption } from '../../util/swagger.util';
 import { Member } from '../../member/entity/member';
 import { AnswerResponse } from '../dto/answerResponse';

--- a/BE/src/auth/controller/auth.controller.ts
+++ b/BE/src/auth/controller/auth.controller.ts
@@ -17,6 +17,7 @@ import {
   createApiResponseOption,
   createApiResponseOptionWithHeaders,
 } from 'src/util/swagger.util';
+import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
 
 @Controller('/api/auth')
 @ApiTags('auth')
@@ -61,7 +62,7 @@ export class AuthController {
   }
 
   @Delete('logout')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiResponse(
     createApiResponseOption(
       200,
@@ -75,7 +76,7 @@ export class AuthController {
   }
 
   @Patch('reissue')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiResponse(
     createApiResponseOptionWithHeaders(
       200,

--- a/BE/src/member/controller/member.controller.ts
+++ b/BE/src/member/controller/member.controller.ts
@@ -1,5 +1,4 @@
 import { Controller, Get, Req, UseGuards } from '@nestjs/common';
-import { AuthGuard } from '@nestjs/passport';
 import { Request } from 'express';
 import { MemberResponse } from '../dto/memberResponse';
 import {
@@ -13,6 +12,7 @@ import { createApiResponseOption } from 'src/util/swagger.util';
 import { MemberService } from '../service/member.service';
 import { validateManipulatedToken } from 'src/util/token.util';
 import { MemberNicknameResponse } from '../dto/memberNicknameResponse';
+import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
 
 @Controller('/api/member')
 @ApiTags('member')
@@ -20,7 +20,7 @@ export class MemberController {
   constructor(private memberService: MemberService) {}
 
   @Get()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth() // 문서 상에 자물쇠 아이콘을 표시하여 쿠키가 필요하다는 것을 나타냄
   @ApiOperation({
     summary: '회원 정보를 반환하는 메서드',
@@ -39,7 +39,6 @@ export class MemberController {
   }
 
   @Get('/name')
-  @ApiCookieAuth()
   @ApiOperation({
     summary: '면접 화면에 표출할 이름을 반환하는 메서드',
   })

--- a/BE/src/question/controller/question.controller.ts
+++ b/BE/src/question/controller/question.controller.ts
@@ -12,7 +12,6 @@ import {
 import { QuestionService } from '../service/question.service';
 import { CreateQuestionRequest } from '../dto/createQuestionRequest';
 import { Request, Response } from 'express';
-import { AuthGuard } from '@nestjs/passport';
 import {
   ApiBody,
   ApiCookieAuth,
@@ -25,6 +24,7 @@ import { QuestionResponse } from '../dto/questionResponse';
 import { Member } from '../../member/entity/member';
 import { CopyQuestionRequest } from '../dto/copyQuestionRequest';
 import { WorkbookIdResponse } from '../../workbook/dto/workbookIdResponse';
+import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
 
 @ApiTags('question')
 @Controller('/api/question')
@@ -32,7 +32,7 @@ export class QuestionController {
   constructor(private questionService: QuestionService) {}
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiBody({ type: CreateQuestionRequest })
   @ApiOperation({
@@ -57,7 +57,7 @@ export class QuestionController {
   }
 
   @Post('/copy')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiBody({ type: CopyQuestionRequest })
   @ApiOperation({
@@ -95,7 +95,7 @@ export class QuestionController {
   }
 
   @Delete(':questionId')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiOperation({
     summary: '질문 삭제',

--- a/BE/src/token/guard/token.hard.guard.ts
+++ b/BE/src/token/guard/token.hard.guard.ts
@@ -2,14 +2,10 @@ import { ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { TokenService } from '../service/token.service';
 import { getTokenValue } from 'src/util/token.util';
-import { MemberRepository } from 'src/member/repository/member.repository';
 
 @Injectable()
 export class TokenHardGuard extends AuthGuard('jwt') {
-  constructor(
-    private tokenService: TokenService,
-    private memberRepository: MemberRepository,
-  ) {
+  constructor(private tokenService: TokenService) {
     super();
   }
 
@@ -26,7 +22,6 @@ export class TokenHardGuard extends AuthGuard('jwt') {
   }
 
   private async validateToken(token: string) {
-    const payload = await this.tokenService.getPayload(token);
-    return this.memberRepository.findById(payload.id);
+    return this.tokenService.findMemberByToken(token, true);
   }
 }

--- a/BE/src/token/guard/token.hard.guard.ts
+++ b/BE/src/token/guard/token.hard.guard.ts
@@ -1,0 +1,32 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { TokenService } from '../service/token.service';
+import { getTokenValue } from 'src/util/token.util';
+import { MemberRepository } from 'src/member/repository/member.repository';
+
+@Injectable()
+export class TokenHardGuard extends AuthGuard('jwt') {
+  constructor(
+    private tokenService: TokenService,
+    private memberRepository: MemberRepository,
+  ) {
+    super();
+  }
+
+  async canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+    const token = getTokenValue(request);
+
+    try {
+      request.user = await this.validateToken(token);
+      return true;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  private async validateToken(token: string) {
+    const payload = await this.tokenService.getPayload(token);
+    return this.memberRepository.findById(payload.id);
+  }
+}

--- a/BE/src/token/service/token.service.ts
+++ b/BE/src/token/service/token.service.ts
@@ -58,12 +58,17 @@ export class TokenService {
     }
   }
 
-  async findMemberByToken(singleToken: string) {
+  async findMemberByToken(
+    singleToken: string,
+    throwException: boolean = false,
+  ) {
     try {
-      return await this.memberRepository.findById(
-        (await this.getPayload(singleToken)).id,
-      );
+      const payload = await this.getPayload(singleToken);
+      const memberId = payload.id;
+
+      return await this.memberRepository.findById(memberId);
     } catch (error) {
+      if (throwException) throw error;
       return null;
     }
   }

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -13,7 +13,6 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { VideoService } from '../service/video.service';
-import { AuthGuard } from '@nestjs/passport';
 import { Request, Response } from 'express';
 import { Member } from 'src/member/entity/member';
 import { CreateVideoRequest } from '../dto/createVideoRequest';

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -32,6 +32,7 @@ import { SingleVideoResponse } from '../dto/singleVideoResponse';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { UPLOAD_UTIL } from '../../util/encoder.util';
 import { UploadVideoRequest } from '../dto/uploadVideoRequest';
+import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
 
 @Controller('/api/video')
 @ApiTags('video')
@@ -39,7 +40,7 @@ export class VideoController {
   constructor(private videoService: VideoService) {}
 
   @Post('upload')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiBody({ type: UploadVideoRequest })
   @ApiOperation({
@@ -67,7 +68,7 @@ export class VideoController {
   }
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiBody({ type: CreateVideoRequest })
   @ApiOperation({
@@ -83,7 +84,7 @@ export class VideoController {
   }
 
   @Post('/pre-signed')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiOperation({
     summary: 'Pre-Signed URL을 발급',
@@ -101,7 +102,7 @@ export class VideoController {
   }
 
   @Get('/all')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiOperation({
     summary: '자신의 모든 비디오 정보를 반환',
@@ -135,7 +136,7 @@ export class VideoController {
   }
 
   @Get(':videoId')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiOperation({
     summary: '비디오 상세 정보를 반환',
@@ -155,7 +156,7 @@ export class VideoController {
   }
 
   @Patch(':videoId')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiOperation({
     summary: '비디오 공개/비공개 상태를 전환',
@@ -177,7 +178,7 @@ export class VideoController {
   }
 
   @Delete(':videoId')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiOperation({
     summary: '비디오 삭제',

--- a/BE/src/video/video.module.ts
+++ b/BE/src/video/video.module.ts
@@ -8,9 +8,10 @@ import { QuestionRepository } from 'src/question/repository/question.repository'
 import { Question } from 'src/question/entity/question';
 import { Member } from 'src/member/entity/member';
 import { MemberRepository } from 'src/member/repository/member.repository';
+import { TokenModule } from 'src/token/token.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Video, Question, Member])],
+  imports: [TypeOrmModule.forFeature([Video, Question, Member]), TokenModule],
   controllers: [VideoController],
   providers: [
     VideoService,

--- a/BE/src/workbook/controller/workbook.controller.ts
+++ b/BE/src/workbook/controller/workbook.controller.ts
@@ -12,7 +12,6 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { WorkbookService } from '../service/workbook.service';
-import { AuthGuard } from '@nestjs/passport';
 import {
   ApiBody,
   ApiCookieAuth,

--- a/BE/src/workbook/controller/workbook.controller.ts
+++ b/BE/src/workbook/controller/workbook.controller.ts
@@ -31,6 +31,7 @@ import { OptionalGuard } from '../../util/decorator.util';
 import { TokenSoftGuard } from '../../token/guard/token.soft.guard';
 import { isEmpty } from 'class-validator';
 import { UpdateWorkbookRequest } from '../dto/updateWorkbookRequest';
+import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
 
 @ApiTags('workbook')
 @Controller('/api/workbook')
@@ -38,7 +39,7 @@ export class WorkbookController {
   constructor(private workbookService: WorkbookService) {}
 
   @Post()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiBody({ type: CreateWorkbookRequest })
   @ApiOperation({
@@ -111,7 +112,7 @@ export class WorkbookController {
   }
 
   @Patch()
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiBody({ type: UpdateWorkbookRequest })
   @ApiOperation({
@@ -134,7 +135,7 @@ export class WorkbookController {
   }
 
   @Delete('/:workbookId')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(TokenHardGuard)
   @ApiCookieAuth()
   @ApiOperation({
     summary: '문제집 삭제',


### PR DESCRIPTION
[![NDD-347](https://badgen.net/badge/JIRA/NDD-347/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-347) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
이전에 사용하던 AccessToken Strategy를 사용하는 경우에 만료된 토큰이던 유효하지 않은 토큰이던 401 Unauthorized로 통합해서 에러를 던져주었다. 이는 JWT Strategy의 생성자 자체에서 verify를 진행하기에 원하는 대로 커스텀 에러를 던질 수 없게 구성이 되어있기 때문인데, 이를 해결하기 위해서 TokenHardGuard라는 토큰에 대한 검증 후 유효한 토큰이라면 회원을 반환하고, 그렇지 않는 경우에는 알맞게 에러 핸들링을 진행하는 새로운 Guard를 만들 필요성이 있었다.

계속해서 Answer, Video Controller 관련 테스트만 실패하여서 무엇인지 문제인지 코드를 한참 뜯어보느라 시간을 1시간 정도 더 쓴 것 같다. 단순하게 각 controller의 TokenHardGuard에서 tokenService 사용을 위해 각 module에 tokenModule을 import 하지 않아 발생한 문제였다.

# How
기존에 구현해두셨던 TokenSoftGuard와 기능이 많이 유사하기에 이를 기반으로 작업을 진행했다.
처음에 getPayload로 토큰에서 payload를 불러온 후 그 내부에 저장된 id를 사용해 memberRepository에서 조회하도록 구현했으나, 이미 tokenService에 이와 유사한 기능을 하는 findMemberByToken이라는 메서드가 존재하여 이를 사용하도록 리팩터링을 진행하였다.
그리고 컨트롤러들에서 TokenHardGuard를 사용하도록 변경하였고, 이후 테스트 통과를 위해 관련 Module들에 의존성을 추가해주었다.

# Result
```JavaScript
@Injectable()
export class TokenHardGuard extends AuthGuard('jwt') {
  constructor(private tokenService: TokenService) {
    super();
  }

  async canActivate(context: ExecutionContext) {
    const request = context.switchToHttp().getRequest();
    const token = getTokenValue(request);

    try {
      request.user = await this.validateToken(token);
      return true;
    } catch (error) {
      throw error;
    }
  }

  private async validateToken(token: string) {
    return this.tokenService.findMemberByToken(token, true);
  }
}
```
기존에 존재하던 TokenSoftGuard와 거의 유사한 코드이다. 다만 다른 점은 Soft의 경우에는 user를 null로 설정하고 반환하며 Guard를 통과시켰지만, 여기서는 에러를 catch하면 바로 throw하여 Guard를 통과하지 못하도록 구현하였다.

그리고 findMemberByToken을 아래와 같이 Exception을 처리할 것인지 아닌지 분기하여 Soft와 Hard에서 모두 하나의 메서드로 처리할 수 있도록 구현하였다.
```JavaScript
async findMemberByToken(
  singleToken: string,
  throwException: boolean = false,
) {
  try {
    const payload = await this.getPayload(singleToken);
    const memberId = payload.id;

    return await this.memberRepository.findById(memberId);
  } catch (error) {
    if (throwException) throw error;
    return null;
  }
}
``` 

# Prize
이제 토큰의 만료나 유효하지 않는 경우에 알맞은 커스텀 에러가 반환되기에 클라이언트 측에서 어떤 문제로 서비스 이용이 거부되었는지 확실히 할 수 있게 되었다.

[NDD-347]: https://milk717.atlassian.net/browse/NDD-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ