### PR TITLE
[NDD-372] 카카오 인앱 브라우저 접근 시 다른 브라우저를 키도록 하는 hooks 개발 (2h/2h)

### DIFF
--- a/FE/src/KakoInAppBrowserDetect.tsx
+++ b/FE/src/KakoInAppBrowserDetect.tsx
@@ -13,7 +13,7 @@ const KakaoInAppBrowserDetect: React.FC<PropsWithChildren> = ({ children }) => {
     if (isKakaoInAppBrowser) moveOtherBrowser();
   }, [isKakaoInAppBrowser, moveOtherBrowser]);
 
-  if (!isKakaoInAppBrowser)
+  if (isKakaoInAppBrowser)
     return (
       <div
         css={css`

--- a/FE/src/KakoInAppBrowserDetect.tsx
+++ b/FE/src/KakoInAppBrowserDetect.tsx
@@ -1,0 +1,49 @@
+import { PropsWithChildren } from 'react';
+import useKakaoInAppBrowserDetect from '@hooks/useKakaoInAppBrowserDetect';
+import { useEffect } from 'react';
+import { Button, Typography } from '@foundation/index';
+import { css } from '@emotion/react';
+import ErrorBear from '@assets/images/error-bear.png';
+
+const KakaoInAppBrowserDetect: React.FC<PropsWithChildren> = ({ children }) => {
+  const { isKakaoInAppBrowser, moveOtherBrowser } =
+    useKakaoInAppBrowserDetect();
+
+  useEffect(() => {
+    if (isKakaoInAppBrowser) moveOtherBrowser();
+  }, [isKakaoInAppBrowser, moveOtherBrowser]);
+  if (isKakaoInAppBrowser)
+    return (
+      <>
+        <img
+          src={ErrorBear}
+          alt={'노트북을 하는 곰돌이의 뒷모습'}
+          css={css`
+            max-width: 40vw;
+          `}
+        />
+        <div
+          css={css`
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+          `}
+        >
+          <Typography variant="title2">
+            현재 카카카오 인앱 브라우저로 접속하셨어요🥲
+          </Typography>
+          <Typography variant="title2">
+            아쉽지만 곰터뷰는 카카오 브라우저에서 완벽한 서비스를 제공하지
+            못하고 있어요😂
+          </Typography>
+          <Typography variant="title2">
+            아래의 버튼을 클릭하셔서 다른 브라우저에서 곰터뷰를 이용해주세요!
+          </Typography>
+          <Button onClick={() => moveOtherBrowser()}>브라우저 열기</Button>
+        </div>
+      </>
+    );
+  else return <>{children}</>;
+};
+
+export default KakaoInAppBrowserDetect;

--- a/FE/src/KakoInAppBrowserDetect.tsx
+++ b/FE/src/KakoInAppBrowserDetect.tsx
@@ -13,7 +13,7 @@ const KakaoInAppBrowserDetect: React.FC<PropsWithChildren> = ({ children }) => {
     if (isKakaoInAppBrowser) moveOtherBrowser();
   }, [isKakaoInAppBrowser, moveOtherBrowser]);
 
-  if (isKakaoInAppBrowser)
+  if (!isKakaoInAppBrowser)
     return (
       <div
         css={css`
@@ -27,7 +27,8 @@ const KakaoInAppBrowserDetect: React.FC<PropsWithChildren> = ({ children }) => {
           src={LandingBear}
           alt={'노트북을 하는 곰돌이의 뒷모습'}
           css={css`
-            max-width: 40vw;
+            max-height: 50vh;
+            margin: 5rem 0rem;
           `}
         />
         <div
@@ -47,13 +48,15 @@ const KakaoInAppBrowserDetect: React.FC<PropsWithChildren> = ({ children }) => {
           <Typography
             variant="body3"
             css={css`
-              margin-bottom: 2.5rem;
+              margin-bottom: 5rem;
             `}
           >
             아래의 버튼을 클릭하셔서 다른 브라우저에서 곰터뷰를 이용해주세요!
           </Typography>
-          <Button onClick={moveOtherBrowser}>곰터뷰 열기</Button>
         </div>
+        <Button size="lg" onClick={moveOtherBrowser}>
+          곰터뷰 열기
+        </Button>
       </div>
     );
   else return <>{children}</>;

--- a/FE/src/KakoInAppBrowserDetect.tsx
+++ b/FE/src/KakoInAppBrowserDetect.tsx
@@ -12,9 +12,17 @@ const KakaoInAppBrowserDetect: React.FC<PropsWithChildren> = ({ children }) => {
   useEffect(() => {
     if (isKakaoInAppBrowser) moveOtherBrowser();
   }, [isKakaoInAppBrowser, moveOtherBrowser]);
+
   if (isKakaoInAppBrowser)
     return (
-      <>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+        `}
+      >
         <img
           src={ErrorBear}
           alt={'노트북을 하는 곰돌이의 뒷모습'}
@@ -39,9 +47,9 @@ const KakaoInAppBrowserDetect: React.FC<PropsWithChildren> = ({ children }) => {
           <Typography variant="title2">
             아래의 버튼을 클릭하셔서 다른 브라우저에서 곰터뷰를 이용해주세요!
           </Typography>
-          <Button onClick={() => moveOtherBrowser()}>브라우저 열기</Button>
+          <Button onClick={moveOtherBrowser}>브라우저 열기</Button>
         </div>
-      </>
+      </div>
     );
   else return <>{children}</>;
 };

--- a/FE/src/KakoInAppBrowserDetect.tsx
+++ b/FE/src/KakoInAppBrowserDetect.tsx
@@ -3,7 +3,7 @@ import useKakaoInAppBrowserDetect from '@hooks/useKakaoInAppBrowserDetect';
 import { useEffect } from 'react';
 import { Button, Typography } from '@foundation/index';
 import { css } from '@emotion/react';
-import ErrorBear from '@assets/images/error-bear.png';
+import LandingBear from '@assets/images/landing-bear.png';
 
 const KakaoInAppBrowserDetect: React.FC<PropsWithChildren> = ({ children }) => {
   const { isKakaoInAppBrowser, moveOtherBrowser } =
@@ -13,7 +13,7 @@ const KakaoInAppBrowserDetect: React.FC<PropsWithChildren> = ({ children }) => {
     if (isKakaoInAppBrowser) moveOtherBrowser();
   }, [isKakaoInAppBrowser, moveOtherBrowser]);
 
-  if (isKakaoInAppBrowser)
+  if (!isKakaoInAppBrowser)
     return (
       <div
         css={css`
@@ -24,7 +24,7 @@ const KakaoInAppBrowserDetect: React.FC<PropsWithChildren> = ({ children }) => {
         `}
       >
         <img
-          src={ErrorBear}
+          src={LandingBear}
           alt={'노트북을 하는 곰돌이의 뒷모습'}
           css={css`
             max-width: 40vw;
@@ -37,17 +37,22 @@ const KakaoInAppBrowserDetect: React.FC<PropsWithChildren> = ({ children }) => {
             align-items: center;
           `}
         >
-          <Typography variant="title2">
+          <Typography variant="body3">
             현재 카카카오 인앱 브라우저로 접속하셨어요🥲
           </Typography>
-          <Typography variant="title2">
+          <Typography variant="body3">
             아쉽지만 곰터뷰는 카카오 브라우저에서 완벽한 서비스를 제공하지
             못하고 있어요😂
           </Typography>
-          <Typography variant="title2">
+          <Typography
+            variant="body3"
+            css={css`
+              margin-bottom: 2.5rem;
+            `}
+          >
             아래의 버튼을 클릭하셔서 다른 브라우저에서 곰터뷰를 이용해주세요!
           </Typography>
-          <Button onClick={moveOtherBrowser}>브라우저 열기</Button>
+          <Button onClick={moveOtherBrowser}>곰터뷰 열기</Button>
         </div>
       </div>
     );

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -7,16 +7,8 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import GlobalSVGProvider from '@/GlobalSvgProvider';
 import AppRouter from '@/AppRouter';
 import { ToastContainer } from '@foundation/Toast/ToastContainer';
-import useKakaoInAppBrowserDetect from '@hooks/useKakaoInAppBrowserDetect';
-import { useEffect } from 'react';
+
 function App() {
-  const { isKakaoInAppBrowser, moveOtherBrowser } =
-    useKakaoInAppBrowserDetect();
-
-  useEffect(() => {
-    if (isKakaoInAppBrowser) moveOtherBrowser();
-  }, [isKakaoInAppBrowser, moveOtherBrowser]);
-
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -7,8 +7,16 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import GlobalSVGProvider from '@/GlobalSvgProvider';
 import AppRouter from '@/AppRouter';
 import { ToastContainer } from '@foundation/Toast/ToastContainer';
-
+import useKakaoInAppBrowserDetect from '@hooks/useKakaoInAppBrowserDetect';
+import { useEffect } from 'react';
 function App() {
+  const { isKakaoInAppBrowser, moveOtherBrowser } =
+    useKakaoInAppBrowserDetect();
+
+  useEffect(() => {
+    if (isKakaoInAppBrowser) moveOtherBrowser();
+  }, [isKakaoInAppBrowser, moveOtherBrowser]);
+
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {

--- a/FE/src/AppRouter.tsx
+++ b/FE/src/AppRouter.tsx
@@ -19,18 +19,21 @@ import APIErrorBoundary from './APIErrorBoundary';
 import SomethingWrongErrorPage from '@page/errorPage/SomethingWrong';
 import ModalProvider from './modalProvider';
 import MediaStreamPage from '@page/mediaStreamPage';
+import KakaoInAppBrowserDetect from './\bKakoInAppBrowserDetect';
 
 const AppRouter = ({ queryClient }: { queryClient: QueryClient }) => {
   const routes = createBrowserRouter([
     {
       path: PATH.ROOT,
       element: (
-        <UnknownErrorBoundary>
-          <APIErrorBoundary>
-            <Outlet />
-            <ModalProvider />
-          </APIErrorBoundary>
-        </UnknownErrorBoundary>
+        <KakaoInAppBrowserDetect>
+          <UnknownErrorBoundary>
+            <APIErrorBoundary>
+              <Outlet />
+              <ModalProvider />
+            </APIErrorBoundary>
+          </UnknownErrorBoundary>
+        </KakaoInAppBrowserDetect>
       ),
       loader: () => rootLoader({ queryClient: queryClient }),
       errorElement: <LoaderErrorPage />,

--- a/FE/src/hooks/useKakaoInAppBrowserDetect.ts
+++ b/FE/src/hooks/useKakaoInAppBrowserDetect.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+
+const useKakaoInAppBrowserDetect = () => {
+  // 현재 사용자 에이전트를 확인하여 카카오톡 인앱 브라우저인지 여부를 반환합니다.
+  const userAgent = navigator.userAgent.toLowerCase();
+  const isKakaoInAppBrowser = userAgent.includes('kakaotalk');
+
+  // 현재 페이지의 URL을 외부 브라우저를 통해 이동하는 함수입니다.
+  const moveOtherBrowser = useCallback(() => {
+    const currentUrl = window.location.href;
+    if (isKakaoInAppBrowser) {
+      // 카카오톡 인앱 브라우저의 경우, 카카오톡 외부 브라우저 스킴을 사용합니다.
+      window.location.href =
+        'kakaotalk://web/openExternal?url=' + encodeURIComponent(currentUrl);
+    }
+    // 카카오톡 인앱 브라우저가 아닌 경우는 별도의 처리가 필요 없으므로, 함수에서 아무 작업도 수행하지 않습니다.
+  }, [isKakaoInAppBrowser]);
+
+  return { isKakaoInAppBrowser, moveOtherBrowser };
+};
+
+export default useKakaoInAppBrowserDetect;

--- a/FE/src/hooks/useKakaoInAppBrowserDetect.ts
+++ b/FE/src/hooks/useKakaoInAppBrowserDetect.ts
@@ -1,19 +1,15 @@
 import { useCallback } from 'react';
 
 const useKakaoInAppBrowserDetect = () => {
-  // 현재 사용자 에이전트를 확인하여 카카오톡 인앱 브라우저인지 여부를 반환합니다.
   const userAgent = navigator.userAgent.toLowerCase();
   const isKakaoInAppBrowser = userAgent.includes('kakaotalk');
 
-  // 현재 페이지의 URL을 외부 브라우저를 통해 이동하는 함수입니다.
   const moveOtherBrowser = useCallback(() => {
     const currentUrl = window.location.href;
     if (isKakaoInAppBrowser) {
-      // 카카오톡 인앱 브라우저의 경우, 카카오톡 외부 브라우저 스킴을 사용합니다.
       window.location.href =
         'kakaotalk://web/openExternal?url=' + encodeURIComponent(currentUrl);
     }
-    // 카카오톡 인앱 브라우저가 아닌 경우는 별도의 처리가 필요 없으므로, 함수에서 아무 작업도 수행하지 않습니다.
   }, [isKakaoInAppBrowser]);
 
   return { isKakaoInAppBrowser, moveOtherBrowser };


### PR DESCRIPTION
[![NDD-372](https://badgen.net/badge/JIRA/NDD-372/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-372) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why

카카오 브라우저에서는 크게 두가지 기능이 동작하지 않습니다
1. 구글로그인관련 403 문제 [해당 문제에 대한 설명](https://devtalk.kakao.com/t/oauth-403/117012)  
2. 카카오 인앱브라우저에서 파일 다운로드 막기 [해당 문제에 대한 설명](https://devtalk.kakao.com/t/topic/128291)

# How

### Point 1. 카카오 내부에서 인앱 브라우저를 여는법
사실 가장 난해한 방법이라고 생각이 드실 수도 있지만, 코드상으론 굉장히 짧습니다. 
기존의 안드로이드에서 코드를 여는 로직과 유사하며, iOS에서도 동일하게 동작합니다.

<img width="598" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/77886826/8a91fea7-69fd-4a9d-8576-41780aaf290f">

userAgent를 확인해서 kakao browser를 확인한다면, 코드와 같은 hook을 통해서 기능을 수행합니다.
해당 hook은 AppRouter의 최상단에서 분기처리하며, 더 이상의 처리를 진행하기 전에 로직을 수행합니다.

### Point 2 카카오 디텍터 위치
<img width="561" alt="image" src="https://github.com/boostcampwm2023/web14-gomterview/assets/77886826/3d5dda7d-7ab4-42a5-990b-0cbfcce68892">  
다음과 같이 approuter의 최상단에서 사용해 주었습니다.


# Reference

https://burndogfather.com/271

[NDD-372]: https://milk717.atlassian.net/browse/NDD-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ