### PR TITLE
[NDD-350] QuestionSelectionBox에서 사이드바 반응형 대응 (1.5 / 2h)

### DIFF
--- a/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.styles.ts
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.styles.ts
@@ -1,4 +1,6 @@
-import { keyframes } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
+import { theme } from '@styles/theme';
+import styled from '@emotion/styled';
 
 export const hideSidebar = keyframes`
   from {
@@ -16,4 +18,31 @@ export const showSidebar = keyframes`
   to {
     flex: 0 0 15rem;
   }
+`;
+
+export const QuestionSelectionBoxSidebarAreaDiv = styled.div<{
+  isSidebarOpen: boolean;
+  isTabletWidth: boolean;
+}>`
+  display: flex;
+  flex-direction: column;
+  row-gap: 2rem;
+  padding: 1.5rem 0;
+  border-radius: 1rem 0 0 1rem;
+  background-color: ${theme.colors.surface.default};
+  overflow-y: auto;
+  flex: 1 1 15rem;
+  animation: ${(props) =>
+    props.isSidebarOpen && props.isTabletWidth
+      ? css`
+          ${hideSidebar} 0.3s ease-in-out forwards
+        `
+      : css`
+          ${showSidebar} 0.3s ease-in-out forwards
+        `}}
+`;
+
+export const QuestionSelectionBoxTabPanelAreaDiv = styled.div`
+  flex: 1 1 calc(100% - 15rem);
+  overflow-x: hidden;
 `;

--- a/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.styles.ts
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.styles.ts
@@ -1,0 +1,19 @@
+import { keyframes } from '@emotion/react';
+
+export const hideSidebar = keyframes`
+  from {
+    flex: 0 0 15rem;
+  }
+  to {
+    flex: 0 0 0;
+  }
+`;
+
+export const showSidebar = keyframes`
+  from {
+    flex: 0 0 0;
+  }
+  to {
+    flex: 0 0 15rem;
+  }
+`;

--- a/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.tsx
@@ -24,7 +24,7 @@ const QuestionSelectionBox = () => {
     setModalState,
   ] = useRecoilState(QuestionAnswerSelectionModal);
 
-  const [isSideBarOpen, setIsSideBarOpen] = useState(false);
+  const [isSideBarOpen, setIsSideBarOpen] = useState(true);
 
   if (!workbookListData) return;
   return (

--- a/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.tsx
@@ -8,8 +8,8 @@ import WorkbookAddButton from '@common/QuestionSelectionBox/WorkbookAddButton';
 import { Box, Button, Icon, Tabs } from '@foundation/index';
 import { theme } from '@styles/theme';
 import {
-  hideSidebar,
-  showSidebar,
+  QuestionSelectionBoxSidebarAreaDiv,
+  QuestionSelectionBoxTabPanelAreaDiv,
 } from '@common/QuestionSelectionBox/QuestionSelectionBox.styles';
 import { css } from '@emotion/react';
 import { useState } from 'react';
@@ -57,28 +57,13 @@ const QuestionSelectionBox = () => {
             row-gap: 1.5rem;
           `}
         >
-          <div
-            css={css`
-              display: flex;
-              flex-direction: column;
-              row-gap: 2rem;
-              padding: 1.5rem 0;
-              border-radius: 1rem 0 0 1rem;
-              background-color: ${theme.colors.surface.default};
-              overflow-y: auto;
-              flex: 1 1 15rem;
-              animation: ${!isSideBarOpen && isDeviceBreakpoint('tablet')
-                ? css`
-                    ${hideSidebar} 0.3s ease-in-out forwards
-                  `
-                : css`
-                    ${showSidebar} 0.3s ease-in-out forwards
-                  `};
-            `}
+          <QuestionSelectionBoxSidebarAreaDiv
+            isSidebarOpen={isSideBarOpen}
+            isTabletWidth={isDeviceBreakpoint('tablet')}
           >
             <WorkbookAddButton />
             <QuestionTabList workbookListData={workbookListData} />
-          </div>
+          </QuestionSelectionBoxSidebarAreaDiv>
           {isDeviceBreakpoint('tablet') && (
             <div
               css={css`
@@ -102,12 +87,7 @@ const QuestionSelectionBox = () => {
               </Button>
             </div>
           )}
-          <div
-            css={css`
-              flex: 1 1 calc(100% - 15rem);
-              overflow-x: hidden;
-            `}
-          >
+          <QuestionSelectionBoxTabPanelAreaDiv>
             {workbookListData.map((workbook, index) => (
               <TabPanelItem
                 key={workbook.workbookId}
@@ -115,7 +95,7 @@ const QuestionSelectionBox = () => {
                 workbook={workbook}
               />
             ))}
-          </div>
+          </QuestionSelectionBoxTabPanelAreaDiv>
         </Tabs>
       </Box>
     </>

--- a/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.tsx
@@ -5,7 +5,7 @@ import AnswerSelectionModal from './AnswerSelectionModal/AnswerSelectionModal';
 import useWorkbookTitleListQuery from '@hooks/apis/queries/useWorkbookTitleListQuery';
 import QuestionTabList from '@common/QuestionSelectionBox/QuestionTabList';
 import WorkbookAddButton from '@common/QuestionSelectionBox/WorkbookAddButton';
-import { Box, Button, Icon, Tabs } from '@foundation/index';
+import { Box, Tabs } from '@foundation/index';
 import { theme } from '@styles/theme';
 import {
   QuestionSelectionBoxSidebarAreaDiv,
@@ -64,35 +64,14 @@ const QuestionSelectionBox = () => {
             <WorkbookAddButton />
             <QuestionTabList workbookListData={workbookListData} />
           </QuestionSelectionBoxSidebarAreaDiv>
-          {isDeviceBreakpoint('tablet') && (
-            <div
-              css={css`
-                position: relative;
-              `}
-            >
-              <Button
-                variants="secondary"
-                onClick={() => setIsSideBarOpen((prev) => !prev)}
-                css={css`
-                  position: absolute;
-                  bottom: 0.5rem;
-                  display: flex;
-                  align-items: center;
-                  border: none;
-                  border-radius: 1rem;
-                  z-index: ${theme.zIndex.contentOverlay.overlay5};
-                `}
-              >
-                <Icon id="menu" width="24" height="24" />
-              </Button>
-            </div>
-          )}
           <QuestionSelectionBoxTabPanelAreaDiv>
             {workbookListData.map((workbook, index) => (
               <TabPanelItem
                 key={workbook.workbookId}
                 tabIndex={index.toString()}
                 workbook={workbook}
+                isSidebarOpen={isSideBarOpen}
+                onSidebarToggleClick={() => setIsSideBarOpen((prev) => !prev)}
               />
             ))}
           </QuestionSelectionBoxTabPanelAreaDiv>

--- a/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.tsx
@@ -5,20 +5,26 @@ import AnswerSelectionModal from './AnswerSelectionModal/AnswerSelectionModal';
 import useWorkbookTitleListQuery from '@hooks/apis/queries/useWorkbookTitleListQuery';
 import QuestionTabList from '@common/QuestionSelectionBox/QuestionTabList';
 import WorkbookAddButton from '@common/QuestionSelectionBox/WorkbookAddButton';
-import { Box, Tabs } from '@foundation/index';
+import { Box, Button, Icon, Tabs } from '@foundation/index';
 import { theme } from '@styles/theme';
 import {
   hideSidebar,
   showSidebar,
 } from '@common/QuestionSelectionBox/QuestionSelectionBox.styles';
 import { css } from '@emotion/react';
+import { useState } from 'react';
+import useBreakpoint from '@hooks/useBreakPoint';
 
 const QuestionSelectionBox = () => {
+  const isDeviceBreakpoint = useBreakpoint();
+
   const { data: workbookListData } = useWorkbookTitleListQuery();
   const [
     { isOpen: isQuestionAnswerSelectionModalOpen, workbookId, question },
     setModalState,
   ] = useRecoilState(QuestionAnswerSelectionModal);
+
+  const [isSideBarOpen, setIsSideBarOpen] = useState(false);
 
   if (!workbookListData) return;
   return (
@@ -45,7 +51,6 @@ const QuestionSelectionBox = () => {
       >
         <Tabs
           css={css`
-            position: relative;
             display: flex;
             width: 100%;
             height: 100%;
@@ -62,18 +67,41 @@ const QuestionSelectionBox = () => {
               background-color: ${theme.colors.surface.default};
               overflow-y: auto;
               flex: 1 1 15rem;
-
-              @media (max-width: ${theme.breakpoints.tablet}) {
-                animation: ${hideSidebar} 0.3s ease-in-out forwards;
-              }
-              @media (min-width: ${theme.breakpoints.tablet}) {
-                animation: ${showSidebar} 0.3s ease-in-out forwards;
-              }
+              animation: ${!isSideBarOpen && isDeviceBreakpoint('tablet')
+                ? css`
+                    ${hideSidebar} 0.3s ease-in-out forwards
+                  `
+                : css`
+                    ${showSidebar} 0.3s ease-in-out forwards
+                  `};
             `}
           >
             <WorkbookAddButton />
             <QuestionTabList workbookListData={workbookListData} />
           </div>
+          {isDeviceBreakpoint('tablet') && (
+            <div
+              css={css`
+                position: relative;
+              `}
+            >
+              <Button
+                variants="secondary"
+                onClick={() => setIsSideBarOpen((prev) => !prev)}
+                css={css`
+                  position: absolute;
+                  bottom: 0.5rem;
+                  display: flex;
+                  align-items: center;
+                  border: none;
+                  border-radius: 1rem;
+                  z-index: ${theme.zIndex.contentOverlay.overlay5};
+                `}
+              >
+                <Icon id="menu" width="24" height="24" />
+              </Button>
+            </div>
+          )}
           <div
             css={css`
               flex: 1 1 calc(100% - 15rem);

--- a/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.tsx
@@ -1,13 +1,17 @@
-import { theme } from '@styles/theme';
-import { css } from '@emotion/react';
 import TabPanelItem from './QuestionTabPanelItem';
 import { useRecoilState } from 'recoil';
 import { QuestionAnswerSelectionModal } from '@atoms/modal';
 import AnswerSelectionModal from './AnswerSelectionModal/AnswerSelectionModal';
-import { Box, Tabs } from '@foundation/index';
 import useWorkbookTitleListQuery from '@hooks/apis/queries/useWorkbookTitleListQuery';
 import QuestionTabList from '@common/QuestionSelectionBox/QuestionTabList';
 import WorkbookAddButton from '@common/QuestionSelectionBox/WorkbookAddButton';
+import { Box, Tabs } from '@foundation/index';
+import { theme } from '@styles/theme';
+import {
+  hideSidebar,
+  showSidebar,
+} from '@common/QuestionSelectionBox/QuestionSelectionBox.styles';
+import { css } from '@emotion/react';
 
 const QuestionSelectionBox = () => {
   const { data: workbookListData } = useWorkbookTitleListQuery();
@@ -41,6 +45,7 @@ const QuestionSelectionBox = () => {
       >
         <Tabs
           css={css`
+            position: relative;
             display: flex;
             width: 100%;
             height: 100%;
@@ -51,12 +56,19 @@ const QuestionSelectionBox = () => {
             css={css`
               display: flex;
               flex-direction: column;
-              width: 15rem;
               row-gap: 2rem;
-              padding-top: 1.5rem;
+              padding: 1.5rem 0;
               border-radius: 1rem 0 0 1rem;
               background-color: ${theme.colors.surface.default};
               overflow-y: auto;
+              flex: 1 1 15rem;
+
+              @media (max-width: ${theme.breakpoints.tablet}) {
+                animation: ${hideSidebar} 0.3s ease-in-out forwards;
+              }
+              @media (min-width: ${theme.breakpoints.tablet}) {
+                animation: ${showSidebar} 0.3s ease-in-out forwards;
+              }
             `}
           >
             <WorkbookAddButton />
@@ -64,8 +76,8 @@ const QuestionSelectionBox = () => {
           </div>
           <div
             css={css`
-              width: 100%;
-              max-width: calc(100% - 15rem);
+              flex: 1 1 calc(100% - 15rem);
+              overflow-x: hidden;
             `}
           >
             {workbookListData.map((workbook, index) => (

--- a/FE/src/components/common/QuestionSelectionBox/QuestionTabList.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionTabList.tsx
@@ -1,7 +1,6 @@
 import { SelectionBox, Tabs, Typography } from '@foundation/index';
 import { WorkbookTitleListResDto } from '@/types/workbook';
 import { css } from '@emotion/react';
-import { truncateText } from '@/utils/textUtils';
 
 type QuestionTabListProps = {
   workbookListData: WorkbookTitleListResDto;
@@ -23,8 +22,8 @@ const QuestionTabList: React.FC<QuestionTabListProps> = ({
             id={`workbook-${workbook.workbookId.toString()}`}
             name="workbook"
           >
-            <Typography variant="title4">
-              {truncateText(workbook.title, 12)}
+            <Typography variant="title4" noWrap component="p">
+              {workbook.title}
             </Typography>
           </SelectionBox>
         </Tabs.Tab>

--- a/FE/src/components/common/QuestionSelectionBox/QuestionTabPanelHeader.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionTabPanelHeader.tsx
@@ -8,6 +8,7 @@ import useModal from '@hooks/useModal';
 import { WorkbookGeneratorModal } from '@common/index';
 import useWorkbookDelete from '@hooks/useWorkbookDelete';
 import { toast } from '@foundation/Toast/toast';
+import useBreakpoint from '@hooks/useBreakPoint';
 
 type QuestionTabPanelHeaderProps = {
   workbook: ExcludeArray<WorkbookTitleListResDto>;
@@ -21,6 +22,7 @@ const QuestionTabPanelHeader: React.FC<QuestionTabPanelHeaderProps> = ({
   onWorkbookDelete,
   onEditButtonClick,
 }) => {
+  const isDeviceBreakpoint = useBreakpoint();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { deleteWorkbook } = useWorkbookDelete();
   const { openModal, closeModal } = useModal(() => {
@@ -53,6 +55,9 @@ const QuestionTabPanelHeader: React.FC<QuestionTabPanelHeaderProps> = ({
           css={css`
             display: flex;
             justify-content: space-between;
+            align-items: center;
+            flex-wrap: wrap;
+            row-gap: 0.5rem;
           `}
         >
           <div
@@ -65,7 +70,8 @@ const QuestionTabPanelHeader: React.FC<QuestionTabPanelHeaderProps> = ({
             <Button
               variants="secondary"
               size="sm"
-              onClick={openModal}
+              onClick={onEditButtonClick}
+              visible={!isDeviceBreakpoint('mobile')}
               css={css`
                 display: flex;
                 align-items: center;
@@ -75,7 +81,7 @@ const QuestionTabPanelHeader: React.FC<QuestionTabPanelHeaderProps> = ({
               `}
             >
               <Icon id="edit-outline" width="20" height="20" />
-              면접 세트 수정
+              면접 질문 수정
             </Button>
             <div
               css={css`
@@ -96,8 +102,14 @@ const QuestionTabPanelHeader: React.FC<QuestionTabPanelHeaderProps> = ({
                 <Icon id="ellipsis-vertical" />
               </Button>
               <Menu open={isMenuOpen} closeMenu={() => setIsMenuOpen(false)}>
-                <MenuItem onClick={onEditButtonClick}>
+                <MenuItem
+                  onClick={onEditButtonClick}
+                  visible={isDeviceBreakpoint('mobile')}
+                >
                   <Typography noWrap>면접 질문 수정</Typography>
+                </MenuItem>
+                <MenuItem onClick={openModal}>
+                  <Typography noWrap>면접 세트 편집</Typography>
                 </MenuItem>
                 <MenuItem onClick={handleWorkbookDeleteClick}>
                   <Typography noWrap>면접 세트 삭제</Typography>

--- a/FE/src/components/common/QuestionSelectionBox/QuestionTabPanelItem.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionTabPanelItem.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import useQuestionWorkbookQuery from '@hooks/apis/queries/useQuestionWorkbookQuery';
-import { Typography, Toggle, Tabs, Button, Icon } from '@foundation/index';
+import { Button, Icon, Tabs, Toggle, Typography } from '@foundation/index';
 import { WorkbookTitleListResDto } from '@/types/workbook';
 import { ExcludeArray } from '@/types/utils';
 import QuestionAddForm from '@common/QuestionSelectionBox/QuestionAddForm';
@@ -93,7 +93,9 @@ const TabPanelItem: React.FC<TabPanelItemProps> = ({
             align-items: center;
             column-gap: 0.5rem;
             padding: 1rem;
-            border-radius: ${isSidebarOpen ? '0 0 1rem 1rem' : '0 0 1rem 0'};
+            border-radius: ${isSidebarOpen && isDeviceBreakpoint('tablet')
+              ? '0 0 1rem 1rem'
+              : '0 0 1rem 0'};
             background-color: ${theme.colors.surface.default};
           `}
         >

--- a/FE/src/components/common/QuestionSelectionBox/QuestionTabPanelItem.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionTabPanelItem.tsx
@@ -82,6 +82,9 @@ const TabPanelItem: React.FC<TabPanelItemProps> = ({ workbook, tabIndex }) => {
             padding: 1rem;
             background-color: ${theme.colors.surface.default};
             border-radius: 0 0 1rem 0;
+            @media (max-width: ${theme.breakpoints.tablet}) {
+              border-radius: 0 0 1rem 1rem;
+            }
           `}
         >
           <div

--- a/FE/src/components/common/QuestionSelectionBox/QuestionTabPanelItem.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionTabPanelItem.tsx
@@ -4,20 +4,30 @@ import { css } from '@emotion/react';
 import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import useQuestionWorkbookQuery from '@hooks/apis/queries/useQuestionWorkbookQuery';
-import { Typography, Toggle, Tabs } from '@foundation/index';
+import { Typography, Toggle, Tabs, Button, Icon } from '@foundation/index';
 import { WorkbookTitleListResDto } from '@/types/workbook';
 import { ExcludeArray } from '@/types/utils';
 import QuestionAddForm from '@common/QuestionSelectionBox/QuestionAddForm';
 import QuestionTabPanelHeader from '@common/QuestionSelectionBox/QuestionTabPanelHeader';
 import useTabs from '@foundation/Tabs/useTabs';
 import QuestionAccordionList from '@common/QuestionSelectionBox/QuestionAccordionList';
+import useBreakpoint from '@hooks/useBreakPoint';
 
 type TabPanelItemProps = {
   tabIndex: string;
   workbook: ExcludeArray<WorkbookTitleListResDto>;
+  isSidebarOpen: boolean;
+  onSidebarToggleClick: () => void;
 };
 
-const TabPanelItem: React.FC<TabPanelItemProps> = ({ workbook, tabIndex }) => {
+const TabPanelItem: React.FC<TabPanelItemProps> = ({
+  workbook,
+  tabIndex,
+  isSidebarOpen,
+  onSidebarToggleClick,
+}) => {
+  const isDeviceBreakpoint = useBreakpoint();
+
   const settingPage = useRecoilValue(questionSetting);
   const selectedQuestions = settingPage.selectedData.filter(
     (question) => question.workbookId === workbook.workbookId
@@ -77,29 +87,41 @@ const TabPanelItem: React.FC<TabPanelItemProps> = ({ workbook, tabIndex }) => {
         <div
           css={css`
             display: flex;
-            justify-content: flex-end;
-            width: 100%;
+            justify-content: ${isDeviceBreakpoint('tablet')
+              ? 'space-between'
+              : 'flex-end'};
+            align-items: center;
+            column-gap: 0.5rem;
             padding: 1rem;
+            border-radius: ${isSidebarOpen ? '0 0 1rem 1rem' : '0 0 1rem 0'};
             background-color: ${theme.colors.surface.default};
-            border-radius: 0 0 1rem 0;
-            @media (max-width: ${theme.breakpoints.tablet}) {
-              border-radius: 0 0 1rem 1rem;
-            }
           `}
         >
+          <Button
+            variants="secondary"
+            onClick={onSidebarToggleClick}
+            visible={isDeviceBreakpoint('tablet')}
+            css={css`
+              bottom: 0.5rem;
+              display: flex;
+              align-items: center;
+              border: none;
+              border-radius: 1rem;
+              padding: 0.5rem;
+            `}
+          >
+            <Icon id="menu" width="24" height="24" />
+          </Button>
           <div
             onClick={toggleShowSelectionOption}
             css={css`
               display: flex;
+              flex-wrap: wrap;
+              gap: 0.25rem;
               cursor: pointer;
-              align-items: center;
-              column-gap: 0.25rem;
             `}
           >
             <Toggle
-              css={css`
-                margin-left: auto;
-              `}
               onClick={toggleShowSelectionOption}
               isToggled={onlySelectedOption}
             />

--- a/FE/src/components/common/QuestionSelectionBox/WorkbookEditModeDialog.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/WorkbookEditModeDialog.tsx
@@ -18,14 +18,18 @@ const WorkbookEditModeDialog: React.FC<WorkbookEditModeDialogProps> = ({
         position: absolute;
         bottom: 4rem;
         display: flex;
+        flex-wrap: wrap;
+        justify-content: space-around;
         align-items: center;
-        column-gap: 0.5rem;
+        gap: 0.5rem;
         align-self: center;
         padding: 0.5rem 1rem;
+        margin: 0 0.5rem;
         width: auto;
         height: auto;
         border-radius: 1rem;
         background-color: ${theme.colors.surface.default};
+        z-index: ${theme.zIndex.contentOverlay.overlay5};
       `}
     >
       <Button
@@ -33,18 +37,31 @@ const WorkbookEditModeDialog: React.FC<WorkbookEditModeDialogProps> = ({
         variants="secondary"
         onClick={onCancelClick}
         css={css`
+          flex-grow: 1;
           border: none;
           padding-bottom: 0.25rem;
         `}
       >
         <Icon id="close-black" width="12" height="12" />
       </Button>
-      <Typography variant="body1">{count}개 체크함</Typography>
+      <Typography
+        variant="body1"
+        css={css`
+          @media (max-width: ${theme.breakpoints.mobile}) {
+            width: 100%;
+            text-align: center;
+            order: -1;
+          }
+        `}
+      >
+        {count}개 체크함
+      </Typography>
       <Button
         size="sm"
         variants="secondary"
         onClick={onDeleteClick}
         css={css`
+          flex-grow: 1;
           border: none;
           padding-bottom: 0.125rem;
         `}

--- a/FE/src/components/foundation/Button/Button.tsx
+++ b/FE/src/components/foundation/Button/Button.tsx
@@ -6,6 +6,7 @@ import { buttonSize, buttonVariants } from '@foundation/Button/Button.styles';
 type ButtonProps = {
   size?: keyof typeof buttonSize;
   variants?: keyof typeof buttonVariants;
+  visible?: boolean;
 } & HTMLElementTypes<HTMLButtonElement> &
   React.ButtonHTMLAttributes<HTMLButtonElement>;
 
@@ -13,8 +14,10 @@ const Button: React.FC<ButtonProps> = ({
   children,
   size = 'md',
   variants = 'primary',
+  visible = true,
   ...args
 }) => {
+  if (!visible) return null;
   return (
     <button
       css={[

--- a/FE/src/components/foundation/Menu/MenuItem.tsx
+++ b/FE/src/components/foundation/Menu/MenuItem.tsx
@@ -5,10 +5,16 @@ import { Button } from '@foundation/index';
 
 type MenuItemProps = {
   children: ReactNode;
+  visible?: boolean;
 } & HTMLElementTypes<HTMLButtonElement> &
   React.ButtonHTMLAttributes<HTMLButtonElement>;
 
-const MenuItem: React.FC<MenuItemProps> = ({ children, ...args }) => {
+const MenuItem: React.FC<MenuItemProps> = ({
+  children,
+  visible = true,
+  ...args
+}) => {
+  if (!visible) return null;
   return (
     <Button
       variants="secondary"

--- a/FE/src/hooks/useBreakPoint.ts
+++ b/FE/src/hooks/useBreakPoint.ts
@@ -2,13 +2,7 @@ import useWindowSize from './useWindowSize';
 import { breakpoints } from '@styles/_breakpoints';
 
 type Breakpoints = {
-  mobileXS: string;
-  mobileS: string;
-  mobileM: string;
-  mobileL: string;
-  tablet: string;
-  laptop: string;
-  laptopL: string;
+  [K in keyof typeof breakpoints]: string;
 };
 
 const parseBreakpoint = (value: string) => parseInt(value, 10);

--- a/FE/src/index.tsx
+++ b/FE/src/index.tsx
@@ -5,7 +5,7 @@ import App from '@/App';
 import * as Sentry from '@sentry/react';
 
 async function deferRender() {
-  if (process.env.NODE_ENV !== 'local') {
+  if (process.env.REACT_APP_MSW_ENABLE !== 'true') {
     return;
   }
   return worker.start({

--- a/FE/src/styles/_breakpoints.ts
+++ b/FE/src/styles/_breakpoints.ts
@@ -7,6 +7,7 @@ export const breakpoints = {
   mobileS: '320px', //아이폰 미니 등 작은 디바이스
   mobileM: '375px', //일반적인 스마트폰 사이즈
   mobileL: '425px', //큰 스마트폰 사이즈
+  mobile: '576px', //부트스트랩 기준 모바일 사이즈
   tablet: '768px', //태블릿 세로, 모바일 가로
   laptop: '1024px', //테블릿 가로, 노트북
   laptopL: '1440px', //데스크탑

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [코드 리뷰를 "잘"하는 방법 - 윤해민](https://yoonhaemin.com/tag/experience/code-review/)
 - [React에서 페이지 흐름을 “잘” 관리해 보자 - 윤해민](https://yoonhaemin.com/tag/experience/react-page-flow/)
 - [React에서 많은 Modal을 "잘" 관리해 보자 - 윤해민](https://yoonhaemin.com/tag/experience/react-modal/)
+- [[NDD] 곰터뷰는 왜 Cloudflare를 사용해서 배포하게 되었을까](https://www.milk717.com/gomterview-1/)
 - [Oauth2를 도입하신다고요? 꼭 쿠키 사용하세요 ^^ - 김수민](https://www.milk717.com/gomterview-2/)
 - [console.log처럼 쓸 수 있는 toast 만들기 - 김수민](https://www.milk717.com/gomterview-3/)
 


### PR DESCRIPTION
[![NDD-350](https://badgen.net/badge/JIRA/NDD-350/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-350) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

모바일에서 문제 선택 컴포넌트를 볼 때 사이드바의 너비로 인해 문제 선택이 힘들다는 문제가 있었습니다.
따라서 이를 개선하기 위해 화면 너비에 따라 사이드바가 자동으로 접히도록 구현했습니다.

# How
## QuestionSelectionBox 사이드바 접기
사이드바가 접히는 동작은 [이 블로그 테마](https://chirpy.cotes.page/)의 사이드바를 참고해서 만들었습니다.
사이드바는 다음과 같이 동작합니다.

- 화면 너비가 태블릿 사이즈보다 작아지게 될 때 접힙니다.
- 화면 너비가 태블릿 사이즈보다 커지게 될 때 펼쳐집니다.
- 사이드바가 접힌 경우 하단에 토글 버튼을 눌러 사이드바를 펼칠 수 있습니다.
- 사용자가 토글 버튼을 눌러 사이드바가 펼쳐진 경우에는 화면 사이즈가 변경된 경우에도 자동으로 사이드바가 접히지 않습니다.
- 즉, 사이드바의 상태가 접힘인 경우 브라우저 화면 너비에 영향을 받고, 사이드바의 상태가 펼침인 경우 사용자의 버튼 상호작용에만 영향을 받습니다.

## local 환경에서 MSW가 설정되지 않는 문제 해결
```tsx
async function deferRender() {
  if (process.env.NODE_ENV !== 'local') {
    return;
  }
  return worker.start({
    onUnhandledRequest: 'bypass',
  });
}
```
위 코드를 통해 local 개발 환경일 때만 MSW가 활성화되도록 구현했었는데요. 
<img width="761" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/e3ca8a2a-7e64-4240-bde4-e8289aa58981">
`local`이라는 환경변수는 웹팩에 전달하는 커스텀 환경변수이기 때문에 `NODE_ENV`에 전달되지 않습니다.
`NODE_ENV`에 전달되는 값은 위 이미지에서 첫 번째로 박스친 `development`에 해당하는 부분이죠
이는 직접 커스텀할 수 없습니다.
따라서 local 개발환경에서만 MSW를 활성화할 수 있도록 `deferRender` 코드를 아래와 같이 변경했습니다.

```tsx
async function deferRender() {
  if (process.env.REACT_APP_MSW_ENABLE !== 'true') {
    return;
  }
  return worker.start({
    onUnhandledRequest: 'bypass',
  });
}
```

이에 따라 MSW를 사용해서 개발 테스트를 하는 경우 env.local에 아래 환경변수를 추가해주시기 바랍니다.
`REACT_APP_MSW_ENABLE=true`

# Result

https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/bcda9817-1439-4499-800a-3941b0cdff8c


# Reference

[Chirpy](https://chirpy.cotes.page/)

[NDD-350]: https://milk717.atlassian.net/browse/NDD-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ