### PR TITLE
[NDD-368]: 해시로 비디오 조회 시 다른 비디오가 조회되는 문제 해결 & 테스트를 위한 ioredis-mock 사용 (6h / 4h)

### DIFF
--- a/.github/workflows/backend_ci_tool.yml
+++ b/.github/workflows/backend_ci_tool.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Make .env
         run: |
           touch ./.env
-          echo "${{ secrets.BE_ENV }}" > ./.env
+          echo "${{ secrets.BE_CI_ENV }}" > ./.env
       - name: Make Cors Config
         run: |
           cd src/config

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -34,6 +34,8 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      - name: Prune old Docker images
+        run: sudo docker image prune -a -f
       - name: Pull Docker image
         run: sudo docker pull ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}}
       - name: Delete Old docker container

--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -62,6 +62,7 @@
         "eslint": "^8.42.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
+        "ioredis-mock": "^8.9.0",
         "jest": "^29.5.0",
         "prettier": "^3.0.0",
         "source-map-support": "^0.5.21",
@@ -1846,6 +1847,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+      "dev": true
+    },
+    "node_modules/@ioredis/as-callback": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/as-callback/-/as-callback-3.0.0.tgz",
+      "integrity": "sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==",
       "dev": true
     },
     "node_modules/@ioredis/commands": {
@@ -3819,6 +3826,17 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.3.tgz",
       "integrity": "sha512-pP0P/9BnCj1OVvQR2lF41EkDG/lWWnDyA203b/4Fmi2eTyORnBtcDoKDwjWQthELrBvWkMOrvSOnZ8OVlW6tXA=="
+    },
+    "node_modules/@types/ioredis-mock": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/@types/ioredis-mock/-/ioredis-mock-8.2.5.tgz",
+      "integrity": "sha512-cZyuwC9LGtg7s5G9/w6rpy3IOZ6F/hFR0pQlWYZESMo1xQUYbDpa6haqB4grTePjsGzcB/YLBFCjqRunK5wieg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "ioredis": ">=5"
+      }
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -6879,6 +6897,32 @@
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
       "peer": true
     },
+    "node_modules/fengari": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.4.tgz",
+      "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
+      "dev": true,
+      "dependencies": {
+        "readline-sync": "^1.4.9",
+        "sprintf-js": "^1.1.1",
+        "tmp": "^0.0.33"
+      }
+    },
+    "node_modules/fengari-interop": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.3.tgz",
+      "integrity": "sha512-EtZ+oTu3kEwVJnoymFPBVLIbQcCoy9uWCVnMA6h3M/RqHkUBsLYp29+RRHf9rKr6GwjubWREU1O7RretFIXjHw==",
+      "dev": true,
+      "peerDependencies": {
+        "fengari": "^0.1.0"
+      }
+    },
+    "node_modules/fengari/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -7766,6 +7810,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis-mock": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-8.9.0.tgz",
+      "integrity": "sha512-yIglcCkI1lvhwJVoMsR51fotZVsPsSk07ecTCgRTRlicG0Vq3lke6aAaHklyjmRNRsdYAgswqC2A0bPtQK4LSw==",
+      "dev": true,
+      "dependencies": {
+        "@ioredis/as-callback": "^3.0.0",
+        "@ioredis/commands": "^1.2.0",
+        "fengari": "^0.1.4",
+        "fengari-interop": "^0.1.3",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12.22"
+      },
+      "peerDependencies": {
+        "@types/ioredis-mock": "^8",
+        "ioredis": "^5"
       }
     },
     "node_modules/ip": {
@@ -10621,6 +10685,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/rechoir": {

--- a/BE/package.json
+++ b/BE/package.json
@@ -73,6 +73,7 @@
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "ioredis-mock": "^8.9.0",
     "jest": "^29.5.0",
     "prettier": "^3.0.0",
     "source-map-support": "^0.5.21",

--- a/BE/src/util/idrive.util.ts
+++ b/BE/src/util/idrive.util.ts
@@ -1,14 +1,23 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { IDRIVE_CONFIG } from 'src/config/idrive.config';
 
 let s3Client: S3Client; // 싱글톤으로 유지할 S3 Client 인스턴스
 
-export const getIdriveS3Client = (): S3Client => {
+const getIdriveS3Client = (): S3Client => {
   if (!s3Client) {
     s3Client = new S3Client(IDRIVE_CONFIG);
   }
   return s3Client;
 };
 
-export const getPutCommandObject = (key: string): PutObjectCommand =>
+const getPutCommandObject = (key: string): PutObjectCommand =>
   new PutObjectCommand({ Bucket: 'videos', Key: key });
+
+export async function getSignedUrlWithKey(key: string) {
+  const s3 = getIdriveS3Client();
+  const command = getPutCommandObject(key);
+  const expiresIn = 10;
+
+  return await getSignedUrl(s3, command, { expiresIn });
+}

--- a/BE/src/util/redis.util.ts
+++ b/BE/src/util/redis.util.ts
@@ -9,7 +9,10 @@ import {
 export const saveToRedis = async (key: string, value: string) => {
   const redis = new Redis(process.env.REDIS_URL as string);
   try {
-    await redis.set(key, value);
+    await redis.watch(key);
+    const transaction = redis.multi();
+    transaction.set(key, value);
+    await transaction.exec();
   } catch (error) {
     throw new RedisSaveException();
   } finally {
@@ -20,7 +23,10 @@ export const saveToRedis = async (key: string, value: string) => {
 export const deleteFromRedis = async (key: string) => {
   const redis = new Redis(process.env.REDIS_URL as string);
   try {
-    await redis.del(key);
+    await redis.watch(key);
+    const transaction = redis.multi();
+    transaction.del(key);
+    await transaction.exec();
   } catch (error) {
     throw new RedisDeleteException();
   } finally {

--- a/BE/src/util/redis.util.ts
+++ b/BE/src/util/redis.util.ts
@@ -8,7 +8,7 @@ import {
 import redisMock from 'ioredis-mock';
 
 const getNewRedis = () => {
-  return process.env.IS_PRODUCTION
+  return process.env.IS_PROD === 'true'
     ? new Redis(process.env.REDIS_URL as string)
     : new redisMock();
 };

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -12,12 +12,14 @@ import { Request, Response } from 'express';
 import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import {
   IDriveException,
+  InvalidHashException,
   Md5HashException,
   RedisDeleteException,
   RedisRetrieveException,
   RedisSaveException,
   VideoAccessForbiddenException,
   VideoNotFoundException,
+  VideoNotFoundWithHashException,
   VideoOfWithdrawnMemberException,
 } from '../exception/video.exception';
 import {
@@ -235,6 +237,20 @@ describe('VideoController 단위 테스트', () => {
       expect(result).toBe(mockVideoDetailWithHash);
     });
 
+    it('해시로 비디오 조회 시 해시의 길이가 32자가 아니라면 InvalidHashException을 반환한다.', async () => {
+      // given
+
+      // when
+      mockVideoService.getVideoDetailByHash.mockRejectedValue(
+        new InvalidHashException(),
+      );
+
+      // then
+      expect(controller.getVideoDetailByHash(hash)).rejects.toThrow(
+        InvalidHashException,
+      );
+    });
+
     it('해시로 비디오 조회 시 비디오가 private이라면 VideoAccessForbiddenException을 반환한다.', async () => {
       // given
 
@@ -260,6 +276,20 @@ describe('VideoController 단위 테스트', () => {
       // then
       expect(controller.getVideoDetailByHash(hash)).rejects.toThrow(
         VideoOfWithdrawnMemberException,
+      );
+    });
+
+    it('해시로 비디오 조회 시 유효한 해시지만 조회되는 비디오가 없다면 VideoNotFoundWithHashException을 반환한다.', async () => {
+      // given
+
+      // when
+      mockVideoService.getVideoDetailByHash.mockRejectedValue(
+        new VideoNotFoundWithHashException(),
+      );
+
+      // then
+      expect(controller.getVideoDetailByHash(hash)).rejects.toThrow(
+        VideoNotFoundWithHashException,
       );
     });
 

--- a/BE/src/video/controller/video.controller.spec.ts
+++ b/BE/src/video/controller/video.controller.spec.ts
@@ -805,11 +805,12 @@ describe('VideoController 통합 테스트', () => {
 
     it('해시로 private인 비디오 조회를 요청하면 403 상태 코드가 반환된다.', async () => {
       // given
-      await videoRepository.save(privateVideoFixture);
+      const video = await videoRepository.save(privateVideoFixture);
       const hash = crypto
         .createHash('md5')
         .update(privateVideoFixture.url)
         .digest('hex');
+      await saveToRedis(hash, video.url);
 
       // when & then
       const agent = request.agent(app.getHttpServer());

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -127,8 +127,9 @@ export class VideoController {
       VideoDetailResponse,
     ),
   )
+  @ApiResponse(createApiResponseOption(400, 'V10', null))
   @ApiResponse(createApiResponseOption(403, 'V02', null))
-  @ApiResponse(createApiResponseOption(404, 'V04, M01', null))
+  @ApiResponse(createApiResponseOption(404, 'V04, V09, M01', null))
   @ApiResponse(createApiResponseOption(500, 'V06', null))
   async getVideoDetailByHash(@Param('hash') hash: string) {
     return await this.videoService.getVideoDetailByHash(hash);

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -8,9 +8,7 @@ import {
   Post,
   Req,
   Res,
-  UploadedFile,
   UseGuards,
-  UseInterceptors,
 } from '@nestjs/common';
 import { VideoService } from '../service/video.service';
 import { Request, Response } from 'express';
@@ -28,9 +26,6 @@ import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import { VideoDetailResponse } from '../dto/videoDetailResponse';
 import { VideoHashResponse } from '../dto/videoHashResponse';
 import { SingleVideoResponse } from '../dto/singleVideoResponse';
-import { FileInterceptor } from '@nestjs/platform-express';
-import { UPLOAD_UTIL } from '../../util/encoder.util';
-import { UploadVideoRequest } from '../dto/uploadVideoRequest';
 import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
 
 @Controller('/api/video')
@@ -38,33 +33,33 @@ import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
 export class VideoController {
   constructor(private videoService: VideoService) {}
 
-  @Post('upload')
-  @UseGuards(TokenHardGuard)
-  @ApiCookieAuth()
-  @ApiBody({ type: UploadVideoRequest })
-  @ApiOperation({
-    summary: '비디오를 인코딩/클라우드 저장/테이블 저장',
-  })
-  @ApiResponse(
-    createApiResponseOption(
-      201,
-      '비디오 인코딩/클라우드 저장/테이블 저장 완료',
-      null,
-    ),
-  )
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
-  @UseInterceptors(FileInterceptor('file', UPLOAD_UTIL))
-  async uploadFile(
-    @UploadedFile() file: Express.Multer.File,
-    @Req() req: Request,
-    @Body() uploadVideoRequest: UploadVideoRequest,
-  ) {
-    await this.videoService.saveVideoOnCloud(
-      uploadVideoRequest,
-      req.user as Member,
-      file,
-    );
-  }
+  // @Post('upload')
+  // @UseGuards(TokenHardGuard)
+  // @ApiCookieAuth()
+  // @ApiBody({ type: UploadVideoRequest })
+  // @ApiOperation({
+  //   summary: '비디오를 인코딩/클라우드 저장/테이블 저장',
+  // })
+  // @ApiResponse(
+  //   createApiResponseOption(
+  //     201,
+  //     '비디오 인코딩/클라우드 저장/테이블 저장 완료',
+  //     null,
+  //   ),
+  // )
+  // @ApiResponse(createApiResponseOption(500, 'SERVER', null))
+  // @UseInterceptors(FileInterceptor('file', UPLOAD_UTIL))
+  // async uploadFile(
+  //   @UploadedFile() file: Express.Multer.File,
+  //   @Req() req: Request,
+  //   @Body() uploadVideoRequest: UploadVideoRequest,
+  // ) {
+  //   await this.videoService.saveVideoOnCloud(
+  //     uploadVideoRequest,
+  //     req.user as Member,
+  //     file,
+  //   );
+  // }
 
   @Post()
   @UseGuards(TokenHardGuard)

--- a/BE/src/video/controller/video.controller.ts
+++ b/BE/src/video/controller/video.controller.ts
@@ -124,7 +124,7 @@ export class VideoController {
   )
   @ApiResponse(createApiResponseOption(400, 'V10', null))
   @ApiResponse(createApiResponseOption(403, 'V02', null))
-  @ApiResponse(createApiResponseOption(404, 'V04, V09, M01', null))
+  @ApiResponse(createApiResponseOption(404, 'V03, V04, V09, M01', null))
   @ApiResponse(createApiResponseOption(500, 'V06', null))
   async getVideoDetailByHash(@Param('hash') hash: string) {
     return await this.videoService.getVideoDetailByHash(hash);

--- a/BE/src/video/dto/uploadVideoRequest.ts
+++ b/BE/src/video/dto/uploadVideoRequest.ts
@@ -1,23 +1,23 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { createPropertyOption } from '../../util/swagger.util';
-import { IsNotEmpty, IsNumberString, IsString, Matches } from 'class-validator';
+// import { ApiProperty } from '@nestjs/swagger';
+// import { createPropertyOption } from '../../util/swagger.util';
+// import { IsNotEmpty, IsNumberString, IsString, Matches } from 'class-validator';
 
-export class UploadVideoRequest {
-  @ApiProperty(createPropertyOption(1, '문제 ID', Number))
-  @IsNumberString()
-  @IsNotEmpty()
-  questionId: string;
+// export class UploadVideoRequest {
+//   @ApiProperty(createPropertyOption(1, '문제 ID', Number))
+//   @IsNumberString()
+//   @IsNotEmpty()
+//   questionId: string;
 
-  @ApiProperty(createPropertyOption('03:29', '비디오 길이', String))
-  @IsString()
-  @IsNotEmpty()
-  @Matches(/^\d{2}:\d{2}$/, {
-    message: `유효하지 않은 비디오 길이 형태입니다. "mm:ss" 형태로 요청해주세요.`,
-  })
-  videoLength: string;
+//   @ApiProperty(createPropertyOption('03:29', '비디오 길이', String))
+//   @IsString()
+//   @IsNotEmpty()
+//   @Matches(/^\d{2}:\d{2}$/, {
+//     message: `유효하지 않은 비디오 길이 형태입니다. "mm:ss" 형태로 요청해주세요.`,
+//   })
+//   videoLength: string;
 
-  constructor(questionId: number, videoLength: string) {
-    this.questionId = String(questionId);
-    this.videoLength = videoLength;
-  }
-}
+//   constructor(questionId: number, videoLength: string) {
+//     this.questionId = String(questionId);
+//     this.videoLength = videoLength;
+//   }
+// }

--- a/BE/src/video/exception/video.exception.ts
+++ b/BE/src/video/exception/video.exception.ts
@@ -6,7 +6,7 @@ import {
 
 export class IDriveException extends HttpInternalServerError {
   constructor() {
-    super('IDrive 제공 API 처리 도중 에러가 발생하였습니다.', 'V01');
+    super('비디오 업로드 API 처리 도중 에러가 발생하였습니다.', 'V01');
   }
 }
 
@@ -30,24 +30,30 @@ export class VideoOfWithdrawnMemberException extends HttpNotFoundException {
 
 export class RedisDeleteException extends HttpInternalServerError {
   constructor() {
-    super('Redis에서 비디오 정보 삭제 중 오류가 발생하였습니다.', 'V05');
+    super('비디오 정보 삭제 중 오류가 발생하였습니다.', 'V05');
   }
 }
 
 export class RedisRetrieveException extends HttpInternalServerError {
   constructor() {
-    super('Redis에서 비디오 정보를 가져오는 중 오류가 발생하였습니다.', 'V06');
+    super('비디오 정보를 가져오는 중 오류가 발생하였습니다.', 'V06');
   }
 }
 
 export class RedisSaveException extends HttpInternalServerError {
   constructor() {
-    super('Redis에 비디오 정보 저장 중 오류가 발생하였습니다.', 'V07');
+    super('비디오 정보 저장 중 오류가 발생하였습니다.', 'V07');
   }
 }
 
 export class Md5HashException extends HttpInternalServerError {
   constructor() {
-    super('MD5 해시 생성 중 오류가 발생했습니다.', 'V08');
+    super('해시 생성 중 오류가 발생했습니다.', 'V08');
+  }
+}
+
+export class InvalidHashException extends HttpNotFoundException {
+  constructor() {
+    super('유효하지 않은 해시값입니다.', 'V09');
   }
 }

--- a/BE/src/video/exception/video.exception.ts
+++ b/BE/src/video/exception/video.exception.ts
@@ -52,8 +52,14 @@ export class Md5HashException extends HttpInternalServerError {
   }
 }
 
+export class VideoNotFoundWithHashException extends HttpNotFoundException {
+  constructor() {
+    super('해당 해시값으로 등록된 비디오를 조회할 수 없습니다.', 'V09');
+  }
+}
+
 export class InvalidHashException extends HttpNotFoundException {
   constructor() {
-    super('유효하지 않은 해시값입니다.', 'V09');
+    super('유효하지 않은 해시값입니다.', 'V10');
   }
 }

--- a/BE/src/video/exception/video.exception.ts
+++ b/BE/src/video/exception/video.exception.ts
@@ -1,4 +1,5 @@
 import {
+  HttpBadRequestException,
   HttpForbiddenException,
   HttpInternalServerError,
   HttpNotFoundException,
@@ -58,7 +59,7 @@ export class VideoNotFoundWithHashException extends HttpNotFoundException {
   }
 }
 
-export class InvalidHashException extends HttpNotFoundException {
+export class InvalidHashException extends HttpBadRequestException {
   constructor() {
     super('유효하지 않은 해시값입니다.', 'V10');
   }

--- a/BE/src/video/service/video.service.spec.ts
+++ b/BE/src/video/service/video.service.spec.ts
@@ -843,20 +843,28 @@ describe('VideoService 통합 테스트', () => {
       await redisUtil.deleteFromRedis(hash);
     });
 
-    it('해시로 비디오 세부 정보 조회 시 private인 비디오를 조회하려 하면 VideoAccessForbiddenException을 반환한다.', async () => {
-      //given
-      const video = await videoRepository.save(privateVideoFixture);
-      const hash = crypto.createHash('md5').update(video.url).digest('hex');
-      await redisUtil.saveToRedis(hash, video.url);
+    it('해시로 비디오 상세 정보 조회 시 해시가 유효하지 않은 형태라면 InvalidHashException을 반환한다.', async () => {
+      // given
+      const hash = 'invalidHash';
+      // when
 
-      //when
-
-      //then
+      // then
       await expect(videoService.getVideoDetailByHash(hash)).rejects.toThrow(
-        VideoAccessForbiddenException,
+        InvalidHashException,
       );
+    });
 
-      await redisUtil.deleteFromRedis(hash);
+    it('해시로 비디오 상세 정보 조회 시 해시로 조회되는 비디오가 없다면 VideoNotFoundWithHashException을 반환한다.', async () => {
+      // given
+      const video = await videoRepository.save(videoFixture);
+      const hash = crypto.createHash('md5').update(video.url).digest('hex');
+
+      // when
+
+      // then
+      await expect(videoService.getVideoDetailByHash(hash)).rejects.toThrow(
+        VideoNotFoundWithHashException,
+      );
     });
 
     it('해시로 비디오 세부 정보 조회 시 탈퇴한 회원의 비디오를 조회하려 하면 VideoOfWithdrawnMemberException을 반환한다.', async () => {
@@ -870,6 +878,22 @@ describe('VideoService 통합 테스트', () => {
       //then
       await expect(videoService.getVideoDetailByHash(hash)).rejects.toThrow(
         VideoOfWithdrawnMemberException,
+      );
+
+      await redisUtil.deleteFromRedis(hash);
+    });
+
+    it('해시로 비디오 세부 정보 조회 시 private인 비디오를 조회하려 하면 VideoAccessForbiddenException을 반환한다.', async () => {
+      //given
+      const video = await videoRepository.save(privateVideoFixture);
+      const hash = crypto.createHash('md5').update(video.url).digest('hex');
+      await redisUtil.saveToRedis(hash, video.url);
+
+      //when
+
+      //then
+      await expect(videoService.getVideoDetailByHash(hash)).rejects.toThrow(
+        VideoAccessForbiddenException,
       );
 
       await redisUtil.deleteFromRedis(hash);

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -8,6 +8,7 @@ import { PreSignedUrlResponse } from '../dto/preSignedUrlResponse';
 import { QuestionRepository } from 'src/question/repository/question.repository';
 import {
   IDriveException,
+  InvalidHashException,
   Md5HashException,
   VideoAccessForbiddenException,
   VideoNotFoundException,
@@ -138,6 +139,8 @@ export class VideoService {
 
   async getVideoDetailByHash(hash: string) {
     const originUrl = await getValueFromRedis(hash);
+    if (isEmpty(originUrl)) throw new InvalidHashException();
+
     const video = await this.videoRepository.findByUrl(originUrl);
     if (!video.isPublic) throw new VideoAccessForbiddenException();
     if (isEmpty(video.memberId)) throw new VideoOfWithdrawnMemberException();

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -51,60 +51,60 @@ export class VideoService {
     private memberRepository: MemberRepository,
   ) {}
 
-  async saveVideoOnCloud(
-    uploadVideoRequest: UploadVideoRequest,
-    member: Member,
-    file: Express.Multer.File,
-  ) {
-    await this.uploadVideo(file);
-    const videoUrl = await this.sendToBucket(file.originalname, '.mp4');
-    const thumbnail = await this.sendToBucket(file.originalname, '.png');
-    const videoTitle = await this.createVideoTitle(
-      member,
-      Number(uploadVideoRequest.questionId),
-    );
-    await this.createVideo(
-      member,
-      new CreateVideoRequest(
-        Number(uploadVideoRequest.questionId),
-        videoTitle,
-        videoUrl,
-        thumbnail,
-        uploadVideoRequest.videoLength,
-      ),
-    );
-  }
+  // async saveVideoOnCloud(
+  //   uploadVideoRequest: UploadVideoRequest,
+  //   member: Member,
+  //   file: Express.Multer.File,
+  // ) {
+  //   await this.uploadVideo(file);
+  //   const videoUrl = await this.sendToBucket(file.originalname, '.mp4');
+  //   const thumbnail = await this.sendToBucket(file.originalname, '.png');
+  //   const videoTitle = await this.createVideoTitle(
+  //     member,
+  //     Number(uploadVideoRequest.questionId),
+  //   );
+  //   await this.createVideo(
+  //     member,
+  //     new CreateVideoRequest(
+  //       Number(uploadVideoRequest.questionId),
+  //       videoTitle,
+  //       videoUrl,
+  //       thumbnail,
+  //       uploadVideoRequest.videoLength,
+  //     ),
+  //   );
+  // }
 
-  async uploadVideo(file: Express.Multer.File) {
-    logUploadStart(file.originalname);
-    await createDirectoryIfNotExist();
-    await saveVideoIfNotExists(file);
-    await encodeToUpload(file.originalname);
-  }
+  // async uploadVideo(file: Express.Multer.File) {
+  //   logUploadStart(file.originalname);
+  //   await createDirectoryIfNotExist();
+  //   await saveVideoIfNotExists(file);
+  //   await encodeToUpload(file.originalname);
+  // }
 
-  async sendToBucket(name: string, ext: string) {
-    const key = `${uuidv4()}${ext}`;
-    const s3 = new S3(IDRIVE_CONFIG);
-    const contentType = ext === '.mp4' ? 'video/mp4' : 'image/png';
-    const params = {
-      Bucket: ext === '.mp4' ? 'videos' : 'thumbnail',
-      ACL: 'public',
-      Key: key,
-      Body: await readFileAsBuffer(name.replace('.webm', ext)),
-      ContentType: contentType,
-    };
-    await new Promise((resolve, reject) => {
-      s3.putObject(params as PutObjectCommandInput, (err, data) => {
-        if (err) reject(err);
-        console.log(data);
-        resolve(key);
-      });
-    });
-    await deleteFile(name.replace('.webm', ext));
-    return `${process.env.IDRIVE_READ_URL}/${
-      ext === '.mp4' ? 'videos' : 'thumbnail'
-    }/${key}`;
-  }
+  // async sendToBucket(name: string, ext: string) {
+  //   const key = `${uuidv4()}${ext}`;
+  //   const s3 = new S3(IDRIVE_CONFIG);
+  //   const contentType = ext === '.mp4' ? 'video/mp4' : 'image/png';
+  //   const params = {
+  //     Bucket: ext === '.mp4' ? 'videos' : 'thumbnail',
+  //     ACL: 'public',
+  //     Key: key,
+  //     Body: await readFileAsBuffer(name.replace('.webm', ext)),
+  //     ContentType: contentType,
+  //   };
+  //   await new Promise((resolve, reject) => {
+  //     s3.putObject(params as PutObjectCommandInput, (err, data) => {
+  //       if (err) reject(err);
+  //       console.log(data);
+  //       resolve(key);
+  //     });
+  //   });
+  //   await deleteFile(name.replace('.webm', ext));
+  //   return `${process.env.IDRIVE_READ_URL}/${
+  //     ext === '.mp4' ? 'videos' : 'thumbnail'
+  //   }/${key}`;
+  // }
 
   async createVideo(member: Member, createVideoRequest: CreateVideoRequest) {
     validateManipulatedToken(member);

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -12,6 +12,7 @@ import {
   Md5HashException,
   VideoAccessForbiddenException,
   VideoNotFoundException,
+  VideoNotFoundWithHashException,
   VideoOfWithdrawnMemberException,
 } from '../exception/video.exception';
 import { CreateVideoRequest } from '../dto/createVideoRequest';
@@ -138,8 +139,10 @@ export class VideoService {
   }
 
   async getVideoDetailByHash(hash: string) {
+    if (hash.length != 32) throw new InvalidHashException();
+
     const originUrl = await getValueFromRedis(hash);
-    if (isEmpty(originUrl)) throw new InvalidHashException();
+    if (isEmpty(originUrl)) throw new VideoNotFoundWithHashException();
 
     const video = await this.videoRepository.findByUrl(originUrl);
     if (!video.isPublic) throw new VideoAccessForbiddenException();

--- a/BE/src/video/service/video.service.ts
+++ b/BE/src/video/service/video.service.ts
@@ -31,17 +31,6 @@ import {
 import { SingleVideoResponse } from '../dto/singleVideoResponse';
 import { MemberNotFoundException } from 'src/member/exception/member.exception';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import {
-  createDirectoryIfNotExist,
-  deleteFile,
-  encodeToUpload,
-  logUploadStart,
-  readFileAsBuffer,
-  saveVideoIfNotExists,
-} from '../../util/encoder.util';
-import { PutObjectCommandInput, S3 } from '@aws-sdk/client-s3';
-import { IDRIVE_CONFIG } from '../../config/idrive.config';
-import { UploadVideoRequest } from '../dto/uploadVideoRequest';
 
 @Injectable()
 export class VideoService {
@@ -182,13 +171,13 @@ export class VideoService {
     await this.videoRepository.remove(video);
   }
 
-  private async createVideoTitle(member: Member, questionId: number) {
-    const question = await this.questionRepository.findById(questionId);
+  // private async createVideoTitle(member: Member, questionId: number) {
+  //   const question = await this.questionRepository.findById(questionId);
 
-    return `${member.nickname}_${
-      question ? question.content : '삭제된 질문입니다'
-    }_${uuidv4().split('-').pop()}`;
-  }
+  //   return `${member.nickname}_${
+  //     question ? question.content : '삭제된 질문입니다'
+  //   }_${uuidv4().split('-').pop()}`;
+  // }
 
   private validateVideoOwnership(video: Video, memberId: number) {
     if (isEmpty(video)) throw new VideoNotFoundException();


### PR DESCRIPTION
[![NDD-368](https://badgen.net/badge/JIRA/NDD-368/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-368) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
해시로 비디오 조회 시 아래의 세 가지 경우에 대한 에러 핸들링이 안되어 있어서 추후에 실제 서비스 시 문제가 발생할 가능성이 있어보여 이에 대한 에러 핸들링 로직을 추가할 필요성이 있었음
1. 유효하지 않은 해시값을 사용할 경우 (md5 해시가 아닐 경우)
2. Redis 상에서 존재하지 않는 해시를 사용할 경우
3. Redis 상에 존재하는 해시값으로 조회한 URL로 DB에 저장된 비디오가 없는 경우

현재 Prod 서버에서 사용 중인 Redis에서 테스트가 진행되기에 실제 사용 중인 데이터들과 충돌이 일어나는 현상이 발생하지 않게 하는 것이 중요하다고 판단되어, 테스트 환경에서는 Redis가 아닌 ioredis-mock을 사용하도록 변경할 필요성이 있었음

예상 시간인 4시간보다 크게 벗어난 이유는 아래와 같다.
1. 테스트 시 발생한 문제
- 외부 모듈을 모킹하는 것에 어려움이 있었음 (2시간 정도 소요)
이전 테스트 코드를 작성하는 동안 S3RequestPresigner라는 외부 모듈을 모킹해야하는 경우가 있었다.
처음에는 모듈 전체를 mocking하고 spyOn을 사용하는 것으로 진행했으나 단위 테스트 후의 통합 테스트에서도 모킹된 상태로 남아있어 테스트가 전혀 지장되지 않았다.

그래서 그 다음으로 생각한 것이 내장 모듈을 모킹하는 것처럼 `const getValueFromRedisSpy = jest.spyOn(S3RequestPresigner, 'getSignedUrl');`와 같은 형태로 모킹을 진행하려했으나 내장 모듈이 아니어서 그런지 계속해서 재정의를 할 수 없다는 오류만이 출력되었다.

최종적으로 해결한 방법은 S3RequestPresigner를 사용하는 부분을 개발자가 직접 만든 모듈의 메서드 내에서 사용되도록 리팩터링을 진행한 후 직접 만든 메서드를 모킹하여 이를 사용하는 방법이다. 마치 내장 모듈을 모킹한 것처럼 손쉽게 사용할 수 있도록 하였다. 자세한 코드는 아래의 How를 참조

- 테스트 진행 시 하나의 테스트가 완료되면 이전 테스트의 결과로 남아있는 값으로 인한 문제가 발생
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/b0726e26-a393-495b-bd51-7b27ce432716)
위의 사진과 같이 계속해서 하나의 테스트 케이스에 대해 계속해서 테스트를 실패하였다. 로컬에서는 계속 통과가 되었지만, CI를 진행하던 중에 문제가 발생하였다.
이에 대한 해결을 위해, 테스트 하나가 완료되면 DB를 모두 비우는 것처럼, Redis 자체도 바로 비워주도록 해야했고 그렇기에 ioredis-mock 사용까지 한 번에 진행하였다.

2. 애초에 시간을 너무 타이트하게 잡았음
처음에 넉넉하게 테스트 코드가 예상한 만큼 잘 짜여줄 알고, 개발 1시간 / 테스트 코드 관련 1시간 이렇게 잡은 것이 문제였다. 지금 현재 테스트 케이스가 300개에 육박하는데 어디선가 문제가 발생을 안 할꺼라고 낙관적으로 시간을 잡아서 많이 시간이 오버되었다.

# How
1.  에러 핸들링
- 유효하지 않은 해시값을 사용할 경우 (md5 해시가 아닐 경우)
- Redis 상에서 존재하지 않는 해시를 사용할 경우
- Redis 상에 존재하는 해시값으로 조회한 URL로 DB에 저장된 비디오가 없는 경우

위의 3가지 경우에 대한 에러 핸들링 로직을 서비스 로직에 추가
```JavaScript
...
if (hash.length != 32) throw new InvalidHashException();

const originUrl = await getValueFromRedis(hash);
if (isEmpty(originUrl)) throw new VideoNotFoundWithHashException();

const video = await this.videoRepository.findByUrl(originUrl);
if (isEmpty(video)) throw new VideoNotFoundException();
...
```

2. 외부 모듈 모킹에 내부 메서드를 사용한 방법
```JavaScript
let s3Client: S3Client; // 싱글톤으로 유지할 S3 Client 인스턴스

const getIdriveS3Client = (): S3Client => {
  if (!s3Client) {
    s3Client = new S3Client(IDRIVE_CONFIG);
  }
  return s3Client;
};

const getPutCommandObject = (key: string): PutObjectCommand =>
  new PutObjectCommand({ Bucket: 'videos', Key: key });

export async function getSignedUrlWithKey(key: string) {
  const s3 = getIdriveS3Client();
  const command = getPutCommandObject(key);
  const expiresIn = 10;

  return await getSignedUrl(s3, command, { expiresIn });
}
```
위와 같이 getSignedUrl이라는 외부 모듈을 사용하는 부분이 원래는 videoService 자체에 들어가 있어 이를 모킹하는 것에 어려움이 있었으나, 아예 위처럼 util 메서드로 모듈 분리를 시켜서 진행하도록 변경하고나니 이를 모킹하는 작업이 훨씬 쉬워졌다.

```JavaScript
import * as idriveUtil from 'src/util/idrive.util';

const getSignedUrlWithKeySpy = jest.spyOn(
  idriveUtil,
  'getSignedUrlWithKey',
);
getSignedUrlWithKeySpy.mockResolvedValueOnce(url);
```
위와 같이 간단하게 모킹하여 사용할 수 있다.

3. ioredis-mock을 사용한 방법
```JavaScript
const getNewRedis = () => {
  return process.env.IS_PROD === 'true'
    ? new Redis(process.env.REDIS_URL as string)
    : new redisMock();
};

export const saveToRedis = async (
  key: string,
  value: string,
  redis: Redis = getNewRedis(),
) => {
 ...
};

export const deleteFromRedis = async (
  key: string,
  redis: Redis = getNewRedis(),
) => {
...
};

export const getValueFromRedis = async (
  key: string,
  redis: Redis = getNewRedis(),
) => {
  ...
};

export const clearRedis = async (redis: Redis) => {
  try {
    await redis.flushdb();
  } catch (error) {
    throw new Error('Redis 초기화 실패');
  } finally {
    await redis.quit();
  }
};
```
위와 같이 구현하여 ioredis-mock을 사용할 수 있도록 구현하였다. 현재 실행되는 프로젝트가 어떤 상태인지 IS_PROD라는 환경변수 값에 맞게 분기하여 처리하도록 하였다.
또 하나의 문제가 테스트 케이스 별로 따로 ioredis-mock 인스턴스를 생성하여 사용하는데 이 경우는 옵셔널 파라미터를 사용하여 옵셔널 파라미터로 테스트 케이스 별로 ioredis-mock 인스턴스를 가지게 하였고, 일반적인 상황에서는 현재 프로젝트의 상태에 따라 실제 Redis 또는 ioredis-mock을 사용하도록 구현하였다.

# Result
테스트 코드에 새롭게 추가된 에러 핸들링 로직에 대한 검증도 추가되어 있기에 테스트가 잘 실행되는지 확인하면 이번에 진행한 두 가지 태스크에 대한 체크가 가능

로컬에서 테스트가 모두 통과하는지 확인
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/77132784-c0cb-4ce3-afec-babe49fbd0f7)


CI 환경에서는 5번씩 테스트를 진행하여 오류없이 테스트가 잘 진행되는지 확인하였음
![image](https://github.com/boostcampwm2023/web14-gomterview/assets/99426344/b7125612-c760-4267-9a32-1b4c4d3fa91f)


# Prize
유효하지 않은 해시값을 사용할 경우나, Redis 상에서 존재하지 않는 해시를 사용할 경우, 마지막으로 Redis에서 조회된 URL을 가진 비디오가 DB에서 제거된 경우와 같이 비디오 조회 로직에서 치명적인 에러를 일으킬 수 있는 에러에 대한 예외 처리를 확실하게 진행할 수 있었음

테스트 진행 시에 실제 Redis를 더 이상 사용하지 않기에 실제 배포되어 있는 서비스의 데이터와 Redis 내부에서 충돌이 일어날 가능성이 아예 사라짐

개인적으로도 아직 테스트에 대해 아는 것이 많이 부족하다고 느낄 수 있었다. 외부 모듈 불러와서 이를 모킹하고 사용하는 것이 너무나도 어렵다는 점, 외부 모듈을 사용하는 경우에는 서비스 내부 메서드에서 외부 모듈을 사용하게 한 후 이를 모킹하는 것이 더 편리하다는 것을 깨닫게 되었다.

[NDD-368]: https://milk717.atlassian.net/browse/NDD-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ