### PR TITLE
[NDD-369] Modal 레이아웃에서 transtion 적용 (0.5h/0.5h)

### DIFF
--- a/FE/src/components/foundation/Modal/ModalLayout.tsx
+++ b/FE/src/components/foundation/Modal/ModalLayout.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from 'react';
 import Box from '../Box/Box';
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import { theme } from '@/styles/theme';
 import { HTMLElementTypes } from '@/types/utils';
 
@@ -10,29 +9,30 @@ export type ModalLayoutProps = {
   closeModal: () => void;
 } & HTMLElementTypes<HTMLDivElement>;
 
+const ModalAnimation = keyframes`
+  from {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+`;
+
 export const ModalLayout: React.FC<ModalLayoutProps> = ({
   children,
   isOpen,
   closeModal,
   ...args
 }) => {
-  const [isDisplayed, setIsDisplayed] = useState(false);
-
-  useEffect(() => {
-    if (isOpen) {
-      setIsDisplayed(true);
-    } else {
-      setIsDisplayed(false);
-    }
-  }, [isOpen]);
-
   document.body.style.overflow = isOpen ? 'hidden' : 'unset';
 
   return (
     <div
       css={css`
         position: fixed;
-        display: ${isOpen ? 'flex' : 'none'};
+        display: flex;
         justify-content: center;
         align-items: center;
         top: 0;
@@ -42,8 +42,6 @@ export const ModalLayout: React.FC<ModalLayoutProps> = ({
         height: 100%;
         background-color: ${theme.colors.shadow.modalShadow};
         ${theme.typography.body1}
-        opacity: ${isDisplayed ? '1' : '0'};
-        transition: opacity 0.2s ease-out;
       `}
       onClick={() => {
         closeModal();
@@ -55,8 +53,7 @@ export const ModalLayout: React.FC<ModalLayoutProps> = ({
           background-color: ${theme.colors.text.white};
           height: auto;
           width: auto;
-          transform: ${isDisplayed ? 'scale(1)' : 'scale(0.5)'};
-          transition: transform 0.2s ease-out;
+          animation: 0.2s ease-in-out ${ModalAnimation};
         `}
         onClick={(e) => e.stopPropagation()}
         {...args}

--- a/FE/src/components/foundation/Modal/ModalLayout.tsx
+++ b/FE/src/components/foundation/Modal/ModalLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Box from '../Box/Box';
 import { css } from '@emotion/react';
 import { theme } from '@/styles/theme';
@@ -10,13 +10,24 @@ export type ModalLayoutProps = {
   closeModal: () => void;
 } & HTMLElementTypes<HTMLDivElement>;
 
-const ModalLayout: React.FC<ModalLayoutProps> = ({
+export const ModalLayout: React.FC<ModalLayoutProps> = ({
   children,
   isOpen,
   closeModal,
   ...args
 }) => {
+  const [isDisplayed, setIsDisplayed] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsDisplayed(true);
+    } else {
+      setIsDisplayed(false);
+    }
+  }, [isOpen]);
+
   document.body.style.overflow = isOpen ? 'hidden' : 'unset';
+
   return (
     <div
       css={css`
@@ -31,6 +42,8 @@ const ModalLayout: React.FC<ModalLayoutProps> = ({
         height: 100%;
         background-color: ${theme.colors.shadow.modalShadow};
         ${theme.typography.body1}
+        opacity: ${isDisplayed ? '1' : '0'};
+        transition: opacity 0.2s ease-out;
       `}
       onClick={() => {
         closeModal();
@@ -42,6 +55,8 @@ const ModalLayout: React.FC<ModalLayoutProps> = ({
           background-color: ${theme.colors.text.white};
           height: auto;
           width: auto;
+          transform: ${isDisplayed ? 'scale(1)' : 'scale(0.5)'};
+          transition: transform 0.2s ease-out;
         `}
         onClick={(e) => e.stopPropagation()}
         {...args}


### PR DESCRIPTION
[![NDD-369](https://badgen.net/badge/JIRA/NDD-369/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-369) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
Modal 컴포넌트는 프로젝트의 많은 부분에서 사용되고 있습니다. 해당 부분에서 부드러운 UI를 제공하기 위한  transtion을 제공합니다.

# How

isOpend의 변화로 인해서 바로 해당 컴포넌트가 Dom 에 추가되지만, useEffect를 통해서 isDisplayed 상태를 조절합니다

# Result


https://github.com/boostcampwm2023/web14-gomterview/assets/77886826/c5bcea4b-7b5d-4a7e-bdcb-fbf6ecde60e5

[NDD-369]: https://milk717.atlassian.net/browse/NDD-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ