### PR TITLE
[NDD-357]: 문제집 정렬 로직 수정 && 버그픽스 (1h / 1h)

### DIFF
--- a/BE/src/auth/controller/auth.controller.ts
+++ b/BE/src/auth/controller/auth.controller.ts
@@ -101,10 +101,8 @@ export class AuthController {
         .send();
     } catch (e) {
       if (e.status === UNAUTHORIZED) {
-        res
-          .status(401)
-          .clearCookie('accessToken', COOKIE_OPTIONS)
-          .send(new NeedToLoginException());
+        res.status(401).clearCookie('accessToken', COOKIE_OPTIONS);
+        throw new NeedToLoginException();
       }
     }
   }

--- a/BE/src/auth/controller/auth.controller.ts
+++ b/BE/src/auth/controller/auth.controller.ts
@@ -19,6 +19,7 @@ import {
 } from 'src/util/swagger.util';
 import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
 import { UNAUTHORIZED } from '../../constant/constant';
+import { NeedToLoginException } from '../../token/exception/token.exception';
 
 @Controller('/api/auth')
 @ApiTags('auth')
@@ -100,7 +101,10 @@ export class AuthController {
         .send();
     } catch (e) {
       if (e.status === UNAUTHORIZED) {
-        res.clearCookie('accessToken', COOKIE_OPTIONS).send();
+        res
+          .status(401)
+          .clearCookie('accessToken', COOKIE_OPTIONS)
+          .send(new NeedToLoginException());
       }
     }
   }

--- a/BE/src/config/typeorm.config.ts
+++ b/BE/src/config/typeorm.config.ts
@@ -7,6 +7,7 @@ import { Category } from '../category/entity/category';
 import { Workbook } from '../workbook/entity/workbook';
 import { Question } from '../question/entity/question';
 import { Answer } from '../answer/entity/answer';
+import { Video } from '../video/entity/video';
 
 export const MYSQL_OPTION: TypeOrmModuleAsyncOptions = {
   useFactory() {
@@ -15,7 +16,7 @@ export const MYSQL_OPTION: TypeOrmModuleAsyncOptions = {
       name: 'main',
       host: process.env.DATABASE_HOST,
       port: Number(process.env.DATABASE_PORT),
-      entities: [Member, Category, Workbook, Question, Answer],
+      entities: [Member, Category, Workbook, Question, Answer, Video],
       username: process.env.DATABASE_USER,
       password: process.env.DATABASE_PASSWORD,
       database: process.env.DATABASE,

--- a/BE/src/constant/constant.ts
+++ b/BE/src/constant/constant.ts
@@ -26,5 +26,5 @@ export const GONE = 410;
 export const INTERNAL_SERVER_ERROR = 500;
 export const HOUR_IN_SECONDS = 60 * 60000;
 
-export const ACCESS_TOKEN_EXPIRES_IN = '1h'; // 1 시간
-export const REFRESH_TOKEN_EXPIRES_IN = '7d'; // 7 일
+export const ACCESS_TOKEN_EXPIRES_IN = process.env.ACCESS_TOKEN_EXPIRES_IN; // 1 시간
+export const REFRESH_TOKEN_EXPIRES_IN = process.env.REFRESH_TOKEN_EXPIRES_IN; // 7 일

--- a/BE/src/workbook/repository/workbook.repository.ts
+++ b/BE/src/workbook/repository/workbook.repository.ts
@@ -34,6 +34,7 @@ export class WorkbookRepository {
       .leftJoinAndSelect('Workbook.category', 'category')
       .leftJoinAndSelect('Workbook.member', 'member')
       .where('Workbook.isPublic = :state', { state: true })
+      .orderBy('Workbook.copyCount', 'DESC')
       .getMany();
   }
 
@@ -44,6 +45,7 @@ export class WorkbookRepository {
       .leftJoinAndSelect('Workbook.category', 'category')
       .where('Workbook.isPublic = :state', { state: true })
       .andWhere('category.id = :categoryId', { categoryId })
+      .orderBy('Workbook.copyCount', 'DESC')
       .getMany();
   }
 
@@ -62,6 +64,7 @@ export class WorkbookRepository {
       .createQueryBuilder('Workbook')
       .leftJoinAndSelect('Workbook.member', 'member')
       .where('member.id = :memberId', { memberId })
+      .orderBy('Workbook.copyCount', 'DESC')
       .getMany();
   }
 


### PR DESCRIPTION
[![NDD-357](https://badgen.net/badge/JIRA/NDD-357/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-357) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

## 버그사항
- 토큰이 만료되었을 때 200코드로 나온다. 프론트의 입장에선 이를 어느 엔드포인트로 보낼지 분간할 수 없다. 
- 401코드로 반환해도 엔드포인트 분기를 확인하기 어렵다고 한다. 바디에 커스텀 에러코드를 보내주어야 한다. 

## 리펙토링 사항
- 문제집을 반환할 때, 우선순위를 등록해야 한다. 
- 복사된 횟수가 높은 문제집이 더 상위에 존재해야 한다.

# How

```
async reissue(@Req() request: Request, @Res() res: Response) {
    try {
      res
        .cookie(
          'accessToken',
          await this.authService.reissue(getTokenValue(request)),
          COOKIE_OPTIONS,
        )
        .send();
    } catch (e) {
      if (e.status === UNAUTHORIZED) {
        res.status(401).clearCookie('accessToken', COOKIE_OPTIONS);
        throw new NeedToLoginException();
      }
    }
  }
```
- reissue로직을 수정했다. 
# Result

<img width="731" alt="스크린샷 2023-12-13 13 06 17" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/b71f557e-73f0-42de-b674-95de98412f70">

- 재발행 실패시 401에서 상태코드, 에러코드 반환

<img width="577" alt="스크린샷 2023-12-13 13 07 07" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/0e75ac5a-36ba-413b-a9bf-b0acdae4a816">

- 정렬기준을 문제집의 역순으로 수정

[NDD-357]: https://milk717.atlassian.net/browse/NDD-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ