### PR TITLE
[NDD-342]: 비즈니스로직 트랜잭션화 && DB서버와 메인 서버에 관한 헬스체크 기능 구현 (5h / 2h)

### DIFF
--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -45,6 +45,7 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.17",
+        "typeorm-transactional": "^0.5.0",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -3723,6 +3724,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cls-hooked": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.8.tgz",
+      "integrity": "sha512-tf/7H883gFA6MPlWI15EQtfNZ+oPL0gLKkOlx9UHFrun1fC/FkuyNBpTKq1B5E3T4fbvjId6WifHUdSGsMMuPg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.37",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.37.tgz",
@@ -4690,6 +4699,17 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
+    "node_modules/async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "dependencies": {
+        "stack-chain": "^1.3.7"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -5536,6 +5556,27 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "dependencies": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
+      }
+    },
+    "node_modules/cls-hooked/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -6247,6 +6288,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.576.tgz",
       "integrity": "sha512-yXsZyXJfAqzWk1WKryr0Wl0MN2D47xodPvEEwlVePBnhU5E7raevLQR+E6b9JAD3GfL/7MbAL9ZtWQQPcLx7wA==",
       "dev": true
+    },
+    "node_modules/emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "dependencies": {
+        "shimmer": "^1.2.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -11188,6 +11237,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -11393,6 +11447,11 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -12281,6 +12340,23 @@
         "typeorm-aurora-data-api-driver": {
           "optional": true
         }
+      }
+    },
+    "node_modules/typeorm-transactional": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/typeorm-transactional/-/typeorm-transactional-0.5.0.tgz",
+      "integrity": "sha512-53/CwnXpOIJnWU3oVCNbhHB95FwciKSGbY+m/Hw4e2dBM2c4toiOHwf4pmk83Ne7guznmDgVr/5IUfbp+JTPCg==",
+      "dependencies": {
+        "@types/cls-hooked": "^4.3.3",
+        "cls-hooked": "^4.2.2",
+        "semver": "^7.5.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "reflect-metadata": ">= 0.1.12",
+        "typeorm": ">= 0.2.8"
       }
     },
     "node_modules/typeorm/node_modules/brace-expansion": {

--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.465.0",
         "@aws-sdk/s3-request-presigner": "^3.465.0",
+        "@nestjs/axios": "^3.0.1",
         "@nestjs/class-transformer": "^0.4.0",
         "@nestjs/class-validator": "^0.13.4",
         "@nestjs/common": "^10.0.0",
@@ -20,6 +21,7 @@
         "@nestjs/passport": "^10.0.2",
         "@nestjs/platform-express": "^10.2.10",
         "@nestjs/swagger": "^7.1.14",
+        "@nestjs/terminus": "^10.2.0",
         "@nestjs/typeorm": "^10.0.0",
         "@types/bcrypt": "^5.0.1",
         "@types/cookie-parser": "^1.4.5",
@@ -28,6 +30,7 @@
         "@types/passport": "^1.0.14",
         "@types/passport-google-oauth20": "^2.0.13",
         "@types/passport-jwt": "^3.0.12",
+        "axios": "^1.6.2",
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
@@ -2496,6 +2499,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@nestjs/axios": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-3.0.1.tgz",
+      "integrity": "sha512-VlOZhAGDmOoFdsmewn8AyClAdGpKXQQaY1+3PGB+g6ceurGIdTxZgRX3VXc1T6Zs60PedWjg3A82TDOB05mrzQ==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "axios": "^1.3.1",
+        "reflect-metadata": "^0.1.12",
+        "rxjs": "^6.0.0 || ^7.0.0"
+      }
+    },
     "node_modules/@nestjs/class-transformer": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@nestjs/class-transformer/-/class-transformer-0.4.0.tgz",
@@ -2767,6 +2781,75 @@
           "optional": true
         },
         "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/terminus": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-10.2.0.tgz",
+      "integrity": "sha512-zPs98xvJ4ogEimRQOz8eU90mb7z+W/kd/mL4peOgrJ/VqER+ibN2Cboj65uJZW3XuNhpOqaeYOJte86InJd44A==",
+      "dependencies": {
+        "boxen": "5.1.2",
+        "check-disk-space": "3.4.0"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "*",
+        "@grpc/proto-loader": "*",
+        "@mikro-orm/core": "*",
+        "@mikro-orm/nestjs": "*",
+        "@nestjs/axios": "^1.0.0 || ^2.0.0 || ^3.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "@nestjs/microservices": "^9.0.0 || ^10.0.0",
+        "@nestjs/mongoose": "^9.0.0 || ^10.0.0",
+        "@nestjs/sequelize": "^9.0.0 || ^10.0.0",
+        "@nestjs/typeorm": "^9.0.0 || ^10.0.0",
+        "@prisma/client": "*",
+        "mongoose": "*",
+        "reflect-metadata": "0.1.x",
+        "rxjs": "7.x",
+        "sequelize": "*",
+        "typeorm": "*"
+      },
+      "peerDependenciesMeta": {
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "@grpc/proto-loader": {
+          "optional": true
+        },
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/nestjs": {
+          "optional": true
+        },
+        "@nestjs/axios": {
+          "optional": true
+        },
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/mongoose": {
+          "optional": true
+        },
+        "@nestjs/sequelize": {
+          "optional": true
+        },
+        "@nestjs/typeorm": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "mongoose": {
+          "optional": true
+        },
+        "sequelize": {
+          "optional": true
+        },
+        "typeorm": {
           "optional": true
         }
       }
@@ -4538,6 +4621,14 @@
         }
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -4713,8 +4804,17 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -4960,6 +5060,54 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/bplist-parser": {
       "version": "0.2.0",
@@ -5309,6 +5457,14 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "node_modules/check-disk-space": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
+      "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -5397,6 +5553,17 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -5674,7 +5841,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -6141,7 +6307,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7114,6 +7279,25 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "peer": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -7162,7 +7346,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -10536,6 +10719,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -12212,7 +12400,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -12766,6 +12953,17 @@
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/windows-release": {

--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -20,6 +20,7 @@
         "@nestjs/jwt": "^10.1.1",
         "@nestjs/passport": "^10.0.2",
         "@nestjs/platform-express": "^10.2.10",
+        "@nestjs/schedule": "^4.0.0",
         "@nestjs/swagger": "^7.1.14",
         "@nestjs/terminus": "^10.2.0",
         "@nestjs/typeorm": "^10.0.0",
@@ -2738,6 +2739,20 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-4.0.0.tgz",
+      "integrity": "sha512-zz4h54m/F/1qyQKvMJCRphmuwGqJltDAkFxUXCVqJBXEs5kbPt93Pza3heCQOcMH22MZNhGlc9DmDMLXVHmgVQ==",
+      "dependencies": {
+        "cron": "3.1.3",
+        "uuid": "9.0.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.12"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.0.3.tgz",
@@ -3959,6 +3974,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.7.tgz",
+      "integrity": "sha512-gKc9P2d4g5uYwmy4s/MO/yOVPmvHyvzka1YH6i5dM03UrFofHSmgc0D0ymbDRStFWHusk6cwwF6nhLm/ckBbbQ=="
     },
     "node_modules/@types/mime": {
       "version": "1.3.4",
@@ -6041,6 +6061,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "node_modules/cron": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.1.3.tgz",
+      "integrity": "sha512-KVxeKTKYj2eNzN4ElnT6nRSbjbfhyxR92O/Jdp6SH3pc05CDJws59jBrZWEMQlxevCiE6QUTrXy+Im3vC3oD3A==",
+      "dependencies": {
+        "@types/luxon": "~3.3.0",
+        "luxon": "~3.4.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -9209,6 +9238,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/macos-release": {

--- a/BE/package.json
+++ b/BE/package.json
@@ -56,6 +56,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17",
+    "typeorm-transactional": "^0.5.0",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/BE/package.json
+++ b/BE/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.465.0",
     "@aws-sdk/s3-request-presigner": "^3.465.0",
+    "@nestjs/axios": "^3.0.1",
     "@nestjs/class-transformer": "^0.4.0",
     "@nestjs/class-validator": "^0.13.4",
     "@nestjs/common": "^10.0.0",
@@ -31,6 +32,7 @@
     "@nestjs/passport": "^10.0.2",
     "@nestjs/platform-express": "^10.2.10",
     "@nestjs/swagger": "^7.1.14",
+    "@nestjs/terminus": "^10.2.0",
     "@nestjs/typeorm": "^10.0.0",
     "@types/bcrypt": "^5.0.1",
     "@types/cookie-parser": "^1.4.5",
@@ -39,6 +41,7 @@
     "@types/passport": "^1.0.14",
     "@types/passport-google-oauth20": "^2.0.13",
     "@types/passport-jwt": "^3.0.12",
+    "axios": "^1.6.2",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
@@ -116,7 +119,8 @@
       "main.ts",
       "google.strategy.ts",
       "/src/auth/",
-      "/src/token/"
+      "/src/token/",
+      "/src/health/"
     ]
   }
 }

--- a/BE/package.json
+++ b/BE/package.json
@@ -31,6 +31,7 @@
     "@nestjs/jwt": "^10.1.1",
     "@nestjs/passport": "^10.0.2",
     "@nestjs/platform-express": "^10.2.10",
+    "@nestjs/schedule": "^4.0.0",
     "@nestjs/swagger": "^7.1.14",
     "@nestjs/terminus": "^10.2.0",
     "@nestjs/typeorm": "^10.0.0",

--- a/BE/src/answer/controller/answer.controller.spec.ts
+++ b/BE/src/answer/controller/answer.controller.spec.ts
@@ -20,8 +20,6 @@ import { AnswerModule } from '../answer.module';
 import { QuestionModule } from '../../question/question.module';
 import { Answer } from '../entity/answer';
 import { Question } from '../../question/entity/question';
-import { Category } from '../../category/entity/category';
-import { Member } from '../../member/entity/member';
 import {
   addAppModules,
   createIntegrationTestModule,
@@ -38,7 +36,6 @@ import { DefaultAnswerRequest } from '../dto/defaultAnswerRequest';
 import { workbookFixture } from '../../workbook/fixture/workbook.fixture';
 import { WorkbookRepository } from '../../workbook/repository/workbook.repository';
 import { WorkbookModule } from '../../workbook/workbook.module';
-import { Workbook } from '../../workbook/entity/workbook';
 import { CategoryRepository } from '../../category/repository/category.repository';
 import { categoryFixtureWithId } from '../../category/fixture/category.fixture';
 
@@ -122,9 +119,8 @@ describe('AnswerController 통합테스트', () => {
       TokenModule,
       WorkbookModule,
     ];
-    const entities = [Answer, Question, Category, Member, Answer, Workbook];
 
-    const moduleFixture = await createIntegrationTestModule(modules, entities);
+    const moduleFixture = await createIntegrationTestModule(modules);
     app = moduleFixture.createNestApplication();
     addAppModules(app);
     await app.init();

--- a/BE/src/answer/service/answer.service.spec.ts
+++ b/BE/src/answer/service/answer.service.spec.ts
@@ -39,7 +39,6 @@ import { WorkbookModule } from '../../workbook/workbook.module';
 import { categoryFixtureWithId } from '../../category/fixture/category.fixture';
 import { CategoryRepository } from '../../category/repository/category.repository';
 import { CategoryModule } from '../../category/category.module';
-import { Category } from '../../category/entity/category';
 import { QuestionResponse } from '../../question/dto/questionResponse';
 
 describe('AnswerService 단위 테스트', () => {
@@ -193,9 +192,8 @@ describe('AnswerService 통합테스트', () => {
       WorkbookModule,
       CategoryModule,
     ];
-    const entities = [Answer, Question, Member, Answer, Workbook, Category];
 
-    const moduleFixture = await createIntegrationTestModule(modules, entities);
+    const moduleFixture = await createIntegrationTestModule(modules);
     app = moduleFixture.createNestApplication();
     await app.init();
 

--- a/BE/src/answer/service/answer.service.spec.ts
+++ b/BE/src/answer/service/answer.service.spec.ts
@@ -17,7 +17,10 @@ import { MemberModule } from '../../member/member.module';
 import { AnswerModule } from '../answer.module';
 import { Question } from '../../question/entity/question';
 import { Member } from '../../member/entity/member';
-import { createIntegrationTestModule } from '../../util/test.util';
+import {
+  createIntegrationTestModule,
+  createTypeOrmModuleForTest,
+} from '../../util/test.util';
 import { QuestionModule } from '../../question/question.module';
 import {
   answerFixture,
@@ -59,8 +62,13 @@ describe('AnswerService 단위 테스트', () => {
     findById: jest.fn(),
   };
 
+  jest.mock('typeorm-transactional', () => ({
+    Transactional: () => () => ({}),
+  }));
+
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [await createTypeOrmModuleForTest()],
       providers: [
         AnswerService,
         AnswerRepository,

--- a/BE/src/answer/service/answer.service.ts
+++ b/BE/src/answer/service/answer.service.ts
@@ -13,6 +13,7 @@ import { AnswerForbiddenException } from '../exception/answer.exception';
 import { WorkbookRepository } from '../../workbook/repository/workbook.repository';
 import { QuestionForbiddenException } from '../../question/exception/question.exception';
 import { validateWorkbook } from '../../workbook/util/workbook.util';
+import { Transactional } from 'typeorm-transactional';
 
 @Injectable()
 export class AnswerService {
@@ -22,6 +23,7 @@ export class AnswerService {
     private workbookRepository: WorkbookRepository,
   ) {}
 
+  @Transactional()
   async addAnswer(createAnswerRequest: CreateAnswerRequest, member: Member) {
     const question = await this.questionRepository.findOriginById(
       createAnswerRequest.questionId,
@@ -37,6 +39,7 @@ export class AnswerService {
     return AnswerResponse.from(answer, member);
   }
 
+  @Transactional()
   async setDefaultAnswer(
     defaultAnswerRequest: DefaultAnswerRequest,
     member: Member,
@@ -64,6 +67,7 @@ export class AnswerService {
     await this.questionRepository.update(question);
   }
 
+  @Transactional()
   async deleteAnswer(id: number, member: Member) {
     const answer = await this.answerRepository.findById(id);
 
@@ -77,6 +81,7 @@ export class AnswerService {
     throw new AnswerForbiddenException();
   }
 
+  @Transactional()
   async getAnswerList(id: number) {
     const question =
       await this.questionRepository.findQuestionWithOriginById(id);

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -20,6 +20,7 @@ import { Answer } from './answer/entity/answer';
 import { WorkbookModule } from './workbook/workbook.module';
 import { MulterModule } from '@nestjs/platform-express';
 import { Workbook } from './workbook/entity/workbook';
+import { HealthModule } from './health/health.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { Workbook } from './workbook/entity/workbook';
     CategoryModule,
     AnswerModule,
     WorkbookModule,
+    HealthModule,
   ],
   controllers: [AppController],
   providers: [

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -22,7 +22,7 @@ import { MulterModule } from '@nestjs/platform-express';
 
 @Module({
   imports: [
-    TypeOrmModule.forRoot(MYSQL_OPTION),
+    TypeOrmModule.forRootAsync(MYSQL_OPTION),
     TypeOrmModule.forFeature([Category, Member, Question, Answer]),
     MulterModule.register({
       dest: './uploads', // 파일이 저장될 경로 설정

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -19,11 +19,12 @@ import { Question } from './question/entity/question';
 import { Answer } from './answer/entity/answer';
 import { WorkbookModule } from './workbook/workbook.module';
 import { MulterModule } from '@nestjs/platform-express';
+import { Workbook } from './workbook/entity/workbook';
 
 @Module({
   imports: [
     TypeOrmModule.forRootAsync(MYSQL_OPTION),
-    TypeOrmModule.forFeature([Category, Member, Question, Answer]),
+    TypeOrmModule.forFeature([Category, Member, Question, Answer, Workbook]),
     MulterModule.register({
       dest: './uploads', // 파일이 저장될 경로 설정
     }),

--- a/BE/src/category/controller/category.controller.spec.ts
+++ b/BE/src/category/controller/category.controller.spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CategoryRepository } from '../repository/category.repository';
-import { Category } from '../entity/category';
 import { CategoryResponse } from '../dto/categoryResponse';
 import { INestApplication } from '@nestjs/common';
 import {
@@ -61,12 +60,9 @@ describe('CategoryController 통합 테스트', () => {
 
   beforeAll(async () => {
     const modules = [CategoryModule];
-    const entities = [Category];
 
-    const moduleFixture: TestingModule = await createIntegrationTestModule(
-      modules,
-      entities,
-    );
+    const moduleFixture: TestingModule =
+      await createIntegrationTestModule(modules);
 
     app = moduleFixture.createNestApplication();
     addAppModules(app);

--- a/BE/src/category/service/category.service.spec.ts
+++ b/BE/src/category/service/category.service.spec.ts
@@ -7,6 +7,7 @@ import { INestApplication } from '@nestjs/common';
 import {
   addAppModules,
   createIntegrationTestModule,
+  createTypeOrmModuleForTest,
 } from '../../util/test.util';
 import { CategoryModule } from '../category.module';
 
@@ -24,6 +25,7 @@ describe('CategoryService 단위 테스트', () => {
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [await createTypeOrmModuleForTest()],
       providers: [CategoryService, CategoryRepository],
     })
       .overrideProvider(CategoryRepository)

--- a/BE/src/category/service/category.service.spec.ts
+++ b/BE/src/category/service/category.service.spec.ts
@@ -18,6 +18,10 @@ describe('CategoryService 단위 테스트', () => {
     save: jest.fn(),
   };
 
+  jest.mock('typeorm-transactional', () => ({
+    Transactional: () => () => ({}),
+  }));
+
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [CategoryService, CategoryRepository],
@@ -56,12 +60,9 @@ describe('CategoryService 통합 테스트', () => {
 
   beforeAll(async () => {
     const modules = [CategoryModule];
-    const entities = [Category];
 
-    const moduleFixture: TestingModule = await createIntegrationTestModule(
-      modules,
-      entities,
-    );
+    const moduleFixture: TestingModule =
+      await createIntegrationTestModule(modules);
 
     app = moduleFixture.createNestApplication();
     addAppModules(app);

--- a/BE/src/category/service/category.service.ts
+++ b/BE/src/category/service/category.service.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { CategoryRepository } from '../repository/category.repository';
 import { CategoryResponse } from '../dto/categoryResponse';
+import { Transactional } from 'typeorm-transactional';
 
 @Injectable()
 export class CategoryService {
   constructor(private categoryRepository: CategoryRepository) {}
 
+  @Transactional()
   async findUsingCategories() {
     const categories = await this.categoryRepository.findAll();
 

--- a/BE/src/config/typeorm.config.ts
+++ b/BE/src/config/typeorm.config.ts
@@ -2,13 +2,20 @@ import { TypeOrmModuleAsyncOptions } from '@nestjs/typeorm';
 import 'dotenv/config';
 import { addTransactionalDataSource } from 'typeorm-transactional';
 import { DataSource } from 'typeorm';
+import { Member } from '../member/entity/member';
+import { Category } from '../category/entity/category';
+import { Workbook } from '../workbook/entity/workbook';
+import { Question } from '../question/entity/question';
+import { Answer } from '../answer/entity/answer';
 
 export const MYSQL_OPTION: TypeOrmModuleAsyncOptions = {
   useFactory() {
     return {
       type: 'mysql',
+      name: 'main',
       host: process.env.DATABASE_HOST,
       port: Number(process.env.DATABASE_PORT),
+      entities: [Member, Category, Workbook, Question, Answer],
       username: process.env.DATABASE_USER,
       password: process.env.DATABASE_PASSWORD,
       database: process.env.DATABASE,

--- a/BE/src/config/typeorm.config.ts
+++ b/BE/src/config/typeorm.config.ts
@@ -1,13 +1,26 @@
-import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { TypeOrmModuleAsyncOptions } from '@nestjs/typeorm';
 import 'dotenv/config';
+import { addTransactionalDataSource } from 'typeorm-transactional';
+import { DataSource } from 'typeorm';
 
-export const MYSQL_OPTION: TypeOrmModuleOptions = {
-  type: 'mysql',
-  host: process.env.DATABASE_HOST,
-  port: Number(process.env.DATABASE_PORT),
-  username: process.env.DATABASE_USER,
-  password: process.env.DATABASE_PASSWORD,
-  database: process.env.DATABASE,
-  autoLoadEntities: true,
-  synchronize: true,
+export const MYSQL_OPTION: TypeOrmModuleAsyncOptions = {
+  useFactory() {
+    return {
+      type: 'mysql',
+      host: process.env.DATABASE_HOST,
+      port: Number(process.env.DATABASE_PORT),
+      username: process.env.DATABASE_USER,
+      password: process.env.DATABASE_PASSWORD,
+      database: process.env.DATABASE,
+      autoLoadEntities: true,
+      synchronize: true,
+    };
+  },
+  async dataSourceFactory(options) {
+    if (!options) {
+      throw new Error('Invalid options passed');
+    }
+
+    return addTransactionalDataSource(new DataSource(options));
+  },
 };

--- a/BE/src/health/health.module.ts
+++ b/BE/src/health/health.module.ts
@@ -1,0 +1,33 @@
+import { Logger, Module } from '@nestjs/common';
+import {
+  HealthCheckService,
+  TerminusModule,
+  TypeOrmHealthIndicator,
+} from '@nestjs/terminus';
+import { HttpModule } from '@nestjs/axios';
+import { HealthCheckExecutor } from '@nestjs/terminus/dist/health-check/health-check-executor.service';
+import { LoggerService } from '../config/logger.config';
+import { ScheduleModule } from '@nestjs/schedule';
+import { HealthCheckScheduler } from './health.scheduler';
+
+const logger = new LoggerService('healthcheck');
+
+@Module({
+  imports: [TerminusModule, HttpModule, ScheduleModule.forRoot()],
+  providers: [
+    HealthCheckScheduler,
+    HealthCheckService,
+    TypeOrmHealthIndicator,
+    HealthCheckExecutor,
+    {
+      provide: 'TERMINUS_ERROR_LOGGER',
+      useValue: Logger.error.bind(logger),
+    },
+    {
+      provide: 'TERMINUS_LOGGER',
+      useValue: logger,
+    },
+  ],
+  controllers: [],
+})
+export class HealthModule {}

--- a/BE/src/health/health.scheduler.ts
+++ b/BE/src/health/health.scheduler.ts
@@ -6,6 +6,7 @@ import {
   TypeOrmHealthIndicator,
 } from '@nestjs/terminus';
 import { LoggerService } from '../config/logger.config';
+import 'dotenv/config';
 
 @Injectable()
 export class HealthCheckScheduler {
@@ -35,10 +36,7 @@ export class HealthCheckScheduler {
     try {
       await this.health.check([
         async () =>
-          await this.http.pingCheck(
-            'gomterview-main',
-            'https://api.gomterview.com/api/member/name',
-          ),
+          await this.http.pingCheck('gomterview-main', process.env.BE_URL),
       ]);
       this.main.log(`${new Date()} : ON`);
     } catch (error) {

--- a/BE/src/health/health.scheduler.ts
+++ b/BE/src/health/health.scheduler.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import {
+  HealthCheckService,
+  HttpHealthIndicator,
+  TypeOrmHealthIndicator,
+} from '@nestjs/terminus';
+import { LoggerService } from '../config/logger.config';
+
+@Injectable()
+export class HealthCheckScheduler {
+  private readonly dbLogger = new LoggerService('DB');
+  private readonly main = new LoggerService('MAIN');
+
+  constructor(
+    private health: HealthCheckService,
+    private db: TypeOrmHealthIndicator,
+    private http: HttpHealthIndicator,
+  ) {}
+
+  @Cron('0 * * * * *')
+  async checkDB() {
+    try {
+      await this.health.check([
+        async () => await this.db.pingCheck('database'),
+      ]);
+      this.dbLogger.log(`${new Date()} : ON`);
+    } catch (error) {
+      this.dbLogger.error(`${new Date()} : OFF`, error.stack);
+    }
+  }
+
+  @Cron('0 * * * * *')
+  async checkMain() {
+    try {
+      await this.health.check([
+        async () =>
+          await this.http.pingCheck(
+            'gomterview-main',
+            'https://api.gomterview.com/api/member/name',
+          ),
+      ]);
+      this.main.log(`${new Date()} : ON`);
+    } catch (error) {
+      this.main.error(`${new Date()} : OFF`, error.stack);
+    }
+  }
+}

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -4,8 +4,10 @@ import { ValidationPipe } from '@nestjs/common';
 import { setupSwagger } from './config/swagger.config';
 import { CORS_CONFIG } from './config/cors.config';
 import * as cookieParser from 'cookie-parser';
+import { initializeTransactionalContext } from 'typeorm-transactional';
 
 async function bootstrap() {
+  initializeTransactionalContext();
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser());
   app.useGlobalPipes(new ValidationPipe());

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -8,7 +8,9 @@ import { initializeTransactionalContext } from 'typeorm-transactional';
 
 async function bootstrap() {
   initializeTransactionalContext();
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, {
+    abortOnError: true,
+  });
   app.use(cookieParser());
   app.useGlobalPipes(new ValidationPipe());
   app.enableCors(CORS_CONFIG);

--- a/BE/src/member/controller/member.controller.spec.ts
+++ b/BE/src/member/controller/member.controller.spec.ts
@@ -20,12 +20,10 @@ import { MemberService } from '../service/member.service';
 import { TokenService } from '../../token/service/token.service';
 import { TokenModule } from '../../token/token.module';
 import { MemberModule } from '../member.module';
-import { Member } from '../entity/member';
 import {
   addAppModules,
   createIntegrationTestModule,
 } from '../../util/test.util';
-import { Category } from '../../category/entity/category';
 import { MemberNicknameResponse } from '../dto/memberNicknameResponse';
 import { MemberRepository } from '../repository/member.repository';
 import { JwtService } from '@nestjs/jwt';
@@ -138,12 +136,9 @@ describe('MemberController 통합 테스트', () => {
 
   beforeAll(async () => {
     const modules = [AuthModule, TokenModule, MemberModule];
-    const entities = [Member, Category];
 
-    const moduleFixture: TestingModule = await createIntegrationTestModule(
-      modules,
-      entities,
-    );
+    const moduleFixture: TestingModule =
+      await createIntegrationTestModule(modules);
 
     app = moduleFixture.createNestApplication();
     addAppModules(app);

--- a/BE/src/member/service/member.service.spec.ts
+++ b/BE/src/member/service/member.service.spec.ts
@@ -11,7 +11,6 @@ import {
 } from 'src/token/exception/token.exception';
 import { INestApplication } from '@nestjs/common';
 import { MemberModule } from '../member.module';
-import { Member } from '../entity/member';
 import { addAppModules, createIntegrationTestModule } from 'src/util/test.util';
 import { AuthModule } from 'src/auth/auth.module';
 import { AuthService } from 'src/auth/service/auth.service';
@@ -29,6 +28,10 @@ describe('MemberService 단위 테스트', () => {
     findById: jest.fn(),
     findByEmail: jest.fn(),
   };
+
+  jest.mock('typeorm-transactional', () => ({
+    Transactional: () => () => ({}),
+  }));
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -132,12 +135,8 @@ describe('MemberService 통합 테스트', () => {
 
   beforeAll(async () => {
     const modules = [MemberModule, AuthModule];
-    const entities = [Member];
-
-    const moduleFixture: TestingModule = await createIntegrationTestModule(
-      modules,
-      entities,
-    );
+    const moduleFixture: TestingModule =
+      await createIntegrationTestModule(modules);
 
     app = moduleFixture.createNestApplication();
     addAppModules(app);

--- a/BE/src/question/controller/question.controller.spec.ts
+++ b/BE/src/question/controller/question.controller.spec.ts
@@ -9,7 +9,6 @@ import {
 } from '../fixture/question.fixture';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { TokenModule } from '../../token/token.module';
-import { Member } from '../../member/entity/member';
 import { createIntegrationTestModule } from '../../util/test.util';
 import { QuestionModule } from '../question.module';
 import { AuthModule } from '../../auth/auth.module';
@@ -26,7 +25,6 @@ import { Question } from '../entity/question';
 import { CreateQuestionRequest } from '../dto/createQuestionRequest';
 import * as cookieParser from 'cookie-parser';
 import { QuestionRepository } from '../repository/question.repository';
-import { Answer } from '../../answer/entity/answer';
 import { WorkbookRepository } from '../../workbook/repository/workbook.repository';
 import { workbookFixture } from '../../workbook/fixture/workbook.fixture';
 import { WorkbookModule } from '../../workbook/workbook.module';
@@ -34,7 +32,6 @@ import { Workbook } from '../../workbook/entity/workbook';
 import { MemberRepository } from '../../member/repository/member.repository';
 import { CategoryRepository } from '../../category/repository/category.repository';
 import { CategoryModule } from '../../category/category.module';
-import { Category } from '../../category/entity/category';
 import { categoryFixtureWithId } from '../../category/fixture/category.fixture';
 import { CopyQuestionRequest } from '../dto/copyQuestionRequest';
 
@@ -131,12 +128,9 @@ describe('QuestionController 통합테스트', () => {
       WorkbookModule,
       CategoryModule,
     ];
-    const entities = [Member, Workbook, Question, Answer, Category];
 
-    const moduleFixture: TestingModule = await createIntegrationTestModule(
-      modules,
-      entities,
-    );
+    const moduleFixture: TestingModule =
+      await createIntegrationTestModule(modules);
 
     app = moduleFixture.createNestApplication();
     app.use(cookieParser());

--- a/BE/src/question/service/question.service.spec.ts
+++ b/BE/src/question/service/question.service.spec.ts
@@ -7,7 +7,10 @@ import {
   questionFixture,
 } from '../fixture/question.fixture';
 import { QuestionResponse } from '../dto/questionResponse';
-import { createIntegrationTestModule } from '../../util/test.util';
+import {
+  createIntegrationTestModule,
+  createTypeOrmModuleForTest,
+} from '../../util/test.util';
 import { QuestionModule } from '../question.module';
 import { Question } from '../entity/question';
 import { INestApplication } from '@nestjs/common';
@@ -63,6 +66,7 @@ describe('QuestionService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [await createTypeOrmModuleForTest()],
       providers: [QuestionService, QuestionRepository, WorkbookRepository],
     })
       .overrideProvider(QuestionRepository)

--- a/BE/src/question/service/question.service.spec.ts
+++ b/BE/src/question/service/question.service.spec.ts
@@ -20,7 +20,6 @@ import {
 } from '../../member/fixture/member.fixture';
 import { QuestionNotFoundException } from '../exception/question.exception';
 import { ManipulatedTokenNotFiltered } from '../../token/exception/token.exception';
-import { Answer } from '../../answer/entity/answer';
 import { AnswerModule } from '../../answer/answer.module';
 import { WorkbookRepository } from '../../workbook/repository/workbook.repository';
 import {
@@ -37,7 +36,6 @@ import {
 import { CategoryRepository } from '../../category/repository/category.repository';
 import { categoryFixtureWithId } from '../../category/fixture/category.fixture';
 import { CategoryModule } from '../../category/category.module';
-import { Category } from '../../category/entity/category';
 import { WorkbookIdResponse } from '../../workbook/dto/workbookIdResponse';
 import { CopyQuestionRequest } from '../dto/copyQuestionRequest';
 
@@ -58,6 +56,10 @@ describe('QuestionService', () => {
     findById: jest.fn(),
     update: jest.fn(),
   };
+
+  jest.mock('typeorm-transactional', () => ({
+    Transactional: () => () => ({}),
+  }));
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -283,9 +285,8 @@ describe('QuestionService 통합 테스트', () => {
       AnswerModule,
       CategoryModule,
     ];
-    const entities = [Question, Workbook, Member, Answer, Category];
 
-    const moduleFixture = await createIntegrationTestModule(modules, entities);
+    const moduleFixture = await createIntegrationTestModule(modules);
     app = moduleFixture.createNestApplication();
     await app.init();
 

--- a/BE/src/question/service/question.service.ts
+++ b/BE/src/question/service/question.service.ts
@@ -16,6 +16,7 @@ import { CopyQuestionRequest } from '../dto/copyQuestionRequest';
 import { Workbook } from '../../workbook/entity/workbook';
 import { WorkbookIdResponse } from '../../workbook/dto/workbookIdResponse';
 import { NeedToFindByWorkbookIdException } from '../../workbook/exception/workbook.exception';
+import { Transactional } from 'typeorm-transactional';
 
 @Injectable()
 export class QuestionService {
@@ -24,6 +25,7 @@ export class QuestionService {
     private workbookRepository: WorkbookRepository,
   ) {}
 
+  @Transactional()
   async createQuestion(
     createQuestionRequest: CreateQuestionRequest,
     member: Member,
@@ -42,6 +44,7 @@ export class QuestionService {
     return QuestionResponse.from(question);
   }
 
+  @Transactional()
   async copyQuestions(
     copyQuestionRequest: CopyQuestionRequest,
     member: Member,
@@ -69,6 +72,7 @@ export class QuestionService {
     return WorkbookIdResponse.of(workbook);
   }
 
+  @Transactional()
   async findAllByWorkbookId(workbookId: number) {
     if (isEmpty(workbookId)) {
       throw new NeedToFindByWorkbookIdException();
@@ -79,6 +83,7 @@ export class QuestionService {
     return questions.map(QuestionResponse.from);
   }
 
+  @Transactional()
   async deleteQuestionById(questionId: number, member: Member) {
     validateManipulatedToken(member);
     const question = await this.questionRepository.findById(questionId);

--- a/BE/src/util/test.util.ts
+++ b/BE/src/util/test.util.ts
@@ -1,25 +1,23 @@
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { EntitySchema } from 'typeorm';
+import { DataSource, DataSourceOptions, EntitySchema } from 'typeorm';
 import {
   DynamicModule,
   INestApplication,
   ValidationPipe,
 } from '@nestjs/common';
 import * as cookieParser from 'cookie-parser';
+import {
+  addTransactionalDataSource,
+  initializeTransactionalContext,
+} from 'typeorm-transactional';
 
 export const createIntegrationTestModule = async (
   modules: unknown[],
   entities: unknown[],
 ) => {
-  const ormModuleForTest = TypeOrmModule.forRoot({
-    type: 'sqlite', // 또는 다른 테스트용 데이터베이스 설정
-    database: ':memory:', // 메모리 데이터베이스 사용
-    entities: entities as (string | EntitySchema<any>)[],
-    synchronize: true,
-  });
-
-  modules.push(ormModuleForTest);
+  const ormModule = await createTypeOrmModuleForTest(entities);
+  modules.push(ormModule);
 
   return await Test.createTestingModule({
     imports: modules as DynamicModule[],
@@ -29,4 +27,30 @@ export const createIntegrationTestModule = async (
 export const addAppModules = (app: INestApplication) => {
   app.use(cookieParser());
   app.useGlobalPipes(new ValidationPipe());
+};
+
+export const createTypeOrmModuleForTest = async (entities: unknown[]) => {
+  const module = TypeOrmModule.forRootAsync({
+    useFactory() {
+      return ormModuleForTest(entities);
+    },
+    async dataSourceFactory(options) {
+      if (!options) {
+        throw new Error('Invalid options passed');
+      }
+
+      return addTransactionalDataSource(new DataSource(options));
+    },
+  });
+  initializeTransactionalContext();
+  return module;
+};
+
+export const ormModuleForTest = (entities: unknown[]): DataSourceOptions => {
+  return {
+    type: 'sqlite', // 또는 다른 테스트용 데이터베이스 설정
+    database: ':memory:',
+    entities: entities as (string | EntitySchema<any>)[],
+    synchronize: true,
+  };
 };

--- a/BE/src/util/test.util.ts
+++ b/BE/src/util/test.util.ts
@@ -19,10 +19,7 @@ import { Question } from '../question/entity/question';
 import { Answer } from '../answer/entity/answer';
 import { Video } from '../video/entity/video';
 
-export const createIntegrationTestModule = async (
-  modules: unknown[],
-  entities: unknown[],
-) => {
+export const createIntegrationTestModule = async (modules: unknown[]) => {
   const ormModule = await createTypeOrmModuleForTest();
   modules.push(ormModule);
 
@@ -58,5 +55,6 @@ export const ormModuleForTest = (): DataSourceOptions => {
     database: ':memory:',
     entities: [Member, Category, Workbook, Question, Answer, Video],
     synchronize: true,
+    logging: true,
   };
 };

--- a/BE/src/util/test.util.ts
+++ b/BE/src/util/test.util.ts
@@ -55,6 +55,5 @@ export const ormModuleForTest = (): DataSourceOptions => {
     database: ':memory:',
     entities: [Member, Category, Workbook, Question, Answer, Video],
     synchronize: true,
-    logging: true,
   };
 };

--- a/BE/src/util/test.util.ts
+++ b/BE/src/util/test.util.ts
@@ -1,6 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { DataSource, DataSourceOptions, EntitySchema } from 'typeorm';
+import { DataSource, DataSourceOptions } from 'typeorm';
 import {
   DynamicModule,
   INestApplication,
@@ -9,14 +9,21 @@ import {
 import * as cookieParser from 'cookie-parser';
 import {
   addTransactionalDataSource,
+  getDataSourceByName,
   initializeTransactionalContext,
 } from 'typeorm-transactional';
+import { Member } from '../member/entity/member';
+import { Category } from '../category/entity/category';
+import { Workbook } from '../workbook/entity/workbook';
+import { Question } from '../question/entity/question';
+import { Answer } from '../answer/entity/answer';
+import { Video } from '../video/entity/video';
 
 export const createIntegrationTestModule = async (
   modules: unknown[],
   entities: unknown[],
 ) => {
-  const ormModule = await createTypeOrmModuleForTest(entities);
+  const ormModule = await createTypeOrmModuleForTest();
   modules.push(ormModule);
 
   return await Test.createTestingModule({
@@ -29,28 +36,27 @@ export const addAppModules = (app: INestApplication) => {
   app.useGlobalPipes(new ValidationPipe());
 };
 
-export const createTypeOrmModuleForTest = async (entities: unknown[]) => {
+export const createTypeOrmModuleForTest = async () => {
   const module = TypeOrmModule.forRootAsync({
     useFactory() {
-      return ormModuleForTest(entities);
+      return ormModuleForTest();
     },
     async dataSourceFactory(options) {
-      if (!options) {
-        throw new Error('Invalid options passed');
-      }
-
-      return addTransactionalDataSource(new DataSource(options));
+      return (
+        getDataSourceByName('default') ||
+        addTransactionalDataSource(new DataSource(options))
+      );
     },
   });
   initializeTransactionalContext();
   return module;
 };
 
-export const ormModuleForTest = (entities: unknown[]): DataSourceOptions => {
+export const ormModuleForTest = (): DataSourceOptions => {
   return {
     type: 'sqlite', // 또는 다른 테스트용 데이터베이스 설정
     database: ':memory:',
-    entities: entities as (string | EntitySchema<any>)[],
+    entities: [Member, Category, Workbook, Question, Answer, Video],
     synchronize: true,
   };
 };

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -33,13 +33,8 @@ import { VideoHashResponse } from '../dto/videoHashResponse';
 import { SingleVideoResponse } from '../dto/singleVideoResponse';
 import { MemberNotFoundException } from 'src/member/exception/member.exception';
 import { INestApplication } from '@nestjs/common';
-import { Video } from '../entity/video';
 import { VideoModule } from '../video.module';
 import { addAppModules, createIntegrationTestModule } from 'src/util/test.util';
-import { Member } from 'src/member/entity/member';
-import { Question } from 'src/question/entity/question';
-import { Workbook } from 'src/workbook/entity/workbook';
-import { Answer } from 'src/answer/entity/answer';
 import { AuthService } from 'src/auth/service/auth.service';
 import { AuthModule } from 'src/auth/auth.module';
 import * as request from 'supertest';
@@ -51,7 +46,6 @@ import 'dotenv/config';
 import { VideoRepository } from '../repository/video.repository';
 import * as crypto from 'crypto';
 import { MemberRepository } from 'src/member/repository/member.repository';
-import { Category } from 'src/category/entity/category';
 import { CategoryRepository } from 'src/category/repository/category.repository';
 import { categoryFixtureWithId } from 'src/category/fixture/category.fixture';
 
@@ -594,12 +588,9 @@ describe('VideoController 통합 테스트', () => {
 
   beforeAll(async () => {
     const modules = [VideoModule, AuthModule];
-    const entities = [Video, Member, Question, Workbook, Answer, Category];
 
-    const moduleFixture: TestingModule = await createIntegrationTestModule(
-      modules,
-      entities,
-    );
+    const moduleFixture: TestingModule =
+      await createIntegrationTestModule(modules);
 
     app = moduleFixture.createNestApplication();
     addAppModules(app);

--- a/BE/src/video/service/video.service.spec.ts
+++ b/BE/src/video/service/video.service.spec.ts
@@ -38,13 +38,8 @@ import { MemberNotFoundException } from 'src/member/exception/member.exception';
 import { VideoHashResponse } from '../dto/videoHashResponse';
 import { VideoModule } from '../video.module';
 import { Video } from '../entity/video';
-import { Member } from 'src/member/entity/member';
-import { Question } from 'src/question/entity/question';
-import { Workbook } from 'src/workbook/entity/workbook';
-import { Category } from 'src/category/entity/category';
 import { addAppModules, createIntegrationTestModule } from 'src/util/test.util';
 import { INestApplication } from '@nestjs/common';
-import { Answer } from 'src/answer/entity/answer';
 import { CategoryRepository } from 'src/category/repository/category.repository';
 import { WorkbookRepository } from 'src/workbook/repository/workbook.repository';
 import { categoryFixtureWithId } from 'src/category/fixture/category.fixture';
@@ -77,6 +72,10 @@ describe('VideoService 단위 테스트', () => {
   const mockQuestionRepository = {
     findById: jest.fn(),
   };
+
+  jest.mock('typeorm-transactional', () => ({
+    Transactional: () => () => ({}),
+  }));
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -667,12 +666,9 @@ describe('VideoService 통합 테스트', () => {
 
   beforeAll(async () => {
     const modules = [VideoModule, QuestionModule];
-    const entities = [Video, Member, Question, Answer, Workbook, Category];
 
-    const moduleFixture: TestingModule = await createIntegrationTestModule(
-      modules,
-      entities,
-    );
+    const moduleFixture: TestingModule =
+      await createIntegrationTestModule(modules);
 
     app = moduleFixture.createNestApplication();
     addAppModules(app);

--- a/BE/src/workbook/controller/workbook.controller.spec.ts
+++ b/BE/src/workbook/controller/workbook.controller.spec.ts
@@ -24,9 +24,7 @@ import { MemberRepository } from '../../member/repository/member.repository';
 import { AuthModule } from '../../auth/auth.module';
 import { WorkbookModule } from '../workbook.module';
 import { CategoryModule } from '../../category/category.module';
-import { Member } from '../../member/entity/member';
 import { Workbook } from '../entity/workbook';
-import { Category } from '../../category/entity/category';
 import { createIntegrationTestModule } from '../../util/test.util';
 import * as cookieParser from 'cookie-parser';
 import { TokenModule } from '../../token/token.module';
@@ -305,12 +303,9 @@ describe('WorkbookController 통합테스트', () => {
 
   beforeAll(async () => {
     const modules = [AuthModule, WorkbookModule, CategoryModule, TokenModule];
-    const entities = [Member, Workbook, Category];
 
-    const moduleFixture: TestingModule = await createIntegrationTestModule(
-      modules,
-      entities,
-    );
+    const moduleFixture: TestingModule =
+      await createIntegrationTestModule(modules);
 
     app = moduleFixture.createNestApplication();
     app.use(cookieParser());

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -25,14 +25,12 @@ import { MemberRepository } from '../../member/repository/member.repository';
 import { AuthModule } from '../../auth/auth.module';
 import { WorkbookModule } from '../workbook.module';
 import { CategoryModule } from '../../category/category.module';
-import { Member } from '../../member/entity/member';
 import { Workbook } from '../entity/workbook';
 import {
   createIntegrationTestModule,
   createTypeOrmModuleForTest,
 } from '../../util/test.util';
 import * as cookieParser from 'cookie-parser';
-import { Category } from '../../category/entity/category';
 import { CreateWorkbookRequest } from '../dto/createWorkbookRequest';
 import { WorkbookResponse } from '../dto/workbookResponse';
 import {
@@ -364,12 +362,9 @@ describe('WorkbookService 통합테스트', () => {
 
   beforeAll(async () => {
     const modules = [AuthModule, WorkbookModule, CategoryModule, TokenModule];
-    const entities = [Member, Workbook, Category];
 
-    const moduleFixture: TestingModule = await createIntegrationTestModule(
-      modules,
-      entities,
-    );
+    const moduleFixture: TestingModule =
+      await createIntegrationTestModule(modules);
 
     app = moduleFixture.createNestApplication();
     app.use(cookieParser());

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -27,7 +27,10 @@ import { WorkbookModule } from '../workbook.module';
 import { CategoryModule } from '../../category/category.module';
 import { Member } from '../../member/entity/member';
 import { Workbook } from '../entity/workbook';
-import { createIntegrationTestModule } from '../../util/test.util';
+import {
+  createIntegrationTestModule,
+  createTypeOrmModuleForTest,
+} from '../../util/test.util';
 import * as cookieParser from 'cookie-parser';
 import { Category } from '../../category/entity/category';
 import { CreateWorkbookRequest } from '../dto/createWorkbookRequest';
@@ -38,8 +41,10 @@ import {
 } from '../exception/workbook.exception';
 import { WorkbookTitleResponse } from '../dto/workbookTitleResponse';
 import { UpdateWorkbookRequest } from '../dto/updateWorkbookRequest';
+import { TokenModule } from '../../token/token.module';
 
 describe('WorkbookService 단위테스트', () => {
+  let module: TestingModule;
   let service: WorkbookService;
   const mockCategoryRepository = {
     findByCategoryId: jest.fn(),
@@ -58,8 +63,13 @@ describe('WorkbookService 단위테스트', () => {
     findByIdWithoutJoin: jest.fn(),
   };
 
+  jest.mock('typeorm-transactional', () => ({
+    Transactional: () => () => ({}),
+  }));
+
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
+      imports: [await createTypeOrmModuleForTest([])],
       providers: [WorkbookService, CategoryRepository, WorkbookRepository],
     })
       .overrideProvider(CategoryRepository)
@@ -67,9 +77,10 @@ describe('WorkbookService 단위테스트', () => {
       .overrideProvider(WorkbookRepository)
       .useValue(mockWorkbookRepository)
       .compile();
-
     service = module.get<WorkbookService>(WorkbookService);
   });
+
+  beforeEach(() => {});
 
   it('should be defined', () => {
     expect(service).toBeDefined();
@@ -352,7 +363,7 @@ describe('WorkbookService 통합테스트', () => {
   let workbookRepository: WorkbookRepository;
 
   beforeAll(async () => {
-    const modules = [AuthModule, WorkbookModule, CategoryModule];
+    const modules = [AuthModule, WorkbookModule, CategoryModule, TokenModule];
     const entities = [Member, Workbook, Category];
 
     const moduleFixture: TestingModule = await createIntegrationTestModule(

--- a/BE/src/workbook/service/workbook.service.spec.ts
+++ b/BE/src/workbook/service/workbook.service.spec.ts
@@ -69,7 +69,7 @@ describe('WorkbookService 단위테스트', () => {
 
   beforeAll(async () => {
     module = await Test.createTestingModule({
-      imports: [await createTypeOrmModuleForTest([])],
+      imports: [await createTypeOrmModuleForTest()],
       providers: [WorkbookService, CategoryRepository, WorkbookRepository],
     })
       .overrideProvider(CategoryRepository)

--- a/BE/src/workbook/service/workbook.service.ts
+++ b/BE/src/workbook/service/workbook.service.ts
@@ -11,6 +11,7 @@ import { isEmpty } from 'class-validator';
 import { validateWorkbook, validateWorkbookOwner } from '../util/workbook.util';
 import { WorkbookTitleResponse } from '../dto/workbookTitleResponse';
 import { UpdateWorkbookRequest } from '../dto/updateWorkbookRequest';
+import { Transactional } from 'typeorm-transactional';
 
 @Injectable()
 export class WorkbookService {
@@ -19,6 +20,7 @@ export class WorkbookService {
     private categoryRepository: CategoryRepository,
   ) {}
 
+  @Transactional()
   async createWorkbook(
     createWorkbookRequest: CreateWorkbookRequest,
     member: Member,
@@ -40,6 +42,7 @@ export class WorkbookService {
     return result.identifiers[0].id as number;
   }
 
+  @Transactional()
   async findWorkbooks(categoryId: number) {
     if (isEmpty(categoryId)) {
       return await this.findAllWorkbook();
@@ -63,6 +66,7 @@ export class WorkbookService {
     return workbooks.map(WorkbookResponse.of);
   }
 
+  @Transactional()
   async findWorkbookTitles(member: Member) {
     const workbooks = await this.findWorkbookByMember(member);
     return workbooks.map(WorkbookTitleResponse.of);
@@ -76,6 +80,7 @@ export class WorkbookService {
     return await this.workbookRepository.findMembersWorkbooks(member.id);
   }
 
+  @Transactional()
   async findSingleWorkbook(workbookId: number) {
     const workbook = await this.workbookRepository.findById(workbookId);
     validateWorkbook(workbook);
@@ -83,6 +88,7 @@ export class WorkbookService {
     return WorkbookResponse.of(workbook);
   }
 
+  @Transactional()
   async updateWorkbook(
     updateWorkbookRequest: UpdateWorkbookRequest,
     member: Member,
@@ -105,6 +111,7 @@ export class WorkbookService {
     return WorkbookResponse.of(workbook);
   }
 
+  @Transactional()
   async deleteWorkbookById(workbookId: number, member: Member) {
     validateManipulatedToken(member);
     const workbook =


### PR DESCRIPTION
[![NDD-342](https://badgen.net/badge/JIRA/NDD-342/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-342) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

비즈니스로직에서 동작하는 일련의 쿼리들이 개별적으로 동작한다. 
- 문제집 복사 : 문제집의 copyCount를 증가시키고, 질문을 복사하는 과정에서 중간 문제가 있을 경우 모든 플로우를 롤백시켜야 한다
- 트랜잭션화를 통해 하나의 요청단위로 에러가 있을 때 롤백이 가능하다. 

서버의 상태를 확인하기 위한 수단이 필요했다. 
- DB, Main서버가 죽었을 때 이를 확인하고 대응하기 늦다는 문제가 있다. 
- 이를 위해, nestjs에서 지원하는 HealthCheck, Cron을 이용하기로 했다.

# How

## Transaction

- TypeORM-Transactional 라이브러리를 이용해 동작시키게 했다. 
```
export const MYSQL_OPTION: TypeOrmModuleAsyncOptions = {
  useFactory() {
    return {
      type: 'mysql',
      name: 'main',
      host: process.env.DATABASE_HOST,
      port: Number(process.env.DATABASE_PORT),
      entities: [Member, Category, Workbook, Question, Answer],
      username: process.env.DATABASE_USER,
      password: process.env.DATABASE_PASSWORD,
      database: process.env.DATABASE,
      autoLoadEntities: true,
      synchronize: true,
    };
  },
  async dataSourceFactory(options) {
    if (!options) {
      throw new Error('Invalid options passed');
    }

    return addTransactionalDataSource(new DataSource(options));
  },
};
```
- 아래의 로직을 통해, 데이터소스 팩토리를 하나 등록해 이걸로 동작하게 했다. 
- 추가적인 트랜잭션 컨텍스트, 데이터 소스 팩토리는 등록하지 않았다. (후에 기능적 / 트랜잭션 분리의 이유로 수정하게 될 수 있다)
- 이후에 비즈니스로직에서 트랜잭션화 시키는 부분을 @Transactional() 데코레이터로 처리시켰다. 

```
 jest.mock('typeorm-transactional', () => ({
    Transactional: () => () => ({}),
  }));
```
- 이러한 로직으로 Transactional데코레이터가 붙은 부분을 모킹할 수 있었다.

### Error Point
```
Error: DataSource with name "default" has already added.
```
- jest를 이용해 모든 로직을 테스트할 때, 해당 에러가 불규칙적으로 나타나는 현상이 존재했다. 
- 이유 : jest자체가 이를 어렵게 했다. 
    - jest는 모든 테스트가 `병렬적`으로 이루어진다. 
    - 각 테스트는 TestModule을 만들어 사용한다. 
    - 즉, jest가 데이터베이스(sqlite)를 이용해 테스트를 할 때, 각자가 데이터소스 팩토리를 만들게 된다. 

### 해결방법
```
export const createTypeOrmModuleForTest = async () => {
  const module = TypeOrmModule.forRootAsync({
    useFactory() {
      return ormModuleForTest();
    },
    async dataSourceFactory(options) {
      return (
        getDataSourceByName('default') ||
        addTransactionalDataSource(new DataSource(options))
      );
    },
  });
  initializeTransactionalContext();
  return module;
};
```
- dataSourceFactory가 새로운 데이터팩토리를 만드는 것이 아닌, 이미 `default`라는 이름의 팩토리가 있다면 이를 사용하고, 없다면 새롭게 만드는 방식으로 진행해 테스트를 성공시켰다. 
- 다른 해결책 : 각자의 테스트가 다른 dataSourceFactory를 이용하게 하는 방법이 있다. 
    - 하지만 테스트를 진행하는 하드웨어 환경에서 얼마나 병렬적으로 다른 팩토리를 만들어야 할지, 그리고 그렇게 분리하는 것이 효율적인지 테스트에 대한 확인이 필요하다. 
    - CI, Window, Mac, EC2인스턴스등의 모든 환경에서 테스트 수행에 이슈가 없도록, 단일 팩토리로 진행했다. 

## HealthCheck
서버의 이상이 있을 때 우리가 할 수 있는 행동은 장애 감지, 장애 복구, DB 클러스터링, 로드 밸런싱이 있다. 
- 장애 복구의 과정은 클라우드 서비스, 외부 환경등을 이용하는 구조로 되어있어. 장애 감지를 최대한 수월하게 하기로 했다. 
- DB 클러스터링 또한 여러 DB 서버를 두어야 하는 문제로, 현재는 추가하지 않기로 했다. 
- 로드 밸런싱, 장애 감지 방법이 있고, 로드 밸런싱은 DB/Main에 모두 등록해야 하기에 이를 일괄적으로 처리하기 위해 이후 이슈로 남겨두었다.

### 장애 감지 방법
- 로깅
- 에러 핸들링
- 헬스 체크

이렇게 3가지 방법으로 장애를 감지할 수 있다. 
이 중에, 로깅/헬스체크를 합쳐 구현해보기로 했다. 

### Library
- nestjs/schedule : @Cron을 통해 일정 시간마다 동작을 진행시킬 수 있다.
- nestjs/terminus : 각 서버에 간단한 요청을 보내고, 이에 따른 상태 검사를 할 수 있다. 

### Code
```
@Injectable()
export class HealthCheckScheduler {
  private readonly dbLogger = new LoggerService('DB');
  private readonly main = new LoggerService('MAIN');

  constructor(
    private health: HealthCheckService,
    private db: TypeOrmHealthIndicator,
    private http: HttpHealthIndicator,
  ) {}

  @Cron('0 * * * * *')
  async checkDB() {
    try {
      await this.health.check([
        async () => await this.db.pingCheck('database'),
      ]);
      this.dbLogger.log(`${new Date()} : ON`);
    } catch (error) {
      this.dbLogger.error(`${new Date()} : OFF`, error.stack);
    }
  }

  @Cron('0 * * * * *')
  async checkMain() {
    try {
      await this.health.check([
        async () =>
          await this.http.pingCheck('gomterview-main', process.env.BE_URL),
      ]);
      this.main.log(`${new Date()} : ON`);
    } catch (error) {
      this.main.error(`${new Date()} : OFF`, error.stack);
    }
  }
}
```
- 2개의 함수로 이루어져 있다. 
- pingCheck로 해당 주소에 ping을 보내고, 응답이 있으면 단순 로그를, 없다면 error로그를 발생시키게 했다. 
- logger는 윈스턴을 이용했다. 
- 매 1분마다 해당 서버가 살아있는지 확인할 수 있게 된다. 
- 해당 코드를 실행시킨 signaling 서버(우리는 프론트엔드개발자만 사용하는 dev서버를 이용한다)의 로그로 현재 상태를 확인할 수 있다.


# Result

<img width="465" alt="스크린샷 2023-12-11 18 13 49" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/cd7fe82f-cca7-4284-b05f-a7a4f3c1ff4c">
- 모든 플로우를 단일 트랜잭션 내에서 처리할 수 있게 되었다. 

![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/0b1a30d1-9bfc-4d46-9f37-6032234b2208)
- 매 시간마다 서버가 살아있는지 로그를 등록하게 되었다. 

# Prize

- 로직의 트랜잭션화로 롤백처리가 가능해지며, 트랜잭션 단위로 움직여 매 순간 요청/응답을 기다리는 것 보다 더 효율적으로 동작할 수 있게 된다. 
- 서버의 상태 관리를 일관적으로 진행할 수 있다.

# Reference

- https://docs.nestjs.com/recipes/terminus
- https://docs.nestjs.com/techniques/task-scheduling
- https://www.npmjs.com/package/typeorm-transactional


[NDD-342]: https://milk717.atlassian.net/browse/NDD-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ