### PR TITLE
[NDD-364] 문제 선택 페이지 헤더추가, 버튼 하단고정, 토스트 잔상 이슈 해결 (2h)

### DIFF
--- a/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.styles.ts
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.styles.ts
@@ -21,7 +21,7 @@ export const showSidebar = keyframes`
 `;
 
 export const QuestionSelectionBoxSidebarAreaDiv = styled.div<{
-  isSidebarOpen: boolean;
+  isSidebarToggleOn: boolean;
   isTabletWidth: boolean;
 }>`
   display: flex;
@@ -33,7 +33,7 @@ export const QuestionSelectionBoxSidebarAreaDiv = styled.div<{
   overflow-y: auto;
   flex: 1 1 15rem;
   animation: ${(props) =>
-    props.isSidebarOpen && props.isTabletWidth
+    props.isSidebarToggleOn && props.isTabletWidth
       ? css`
           ${hideSidebar} 0.3s ease-in-out forwards
         `

--- a/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionSelectionBox.tsx
@@ -17,7 +17,7 @@ const QuestionSelectionBox = () => {
 
   const { data: workbookListData } = useWorkbookTitleListQuery();
 
-  const [isSideBarOpen, setIsSideBarOpen] = useState(true);
+  const [isSidebarToggleOn, setIsSidebarToggleOn] = useState(true);
 
   if (!workbookListData) return;
   return (
@@ -38,7 +38,7 @@ const QuestionSelectionBox = () => {
           `}
         >
           <QuestionSelectionBoxSidebarAreaDiv
-            isSidebarOpen={isSideBarOpen}
+            isSidebarToggleOn={isSidebarToggleOn}
             isTabletWidth={isDeviceBreakpoint('tablet')}
           >
             <WorkbookAddButton />
@@ -50,8 +50,12 @@ const QuestionSelectionBox = () => {
                 key={workbook.workbookId}
                 tabIndex={index.toString()}
                 workbook={workbook}
-                isSidebarOpen={isSideBarOpen}
-                onSidebarToggleClick={() => setIsSideBarOpen((prev) => !prev)}
+                isSidebarOpen={
+                  isSidebarToggleOn && isDeviceBreakpoint('tablet')
+                }
+                onSidebarToggleClick={() =>
+                  setIsSidebarToggleOn((prev) => !prev)
+                }
               />
             ))}
           </QuestionSelectionBoxTabPanelAreaDiv>

--- a/FE/src/components/common/QuestionSelectionBox/QuestionTabPanelItem.tsx
+++ b/FE/src/components/common/QuestionSelectionBox/QuestionTabPanelItem.tsx
@@ -93,9 +93,7 @@ const TabPanelItem: React.FC<TabPanelItemProps> = ({
             align-items: center;
             column-gap: 0.5rem;
             padding: 1rem;
-            border-radius: ${isSidebarOpen && isDeviceBreakpoint('tablet')
-              ? '0 0 1rem 1rem'
-              : '0 0 1rem 0'};
+            border-radius: ${isSidebarOpen ? '0 0 1rem 1rem' : '0 0 1rem 0'};
             background-color: ${theme.colors.surface.default};
           `}
         >
@@ -127,7 +125,9 @@ const TabPanelItem: React.FC<TabPanelItemProps> = ({
               onClick={toggleShowSelectionOption}
               isToggled={onlySelectedOption}
             />
-            <Typography variant="body3">선택된 질문만 보기</Typography>
+            {!isSidebarOpen && isDeviceBreakpoint('mobile') ? null : (
+              <Typography variant="body3">선택된 질문만 보기</Typography>
+            )}
           </div>
         </div>
       </div>

--- a/FE/src/components/foundation/StepPages/Step.tsx
+++ b/FE/src/components/foundation/StepPages/Step.tsx
@@ -11,6 +11,7 @@ const Step = <T,>({ page, children, path }: StepProps<T>) => {
     <div
       css={css`
         display: ${page === path ? 'block' : 'none'};
+        height: 100%;
       `}
     >
       {children}

--- a/FE/src/components/foundation/StepPages/index.tsx
+++ b/FE/src/components/foundation/StepPages/index.tsx
@@ -1,5 +1,6 @@
 import enhanceChildElement from '@/utils/enhanceChildElement';
 import Step from './Step';
+import { css } from '@emotion/react';
 
 type StepPageProps<T> = {
   page: T;
@@ -8,7 +9,11 @@ type StepPageProps<T> = {
 
 const StepPage = <T,>({ page, children }: StepPageProps<T>) => {
   return (
-    <div>
+    <div
+      css={css`
+        height: 100%;
+      `}
+    >
       {enhanceChildElement({
         children,
         component: Step<T>,

--- a/FE/src/components/foundation/Toast/ToastContainer.tsx
+++ b/FE/src/components/foundation/Toast/ToastContainer.tsx
@@ -17,7 +17,9 @@ export const ToastContainer = () => {
           display: flex;
           flex-direction: column;
           row-gap: 0.5rem;
-          z-index: 9999;
+          pointer-events: none;
+          touch-action: none;
+          z-index: ${theme.zIndex.toast.content};
           @media (max-width: ${theme.breakpoints.mobileL}) {
             left: 0.25rem;
             right: 0.25rem;

--- a/FE/src/components/foundation/Toast/ToastItem.tsx
+++ b/FE/src/components/foundation/Toast/ToastItem.tsx
@@ -54,7 +54,13 @@ const ToastItem: React.FC<ToastProps> = ({
     );
 
   return (
-    <div ref={toastRef}>
+    <div
+      ref={toastRef}
+      css={css`
+        pointer-events: ${isExiting ? 'none' : 'auto'};
+        touch-action: ${isExiting ? 'none' : 'auto'};
+      `}
+    >
       <Box
         onClick={handleClick}
         onMouseEnter={handleMouseEnter}

--- a/FE/src/components/interviewSettingPage/Description.tsx
+++ b/FE/src/components/interviewSettingPage/Description.tsx
@@ -9,13 +9,7 @@ type DescriptionProps = {
 const Description: React.FC<DescriptionProps> = ({ title, children }) => {
   return (
     <>
-      <Typography
-        variant="title3"
-        component="p"
-        css={css`
-          margin-bottom: 2rem;
-        `}
-      >
+      <Typography variant="title3" component="p">
         {title}
       </Typography>
       <Typography

--- a/FE/src/components/interviewSettingPage/InterviewSettingContentLayout.tsx
+++ b/FE/src/components/interviewSettingPage/InterviewSettingContentLayout.tsx
@@ -20,7 +20,15 @@ const InterviewSettingContentLayout: React.FC<
         row-gap: 1rem;
       `}
     >
-      <div>{children}</div>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          row-gap: 1rem;
+        `}
+      >
+        {children}
+      </div>
       <InterviewSettingFooter>
         <div
           css={css`

--- a/FE/src/components/interviewSettingPage/InterviewSettingContentLayout.tsx
+++ b/FE/src/components/interviewSettingPage/InterviewSettingContentLayout.tsx
@@ -18,6 +18,8 @@ const InterviewSettingContentLayout: React.FC<
         display: flex;
         flex-direction: column;
         row-gap: 1rem;
+        flex-grow: 1;
+        height: 100%;
       `}
     >
       <div
@@ -25,6 +27,7 @@ const InterviewSettingContentLayout: React.FC<
           display: flex;
           flex-direction: column;
           row-gap: 1rem;
+          flex-grow: 1;
         `}
       >
         {children}

--- a/FE/src/components/interviewSettingPage/InterviewSettingContentLayout.tsx
+++ b/FE/src/components/interviewSettingPage/InterviewSettingContentLayout.tsx
@@ -37,6 +37,7 @@ const InterviewSettingContentLayout: React.FC<
           css={css`
             display: flex;
             column-gap: 1rem;
+            margin-bottom: 1rem;
           `}
         >
           <Button

--- a/FE/src/components/interviewSettingPage/InterviewSettingContentLayout.tsx
+++ b/FE/src/components/interviewSettingPage/InterviewSettingContentLayout.tsx
@@ -1,0 +1,50 @@
+import { Button } from '@foundation/index';
+import { css } from '@emotion/react';
+import { InterviewSettingFooter } from '@components/interviewSettingPage/interviewSettingFooter';
+
+type InterviewSettingContentLayoutProps = {
+  onPrevClick?: () => void;
+  onNextClick?: () => void;
+  disabledPrev?: boolean;
+  disabledNext?: boolean;
+  children?: React.ReactNode;
+};
+const InterviewSettingContentLayout: React.FC<
+  InterviewSettingContentLayoutProps
+> = ({ onPrevClick, onNextClick, disabledPrev, disabledNext, children }) => {
+  return (
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        row-gap: 1rem;
+      `}
+    >
+      <div>{children}</div>
+      <InterviewSettingFooter>
+        <Button
+          onClick={onPrevClick}
+          size="lg"
+          css={css`
+            padding: 0.6rem 2rem;
+          `}
+          disabled={disabledPrev}
+        >
+          이전
+        </Button>
+        <Button
+          onClick={onNextClick}
+          size="lg"
+          css={css`
+            padding: 0.6rem 2rem;
+          `}
+          disabled={disabledNext}
+        >
+          다음
+        </Button>
+      </InterviewSettingFooter>
+    </div>
+  );
+};
+
+export default InterviewSettingContentLayout;

--- a/FE/src/components/interviewSettingPage/InterviewSettingContentLayout.tsx
+++ b/FE/src/components/interviewSettingPage/InterviewSettingContentLayout.tsx
@@ -22,26 +22,33 @@ const InterviewSettingContentLayout: React.FC<
     >
       <div>{children}</div>
       <InterviewSettingFooter>
-        <Button
-          onClick={onPrevClick}
-          size="lg"
+        <div
           css={css`
-            padding: 0.6rem 2rem;
+            display: flex;
+            column-gap: 1rem;
           `}
-          disabled={disabledPrev}
         >
-          이전
-        </Button>
-        <Button
-          onClick={onNextClick}
-          size="lg"
-          css={css`
-            padding: 0.6rem 2rem;
-          `}
-          disabled={disabledNext}
-        >
-          다음
-        </Button>
+          <Button
+            onClick={onPrevClick}
+            size="lg"
+            css={css`
+              padding: 0.6rem 2rem;
+            `}
+            disabled={disabledPrev}
+          >
+            이전
+          </Button>
+          <Button
+            onClick={onNextClick}
+            size="lg"
+            css={css`
+              padding: 0.6rem 2rem;
+            `}
+            disabled={disabledNext}
+          >
+            다음
+          </Button>
+        </div>
       </InterviewSettingFooter>
     </div>
   );

--- a/FE/src/components/interviewSettingPage/InterviewSettingPageLayout.tsx
+++ b/FE/src/components/interviewSettingPage/InterviewSettingPageLayout.tsx
@@ -1,5 +1,6 @@
 import Layout from '@/components/layout/Layout';
 import { css } from '@emotion/react';
+import { Header } from '@components/layout';
 
 type InterviewSettingPageLayoutProps = {
   children: React.ReactNode;
@@ -9,15 +10,19 @@ const InterviewSettingPageLayout: React.FC<InterviewSettingPageLayoutProps> = ({
   children,
 }) => {
   return (
-    <Layout
-      direction="column"
-      css={css`
-        padding: 0 1rem 1rem 1rem;
-        height: auto;
-      `}
-    >
-      {children}
-    </Layout>
+    <div>
+      <Header />
+      <Layout
+        direction="column"
+        css={css`
+          row-gap: 1rem;
+          padding: 1rem;
+          height: auto;
+        `}
+      >
+        {children}
+      </Layout>
+    </div>
   );
 };
 

--- a/FE/src/components/interviewSettingPage/InterviewSettingPageLayout.tsx
+++ b/FE/src/components/interviewSettingPage/InterviewSettingPageLayout.tsx
@@ -23,7 +23,7 @@ const InterviewSettingPageLayout: React.FC<InterviewSettingPageLayoutProps> = ({
         css={css`
           flex-grow: 1;
           row-gap: 1.5rem;
-          padding: 1rem;
+          padding: 1rem 1rem 0 1rem;
           width: 100%;
           height: auto;
         `}

--- a/FE/src/components/interviewSettingPage/InterviewSettingPageLayout.tsx
+++ b/FE/src/components/interviewSettingPage/InterviewSettingPageLayout.tsx
@@ -10,13 +10,21 @@ const InterviewSettingPageLayout: React.FC<InterviewSettingPageLayoutProps> = ({
   children,
 }) => {
   return (
-    <div>
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        height: 100svh;
+      `}
+    >
       <Header />
       <Layout
         direction="column"
         css={css`
+          flex-grow: 1;
           row-gap: 1.5rem;
           padding: 1rem;
+          width: 100%;
           height: auto;
         `}
       >

--- a/FE/src/components/interviewSettingPage/InterviewSettingPageLayout.tsx
+++ b/FE/src/components/interviewSettingPage/InterviewSettingPageLayout.tsx
@@ -15,7 +15,7 @@ const InterviewSettingPageLayout: React.FC<InterviewSettingPageLayoutProps> = ({
       <Layout
         direction="column"
         css={css`
-          row-gap: 1rem;
+          row-gap: 1.5rem;
           padding: 1rem;
           height: auto;
         `}

--- a/FE/src/components/interviewSettingPage/RecordPage/RecordRadio.tsx
+++ b/FE/src/components/interviewSettingPage/RecordPage/RecordRadio.tsx
@@ -47,6 +47,14 @@ const RecordRadio: React.FC<RecordRadioProps> = ({
             align-items: center;
             padding: 0.8rem 3rem;
             gap: 3rem;
+            transition: background-color 0.15s ease-in-out;
+
+            &:hover {
+              background-color: ${theme.colors.surface.inner};
+            }
+            &:active {
+              transform: translateY(0.25rem);
+            }
           `}
         >
           <Icon id={IconId} width="3rem" height="3rem" />

--- a/FE/src/components/interviewSettingPage/interviewSettingFooter.tsx
+++ b/FE/src/components/interviewSettingPage/interviewSettingFooter.tsx
@@ -2,15 +2,13 @@ import styled from '@emotion/styled';
 
 export const InterviewSettingFooter = styled.div`
   position: sticky;
-  bottom: 0;
+  bottom: 1rem;
   backdrop-filter: blur(3px); /* 10px 블러 효과 */
   background: linear-gradient(
     180deg,
     rgba(255, 255, 255, 0) 0%,
     rgba(255, 255, 255, 0.72) 100%
   );
-  padding: 0.5rem;
   display: flex;
   justify-content: center;
-  gap: 1rem;
 `;

--- a/FE/src/components/interviewSettingPage/interviewSettingFooter.tsx
+++ b/FE/src/components/interviewSettingPage/interviewSettingFooter.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 export const InterviewSettingFooter = styled.div`
   position: sticky;
-  bottom: 1rem;
+  bottom: 0;
   backdrop-filter: blur(3px); /* 10px 블러 효과 */
   background: linear-gradient(
     180deg,
@@ -11,4 +11,5 @@ export const InterviewSettingFooter = styled.div`
   );
   display: flex;
   justify-content: center;
+  width: 100%;
 `;

--- a/FE/src/components/interviewSettingPage/interviewSettingFooter.tsx
+++ b/FE/src/components/interviewSettingPage/interviewSettingFooter.tsx
@@ -13,5 +13,4 @@ export const InterviewSettingFooter = styled.div`
   display: flex;
   justify-content: center;
   gap: 1rem;
-  margin-top: 2rem;
 `;

--- a/FE/src/components/layout/Header/NavigationMenu.tsx
+++ b/FE/src/components/layout/Header/NavigationMenu.tsx
@@ -23,11 +23,13 @@ const NavigationMenu: React.FC<PropsWithChildren> = ({ children }) => {
         variants="secondary"
         onClick={() => setIsOpen(true)}
         css={css`
+          display: flex;
+          align-items: center;
           border: none;
           border-radius: 2rem;
         `}
       >
-        <Icon id="menu" width="40" height="40" />
+        <Icon id="menu" width="32" height="32" />
       </Button>
       <Menu
         open={isOpen}

--- a/FE/src/page/interviewSettingPage/QuestionSettingPage.tsx
+++ b/FE/src/page/interviewSettingPage/QuestionSettingPage.tsx
@@ -1,9 +1,7 @@
 import { questionSetting } from '@/atoms/interviewSetting';
 import { QuestionSelectionBox } from '@common/index';
-import { InterviewSettingFooter } from '@components/interviewSettingPage';
-import { css } from '@emotion/react';
-import { Button } from '@foundation/index';
 import { useRecoilValue } from 'recoil';
+import InterviewSettingContentLayout from '@components/interviewSettingPage/InterviewSettingContentLayout';
 
 type QuestionSettingPageProps = {
   onNextClick?: () => void;
@@ -17,36 +15,13 @@ const QuestionSettingPage: React.FC<QuestionSettingPageProps> = ({
   const setting = useRecoilValue(questionSetting);
 
   return (
-    <>
-      <div
-        css={css`
-          margin-top: 2rem;
-        `}
-      >
-        <QuestionSelectionBox />
-      </div>
-      <InterviewSettingFooter>
-        <Button
-          onClick={onPrevClick}
-          size="lg"
-          css={css`
-            padding: 0.6rem 2rem;
-          `}
-        >
-          이전
-        </Button>
-        <Button
-          onClick={onNextClick}
-          size="lg"
-          css={css`
-            padding: 0.6rem 2rem;
-          `}
-          disabled={!setting.isSuccess}
-        >
-          다음
-        </Button>
-      </InterviewSettingFooter>
-    </>
+    <InterviewSettingContentLayout
+      onPrevClick={onPrevClick}
+      onNextClick={onNextClick}
+      disabledNext={!setting.isSuccess}
+    >
+      <QuestionSelectionBox />
+    </InterviewSettingContentLayout>
   );
 };
 

--- a/FE/src/page/interviewSettingPage/RecordSettingPage.tsx
+++ b/FE/src/page/interviewSettingPage/RecordSettingPage.tsx
@@ -47,38 +47,47 @@ const RecordSettingPage: React.FC<RecordSettingPageProps> = ({
       {/* TODO: 엔터 인식해서 자동으로 줄바꿈 해주는 기능 추가 */}
       <div
         css={css`
-          max-width: 30rem;
-          margin: 4rem auto;
           display: flex;
-          flex-direction: column;
-          gap: 2rem;
+          justify-content: center;
+          align-items: center;
+          flex-grow: 1;
+          width: 100%;
         `}
       >
-        <RecordRadio
-          group="record"
-          IconId="save-idrive"
-          onChange={() => handleRecordChange('idrive')}
-          disabled={!userInfo}
-          defaultChecked={setting.method === 'idrive'}
+        <div
+          css={css`
+            display: flex;
+            flex-direction: column;
+            gap: 2rem;
+            width: 30rem;
+          `}
         >
-          서버에 저장
-        </RecordRadio>
-        <RecordRadio
-          group="record"
-          IconId="save-local"
-          onChange={() => handleRecordChange('local')}
-          defaultChecked={setting.method === 'local'}
-        >
-          로컬에 저장
-        </RecordRadio>
-        <RecordRadio
-          group="record"
-          IconId="save-not"
-          onChange={() => handleRecordChange('none')}
-          defaultChecked={setting.method === 'none'}
-        >
-          저장하지 않음
-        </RecordRadio>
+          <RecordRadio
+            group="record"
+            IconId="save-idrive"
+            onChange={() => handleRecordChange('idrive')}
+            disabled={!userInfo}
+            defaultChecked={setting.method === 'idrive'}
+          >
+            서버에 저장
+          </RecordRadio>
+          <RecordRadio
+            group="record"
+            IconId="save-local"
+            onChange={() => handleRecordChange('local')}
+            defaultChecked={setting.method === 'local'}
+          >
+            로컬에 저장
+          </RecordRadio>
+          <RecordRadio
+            group="record"
+            IconId="save-not"
+            onChange={() => handleRecordChange('none')}
+            defaultChecked={setting.method === 'none'}
+          >
+            저장하지 않음
+          </RecordRadio>
+        </div>
       </div>
     </InterviewSettingContentLayout>
   );

--- a/FE/src/page/interviewSettingPage/RecordSettingPage.tsx
+++ b/FE/src/page/interviewSettingPage/RecordSettingPage.tsx
@@ -48,8 +48,7 @@ const RecordSettingPage: React.FC<RecordSettingPageProps> = ({
       <div
         css={css`
           max-width: 30rem;
-          margin: 5rem auto;
-
+          margin: 4rem auto;
           display: flex;
           flex-direction: column;
           gap: 2rem;

--- a/FE/src/page/interviewSettingPage/RecordSettingPage.tsx
+++ b/FE/src/page/interviewSettingPage/RecordSettingPage.tsx
@@ -1,13 +1,12 @@
 import { RecordMethod, recordSetting } from '@/atoms/interviewSetting';
 import {
   Description,
-  InterviewSettingFooter,
   RecordRadio,
 } from '@components/interviewSettingPage';
 import { css } from '@emotion/react';
-import { Button } from '@foundation/index';
 import useUserInfo from '@hooks/useUserInfo';
 import { useRecoilState } from 'recoil';
+import InterviewSettingContentLayout from '@components/interviewSettingPage/InterviewSettingContentLayout';
 
 type RecordSettingPageProps = {
   onNextClick?: () => void;
@@ -28,7 +27,11 @@ const RecordSettingPage: React.FC<RecordSettingPageProps> = ({
   };
 
   return (
-    <>
+    <InterviewSettingContentLayout
+      onPrevClick={onPrevClick}
+      onNextClick={onNextClick}
+      disabledNext={!setting.isSuccess}
+    >
       <Description title="녹화 설정">
         - 면접 시작 전, 사용하시는 장치의 화면 및 소리가 정상적으로 연결되어
         있는지 확인해 주세요.
@@ -78,28 +81,7 @@ const RecordSettingPage: React.FC<RecordSettingPageProps> = ({
           저장하지 않음
         </RecordRadio>
       </div>
-      <InterviewSettingFooter>
-        <Button
-          onClick={onPrevClick}
-          size="lg"
-          css={css`
-            padding: 0.6rem 2rem;
-          `}
-        >
-          이전
-        </Button>
-        <Button
-          onClick={onNextClick}
-          size="lg"
-          css={css`
-            padding: 0.6rem 2rem;
-          `}
-          disabled={!setting.isSuccess}
-        >
-          다음
-        </Button>
-      </InterviewSettingFooter>
-    </>
+    </InterviewSettingContentLayout>
   );
 };
 export default RecordSettingPage;

--- a/FE/src/page/interviewSettingPage/ServiceTermsPage.tsx
+++ b/FE/src/page/interviewSettingPage/ServiceTermsPage.tsx
@@ -1,11 +1,9 @@
 import { serviceTerms } from '@atoms/interviewSetting';
-import {
-  Description,
-  InterviewSettingFooter,
-} from '@components/interviewSettingPage';
+import { Description } from '@components/interviewSettingPage';
 import { css } from '@emotion/react';
-import { Button, CheckBox } from '@foundation/index';
+import { CheckBox } from '@foundation/index';
 import { useRecoilState } from 'recoil';
+import InterviewSettingContentLayout from '@components/interviewSettingPage/InterviewSettingContentLayout';
 
 type ServiceTermsPageProps = {
   onNextClick?: () => void;
@@ -24,7 +22,11 @@ const ServiceTermsPage: React.FC<ServiceTermsPageProps> = ({
       ...args,
     }));
   return (
-    <>
+    <InterviewSettingContentLayout
+      onPrevClick={onPrevClick}
+      onNextClick={onNextClick}
+      disabledNext={!isSuccess}
+    >
       <Description title="서비스 이용약관 동의">
         본 서비스는 사용자의 면접 과정을 녹화해주는 서비스로 해당 과정을
         촬영하기 위해서 카메라 및 음성에 대한 권한이 필요합니다.
@@ -49,29 +51,7 @@ const ServiceTermsPage: React.FC<ServiceTermsPageProps> = ({
       >
         동의 하시겠습니까?
       </CheckBox>
-
-      <InterviewSettingFooter>
-        <Button
-          onClick={onPrevClick}
-          size="lg"
-          css={css`
-            padding: 0.6rem 2rem;
-          `}
-        >
-          이전
-        </Button>
-        <Button
-          onClick={onNextClick}
-          size="lg"
-          css={css`
-            padding: 0.6rem 2rem;
-          `}
-          disabled={!isSuccess}
-        >
-          다음
-        </Button>
-      </InterviewSettingFooter>
-    </>
+    </InterviewSettingContentLayout>
   );
 };
 

--- a/FE/src/page/interviewSettingPage/ServiceTermsPage.tsx
+++ b/FE/src/page/interviewSettingPage/ServiceTermsPage.tsx
@@ -1,6 +1,5 @@
 import { serviceTerms } from '@atoms/interviewSetting';
 import { Description } from '@components/interviewSettingPage';
-import { css } from '@emotion/react';
 import { CheckBox } from '@foundation/index';
 import { useRecoilState } from 'recoil';
 import InterviewSettingContentLayout from '@components/interviewSettingPage/InterviewSettingContentLayout';
@@ -40,11 +39,7 @@ const ServiceTermsPage: React.FC<ServiceTermsPageProps> = ({
         참여자는 해당 약관에 대해서 거부할 수 있지만 거부시에 해당 서비스를
         이용하지 못합니다.
       </Description>
-
       <CheckBox
-        css={css`
-          margin-top: 2rem;
-        `}
         id="terms-checkbox"
         checked={isSuccess}
         onInputChange={toggleIsChecked}

--- a/FE/src/page/interviewSettingPage/VideoSettingPage.tsx
+++ b/FE/src/page/interviewSettingPage/VideoSettingPage.tsx
@@ -76,7 +76,6 @@ const VideoSettingPage: React.FC<VideoSettingPageProps> = ({
       <div
         css={css`
           position: relative;
-          margin-top: 2rem;
           height: 100%;
         `}
       >

--- a/FE/src/page/interviewSettingPage/VideoSettingPage.tsx
+++ b/FE/src/page/interviewSettingPage/VideoSettingPage.tsx
@@ -3,15 +3,12 @@ import useMedia from '@/hooks/useMedia';
 import { theme } from '@/styles/theme';
 import { Mirror } from '@common/index';
 import { RecordStatus } from '@components/interviewPage/InterviewHeader';
-import {
-  Description,
-  InterviewSettingFooter,
-} from '@components/interviewSettingPage';
+import { Description } from '@components/interviewSettingPage';
 import { css } from '@emotion/react';
-import { Button } from '@foundation/index';
 import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import { toast } from '@foundation/Toast/toast';
+import InterviewSettingContentLayout from '@components/interviewSettingPage/InterviewSettingContentLayout';
 type VideoSettingPageProps = {
   onNextClick?: () => void;
   onPrevClick?: () => void;
@@ -59,7 +56,11 @@ const VideoSettingPage: React.FC<VideoSettingPageProps> = ({
   }, [connectStatus, setVideoSettingState]);
 
   return (
-    <>
+    <InterviewSettingContentLayout
+      onPrevClick={onPrevClick}
+      onNextClick={onNextClick}
+      disabledNext={!videoSettingState.isSuccess}
+    >
       <Description title="문제 선택">
         - 면접 시작 전, 사용하시는 장치의 화면 및 소리가 정상적으로 연결되어
         있는지 확인해 주세요.
@@ -99,29 +100,7 @@ const VideoSettingPage: React.FC<VideoSettingPageProps> = ({
           isSetting
         />
       </div>
-
-      <InterviewSettingFooter>
-        <Button
-          onClick={onPrevClick}
-          size="lg"
-          css={css`
-            padding: 0.6rem 2rem;
-          `}
-        >
-          이전
-        </Button>
-        <Button
-          onClick={onNextClick}
-          size="lg"
-          css={css`
-            padding: 0.6rem 2rem;
-          `}
-          disabled={!videoSettingState.isSuccess}
-        >
-          다음
-        </Button>
-      </InterviewSettingFooter>
-    </>
+    </InterviewSettingContentLayout>
   );
 };
 

--- a/FE/src/page/interviewSettingPage/index.tsx
+++ b/FE/src/page/interviewSettingPage/index.tsx
@@ -15,7 +15,6 @@ import { ProgressStepBar } from '@common/index';
 import StepPage from '@foundation/StepPages';
 import { InterviewSettingPageLayout } from '@components/interviewSettingPage';
 import ServiceTermsPage from './ServiceTermsPage';
-import { theme } from '@styles/theme';
 import { toast } from '@foundation/Toast/toast';
 
 const FIRST_PAGE_INDEX = 0;
@@ -113,13 +112,7 @@ const InterviewSettingPage: React.FC = () => {
     <InterviewSettingPageLayout>
       <div
         css={css`
-          position: sticky;
-          top: 0;
-          padding: 1rem 0;
           width: 100%;
-          background-color: rgba(255, 255, 255, 0.5);
-          backdrop-filter: blur(10px); /* 10px 블러 효과 */
-          z-index: ${theme.zIndex.header.content};
         `}
       >
         <ProgressStepBar>


### PR DESCRIPTION
[![NDD-364](https://badgen.net/badge/JIRA/NDD-364/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-364) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

문제 선택 페이지에서 이전, 다음 버튼을 하단에 고정하려고 시작한 작업인데 헤더추가랑 레이아웃 이것 저것 만지다 보니 변경사항이 많아졌네요.


# How
## 디자인 변경사항
- 문제 선택 페이지에 헤더가 없어서 불편하다는 피드백이 있어 헤더를 추가했습니다.
- 문제 선택 페이지 이전, 다음 버튼을 하단에 고정했습니다. 이 과정에서 InterviewSettingFooter가 포함된 `InterviewSettingContentLayout`을 분리했습니다.
- 헤더의 메뉴 토글 버튼과 로고의 위치가 미묘하게 맞지 않아서 가운데로 정렬했습니다.

## 토스트 문제 해결
- 토스트가 사라질 때 자연스럽게 사라지도록 collapseToast를 사용했는데 이 부분이 사라지고있는동안 뒷 부분의 상호작용을 막는다는 문제가 있었습니다. 따라서 `pointer-events`와 `touch-action` 속성을 조정해 이 문제를 해결했습니다.

# Result
<img width="1512" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/57657868/b4029d62-1ab8-43d9-8a56-ce71d1225992">

[NDD-364]: https://milk717.atlassian.net/browse/NDD-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ