### PR TITLE
[NDD-356]: 로깅 기능 추가 && 토큰 관련 이슈 해결(이제 그만좀) (5h / 2h)

### DIFF
--- a/BE/src/config/cors.config.ts
+++ b/BE/src/config/cors.config.ts
@@ -5,4 +5,5 @@ export const CORS_CONFIG: CorsOptions = {
   origin: CORS_ORIGIN,
   credentials: true,
   exposedHeaders: CORS_HEADERS,
+  methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTION', 'HEADER'],
 };

--- a/BE/src/constant/constant.ts
+++ b/BE/src/constant/constant.ts
@@ -28,3 +28,5 @@ export const HOUR_IN_SECONDS = 60 * 60000;
 
 export const ACCESS_TOKEN_EXPIRES_IN = process.env.ACCESS_TOKEN_EXPIRES_IN; // 1 시간
 export const REFRESH_TOKEN_EXPIRES_IN = process.env.REFRESH_TOKEN_EXPIRES_IN; // 7 일
+
+export const NO_CACHE_URL = ['/api/member', '/api/auth/reissue'];

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -6,6 +6,7 @@ import { CORS_CONFIG } from './config/cors.config';
 import * as cookieParser from 'cookie-parser';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 import { LoggerService } from './config/logger.config';
+import { NO_CACHE_URL } from './constant/constant';
 
 async function bootstrap() {
   initializeTransactionalContext();
@@ -20,6 +21,9 @@ async function bootstrap() {
   setupSwagger(app);
   // 캐시 제어 미들웨어 등록
   expressApp.use((req, res, next) => {
+    if (NO_CACHE_URL.includes(req.url)) {
+      res.setHeader('Cache-Control', 'no-cache');
+    }
     logger.info(req.url);
     next();
   });

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -20,7 +20,6 @@ async function bootstrap() {
   setupSwagger(app);
   // 캐시 제어 미들웨어 등록
   expressApp.use((req, res, next) => {
-    res.setHeader('Cache-Control', 'no-cache');
     logger.info(req.url);
     next();
   });

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -5,16 +5,25 @@ import { setupSwagger } from './config/swagger.config';
 import { CORS_CONFIG } from './config/cors.config';
 import * as cookieParser from 'cookie-parser';
 import { initializeTransactionalContext } from 'typeorm-transactional';
+import { LoggerService } from './config/logger.config';
 
 async function bootstrap() {
   initializeTransactionalContext();
   const app = await NestFactory.create(AppModule, {
     abortOnError: true,
   });
+  const expressApp = app.getHttpAdapter().getInstance();
+  const logger = new LoggerService('traffic');
   app.use(cookieParser());
   app.useGlobalPipes(new ValidationPipe());
   app.enableCors(CORS_CONFIG);
   setupSwagger(app);
+  // 캐시 제어 미들웨어 등록
+  expressApp.use((req, res, next) => {
+    res.setHeader('Cache-Control', 'no-cache');
+    logger.info(req.url);
+    next();
+  });
   await app.listen(8080, '0.0.0.0');
 }
 

--- a/BE/src/token/guard/token.hard.guard.ts
+++ b/BE/src/token/guard/token.hard.guard.ts
@@ -2,6 +2,8 @@ import { ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { TokenService } from '../service/token.service';
 import { getTokenValue } from 'src/util/token.util';
+import { isEmpty } from 'class-validator';
+import { InvalidTokenException } from '../exception/token.exception';
 
 @Injectable()
 export class TokenHardGuard extends AuthGuard('jwt') {
@@ -13,6 +15,10 @@ export class TokenHardGuard extends AuthGuard('jwt') {
     const request = context.switchToHttp().getRequest();
     const token = getTokenValue(request);
 
+    if (isEmpty(token)) {
+      throw new InvalidTokenException();
+    }
+
     try {
       request.user = await this.validateToken(token);
       return true;
@@ -22,6 +28,6 @@ export class TokenHardGuard extends AuthGuard('jwt') {
   }
 
   private async validateToken(token: string) {
-    return this.tokenService.findMemberByToken(token, true);
+    return await this.tokenService.findMemberByToken(token, true);
   }
 }

--- a/BE/src/token/service/token.service.ts
+++ b/BE/src/token/service/token.service.ts
@@ -47,7 +47,7 @@ export class TokenService {
       throw new NeedToLoginException();
     }
 
-    return this.updateToken(accessToken, refreshToken);
+    return await this.updateToken(accessToken, refreshToken);
   }
 
   async getPayload(singleToken: string) {

--- a/BE/src/util/exception.util.ts
+++ b/BE/src/util/exception.util.ts
@@ -7,10 +7,14 @@ import {
   NOT_FOUND,
   UNAUTHORIZED,
 } from '../constant/constant';
+import { LoggerService } from '../config/logger.config';
+
+const errorLogger = new LoggerService('ERROR');
 
 class HttpCustomException extends HttpException {
   constructor(message: string, errorCode: string, status: number) {
     super({ message: message, errorCode: errorCode }, status);
+    errorLogger.error(errorCode, super.stack);
   }
 }
 

--- a/BE/src/util/token.util.ts
+++ b/BE/src/util/token.util.ts
@@ -8,11 +8,7 @@ export const getTokenValue = (request: Request) => {
     return request.cookies['accessToken'].split(' ').pop();
   }
 
-  if (request.get('cookie')) {
-    return request.get('cookie').split('Bearer ').pop();
-  }
-
-  return '';
+  return null;
 };
 
 export const validateManipulatedToken = (member: Member | undefined) => {


### PR DESCRIPTION
[![NDD-356](https://badgen.net/badge/JIRA/NDD-356/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-356) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=boostcampwm2023&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- 모든 요청에 대한 로깅을 추가한다. 
- 에러가 발생했을 떄, 해당 에러클래스를 로깅한다.

# How

## Log
### 일반 케이스
```
expressApp.use((req, res, next) => {
    logger.info(req.url);
    next();
  });
```
- main.ts에서 로그를 추가한다. 요청 url이 오면 일반 로그로 url이 요청받아졌음을 로깅해준다. 

### 에러케이스
```
class HttpCustomException extends HttpException {
  constructor(message: string, errorCode: string, status: number) {
    super({ message: message, errorCode: errorCode }, status);
    errorLogger.error(errorCode, super.stack);
  }
}
```
- 에러가 생성될 때, 해당 에러를 로깅해준다. 

## 토큰 이슈
### 이슈 상태
1. reissue, /api/member(프론트에서 루트 상태에서 해당 api를 호출한다)에서 캐시로 인해 토큰이 있는 쿠키가 제대로 담기지 않는다. 
2. cookie parser로 인한 더티체크이후에 일반 로직이 남아있어, 이로 인해 GA쿠키가 access token대신에 넘어오는 문제가 있다. 
3. 윈도우에서 patch메서드 요청시에 patch가 CORS정책상 위반된다는 이야기가 나왔다(해당 이슈는 methods를 등록하지 않았을 때, nestjs default methods로 문제가 없어야 하는데 문제가 발생했다)

### 해결 방안
```
expressApp.use((req, res, next) => {
    if (NO_CACHE_URL.includes(req.url)) {
      res.setHeader('Cache-Control', 'no-cache');
    }
    logger.info(req.url);
    next();
  });
```
- 해당 케이스에 캐시를 제거하도록 처리했다. 

```
export const getTokenValue = (request: Request) => {
  if (request.cookies && request.cookies['accessToken']) {
    return request.cookies['accessToken'].split(' ').pop();
  }

  return null;
};
```
- 쿠키파서를 이용한 로직만을 남기고, 나머지는 제거했다. 

```
export const CORS_CONFIG: CorsOptions = {
  origin: CORS_ORIGIN,
  credentials: true,
  exposedHeaders: CORS_HEADERS,
  methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTION', 'HEADER'],
};
```
- methods를 직접 등록하는 식으로 수정했다.

# Result

<img width="433" alt="스크린샷 2023-12-13 20 32 12" src="https://github.com/boostcampwm2023/web14-gomterview/assets/99702271/2f79b9d4-cdd9-4b24-93e7-0a15d3e4293b">

- 로그의 정상 출력을 확인할 수 있었다.

[NDD-356]: https://milk717.atlassian.net/browse/NDD-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ